### PR TITLE
fix: handle OpenClaw .reset session file renames in watcher

### DIFF
--- a/src/watch/session-resolver.ts
+++ b/src/watch/session-resolver.ts
@@ -3,4 +3,6 @@ export interface SessionResolver {
   filePattern: string;
   /** Return absolute path to the active session file, or null if unknown */
   resolveActiveSession(dir: string): Promise<string | null>;
+  /** Given a file path that no longer exists, try to find its renamed equivalent. */
+  findRenamedFile?(originalPath: string): Promise<string | null>;
 }


### PR DESCRIPTION
## Problem

When OpenClaw's `/new` command fires, it renames the active session file:
`abc123.jsonl` → `abc123.jsonl.reset.{timestamp}`

The watcher tracks sessions by filename + byte offset. When the file gets renamed, `processFileCycle` on the old path returns ENOENT and any unextracted bytes from the end of that session are silently lost.

## Solution

- **`SessionResolver.findRenamedFile?`** - New optional interface method for resolvers to locate renamed files
- **`openClawSessionResolver.findRenamedFile`** - Scans for `.reset.*` files matching the original session UUID
- **ENOENT retry on session switch** - When the old file is gone, finds the renamed copy, seeds state with the old byte offset, and drains remaining content
- **Non-switch ENOENT handling** - Covers the timing edge case where rename beats `sessions.json` update
- **Startup orphan scan** - On watcher init, checks all tracked paths for missing files and drains any found `.reset` equivalents

## Testing

New tests in both `openclaw.test.ts` (resolver) and `watcher.test.ts` (drain + orphan scan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and recovers renamed session files automatically, including on startup, to preserve session continuity.

* **Bug Fixes**
  * More robust handling when tracked files vanish during monitoring or switching; preserves and reapplies session state instead of erroring.

* **Tests**
  * Expanded test coverage for renamed-file recovery, session switching edge cases, and startup orphan handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->