### PR TITLE
feat(daemon): add start/stop/restart + smarter install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 ### Added
 - `_meta` table with schema version stamp for future migrations
 - `agenr db version` command to print schema version metadata
+- `agenr daemon start|stop|restart` commands
+- `agenr daemon install --dir/--platform/--node-path` options for explicit daemon configuration
 
 ### Changed
 - `agenr db stats` output now includes schema version
+- `agenr daemon install` now uses smart platform defaults and writes `watch --dir <path> --platform <name>` instead of `watch --auto`
+- `agenr daemon install` now prefers stable node symlinks (Homebrew) when `process.execPath` is version-specific; use `--node-path` to override
 
 ## 0.4.1 (2026-02-17)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -208,6 +208,12 @@ agenr daemon <subcommand> [options]
 - `install`: install + start watch daemon via launchd (macOS only).
   - `--force`: overwrite existing plist.
   - `--interval <seconds>`: watch interval (default `120`).
+  - `--dir <path>`: sessions directory to watch (overrides auto-detection).
+  - `--platform <name>`: platform name (`openclaw|codex|claude-code`). If provided without `--dir`, uses the platform default directory.
+  - `--node-path <path>`: node binary path override (useful for nvm/fnm/volta setups without stable symlinks).
+- `start`: start the daemon if installed.
+- `stop`: stop the daemon without uninstalling (plist remains on disk).
+- `restart`: restart the daemon.
 - `uninstall`: stop + remove daemon plist.
   - `--yes`: skip uninstall confirmation prompt.
 - `status`: show loaded/running status, current watched file, recent logs.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -226,6 +226,9 @@ agenr daemon <subcommand> [options]
 
 ```bash
 $A daemon install --force
+$A daemon start
+$A daemon stop
+$A daemon restart
 $A daemon status
 $A daemon logs --lines 50
 ```

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -16,7 +16,10 @@ import {
 import {
   runDaemonInstallCommand,
   runDaemonLogsCommand,
+  runDaemonRestartCommand,
+  runDaemonStartCommand,
   runDaemonStatusCommand,
+  runDaemonStopCommand,
   runDaemonUninstallCommand,
 } from "./commands/daemon.js";
 import { runConsolidateCommand } from "./commands/consolidate.js";
@@ -579,9 +582,36 @@ export function createProgram(): Command {
     .description("Install and start the watch daemon (macOS launchd)")
     .option("--force", "Overwrite existing launchd plist", false)
     .option("--interval <seconds>", "Watch interval for daemon mode", parseIntOption, 120)
+    .option("--dir <path>", "Sessions directory to watch (overrides auto-detection)")
+    .option("--platform <name>", "Platform name (openclaw, codex, claude-code)")
+    .option("--node-path <path>", "Node binary path override for launchd")
     .option("--context <path>", "Regenerate context file after each cycle")
     .action(async (opts: DaemonInstallOptions) => {
       const result = await runDaemonInstallCommand(opts);
+      process.exitCode = result.exitCode;
+    });
+
+  daemonCommand
+    .command("start")
+    .description("Start the watch daemon if installed")
+    .action(async () => {
+      const result = await runDaemonStartCommand({});
+      process.exitCode = result.exitCode;
+    });
+
+  daemonCommand
+    .command("stop")
+    .description("Stop the watch daemon without uninstalling")
+    .action(async () => {
+      const result = await runDaemonStopCommand({});
+      process.exitCode = result.exitCode;
+    });
+
+  daemonCommand
+    .command("restart")
+    .description("Restart the watch daemon")
+    .action(async () => {
+      const result = await runDaemonRestartCommand({});
       process.exitCode = result.exitCode;
     });
 

--- a/src/watch/resolvers/index.ts
+++ b/src/watch/resolvers/index.ts
@@ -6,7 +6,7 @@ import { openClawSessionResolver } from "./openclaw.js";
 
 export type WatchPlatform = "openclaw" | "claude-code" | "codex" | "mtime";
 
-function normalizePlatform(value: string): WatchPlatform | null {
+export function normalizePlatform(value: string): WatchPlatform | null {
   const normalized = value.trim().toLowerCase();
   if (normalized === "openclaw") {
     return "openclaw";

--- a/tests/commands/daemon.test.ts
+++ b/tests/commands/daemon.test.ts
@@ -5,8 +5,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   runDaemonInstallCommand,
   runDaemonLogsCommand,
+  runDaemonRestartCommand,
+  runDaemonStartCommand,
   runDaemonStatusCommand,
+  runDaemonStopCommand,
   runDaemonUninstallCommand,
+  resolveStableNodePath,
 } from "../../src/commands/daemon.js";
 
 const tempDirs: string[] = [];
@@ -28,10 +32,12 @@ afterEach(async () => {
 describe("daemon commands", () => {
   it("generates launchd plist and runs bootstrap on install", async () => {
     const home = await makeTempDir();
+    const sessionsDir = path.join(home, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
     const launchctlCalls: string[][] = [];
 
     const result = await runDaemonInstallCommand(
-      { force: true },
+      { force: true, dir: sessionsDir, platform: "openclaw" },
       {
         platformFn: () => "darwin",
         homedirFn: () => home,
@@ -50,7 +56,10 @@ describe("daemon commands", () => {
     const plist = await fs.readFile(plistPath, "utf8");
     expect(plist).toContain("com.agenr.watch");
     expect(plist).toContain("watch");
-    expect(plist).toContain("--auto");
+    expect(plist).toContain("--dir");
+    expect(plist).toContain(sessionsDir);
+    expect(plist).toContain("--platform");
+    expect(plist).toContain("openclaw");
     expect(plist).toContain("--interval");
     expect(plist).toContain("120");
 
@@ -62,9 +71,11 @@ describe("daemon commands", () => {
 
   it("passes --context through to launchd watch arguments", async () => {
     const home = await makeTempDir();
+    const sessionsDir = path.join(home, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
 
     const result = await runDaemonInstallCommand(
-      { force: true, context: "/tmp/CONTEXT.md" },
+      { force: true, context: "/tmp/CONTEXT.md", dir: sessionsDir, platform: "openclaw" },
       {
         platformFn: () => "darwin",
         homedirFn: () => home,
@@ -186,5 +197,410 @@ describe("daemon commands", () => {
     await expect(runDaemonInstallCommand({}, { platformFn: () => "linux" })).rejects.toThrow(
       "macOS only",
     );
+  });
+});
+
+describe("daemon start", () => {
+  it("errors when plist not found", async () => {
+    const home = await makeTempDir();
+    await expect(
+      runDaemonStartCommand({}, { platformFn: () => "darwin", homedirFn: () => home, uidFn: () => 501 }),
+    ).rejects.toThrow("Daemon not installed. Run `agenr daemon install` first.");
+  });
+
+  it("no-ops when already running", async () => {
+    const home = await makeTempDir();
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    await fs.mkdir(path.dirname(plistPath), { recursive: true });
+    await fs.writeFile(plistPath, "test", "utf8");
+
+    const calls: string[][] = [];
+    const result = await runDaemonStartCommand(
+      {},
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        execFileFn: vi.fn(async (_file: string, args: string[]) => {
+          calls.push(args);
+          if (args[0] === "print") {
+            return { stdout: "state = running\npid = 123\n", stderr: "", exitCode: 0 };
+          }
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls).toEqual([["print", "gui/501/com.agenr.watch"]]);
+  });
+
+  it("starts via bootstrap when installed but not loaded", async () => {
+    const home = await makeTempDir();
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    await fs.mkdir(path.dirname(plistPath), { recursive: true });
+    await fs.writeFile(plistPath, "test", "utf8");
+
+    const calls: string[][] = [];
+    const result = await runDaemonStartCommand(
+      {},
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        execFileFn: vi.fn(async (_file: string, args: string[]) => {
+          calls.push(args);
+          if (args[0] === "print") {
+            return { stdout: "", stderr: "Could not find service", exitCode: 113 };
+          }
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls).toEqual([
+      ["print", "gui/501/com.agenr.watch"],
+      ["bootstrap", "gui/501", plistPath],
+    ]);
+  });
+
+  it("handles loaded-but-not-running by bootout then bootstrap", async () => {
+    const home = await makeTempDir();
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    await fs.mkdir(path.dirname(plistPath), { recursive: true });
+    await fs.writeFile(plistPath, "test", "utf8");
+
+    const calls: string[][] = [];
+    const result = await runDaemonStartCommand(
+      {},
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        execFileFn: vi.fn(async (_file: string, args: string[]) => {
+          calls.push(args);
+          if (args[0] === "print") {
+            return { stdout: "state = stopped\n", stderr: "", exitCode: 0 };
+          }
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls).toEqual([
+      ["print", "gui/501/com.agenr.watch"],
+      ["bootout", "gui/501/com.agenr.watch"],
+      ["bootstrap", "gui/501", plistPath],
+    ]);
+  });
+});
+
+describe("daemon stop", () => {
+  it("errors when plist not found", async () => {
+    const home = await makeTempDir();
+    await expect(
+      runDaemonStopCommand({}, { platformFn: () => "darwin", homedirFn: () => home, uidFn: () => 501 }),
+    ).rejects.toThrow("Daemon not installed. Run `agenr daemon install` first.");
+  });
+
+  it("no-ops when not running", async () => {
+    const home = await makeTempDir();
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    await fs.mkdir(path.dirname(plistPath), { recursive: true });
+    await fs.writeFile(plistPath, "test", "utf8");
+
+    const calls: string[][] = [];
+    const result = await runDaemonStopCommand(
+      {},
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        execFileFn: vi.fn(async (_file: string, args: string[]) => {
+          calls.push(args);
+          if (args[0] === "print") {
+            return { stdout: "", stderr: "Could not find service", exitCode: 113 };
+          }
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls).toEqual([["print", "gui/501/com.agenr.watch"]]);
+  });
+
+  it("stops via bootout when running", async () => {
+    const home = await makeTempDir();
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    await fs.mkdir(path.dirname(plistPath), { recursive: true });
+    await fs.writeFile(plistPath, "test", "utf8");
+
+    const calls: string[][] = [];
+    const result = await runDaemonStopCommand(
+      {},
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        execFileFn: vi.fn(async (_file: string, args: string[]) => {
+          calls.push(args);
+          if (args[0] === "print") {
+            return { stdout: "state = running\npid = 321\n", stderr: "", exitCode: 0 };
+          }
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls).toEqual([
+      ["print", "gui/501/com.agenr.watch"],
+      ["bootout", "gui/501/com.agenr.watch"],
+    ]);
+  });
+});
+
+describe("daemon restart", () => {
+  it("errors when not installed", async () => {
+    const home = await makeTempDir();
+    await expect(
+      runDaemonRestartCommand({}, { platformFn: () => "darwin", homedirFn: () => home, uidFn: () => 501 }),
+    ).rejects.toThrow("Daemon not installed.");
+  });
+
+  it("restarts successfully (bootout + sleep + bootstrap)", async () => {
+    const home = await makeTempDir();
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    await fs.mkdir(path.dirname(plistPath), { recursive: true });
+    await fs.writeFile(plistPath, "test", "utf8");
+
+    const calls: string[][] = [];
+    const sleeps: number[] = [];
+
+    const result = await runDaemonRestartCommand(
+      {},
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        sleepFn: async (ms: number) => {
+          sleeps.push(ms);
+        },
+        execFileFn: vi.fn(async (_file: string, args: string[]) => {
+          calls.push(args);
+          if (args[0] === "bootout") {
+            return { stdout: "", stderr: "not loaded", exitCode: 5 };
+          }
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(sleeps).toEqual([500]);
+    expect(calls).toEqual([
+      ["bootout", "gui/501/com.agenr.watch"],
+      ["bootstrap", "gui/501", plistPath],
+    ]);
+  });
+});
+
+describe("resolveStableNodePath", () => {
+  it("returns original path when no version-specific segment detected", async () => {
+    const statFn = vi.fn(async () => {
+      throw new Error("should not be called");
+    });
+
+    await expect(resolveStableNodePath("/usr/local/bin/node", statFn as any)).resolves.toBe("/usr/local/bin/node");
+    expect(statFn).not.toHaveBeenCalled();
+  });
+
+  it("returns stable Homebrew path when available and executable", async () => {
+    const statFn = vi.fn(async (filePath: string) => {
+      if (filePath === "/opt/homebrew/bin/node") {
+        return {
+          isFile: () => true,
+          isDirectory: () => false,
+          mode: 0o755,
+        } as any;
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    await expect(
+      resolveStableNodePath("/opt/homebrew/Cellar/node/25.5.0/bin/node", statFn as any),
+    ).resolves.toBe("/opt/homebrew/bin/node");
+  });
+
+  it("falls back to original when stable path doesn't exist", async () => {
+    const statFn = vi.fn(async () => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    await expect(
+      resolveStableNodePath("/opt/homebrew/Cellar/node/25.5.0/bin/node", statFn as any),
+    ).resolves.toBe("/opt/homebrew/Cellar/node/25.5.0/bin/node");
+  });
+
+  it("--node-path overrides auto-resolution in daemon install", async () => {
+    const home = await makeTempDir();
+    const sessionsDir = path.join(home, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const result = await runDaemonInstallCommand(
+      { force: true, dir: sessionsDir, platform: "openclaw", nodePath: "/custom/node" },
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        argvFn: () => ["node", "/tmp/dist/cli.js"],
+        execFileFn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    const plist = await fs.readFile(plistPath, "utf8");
+    expect(plist).toContain("<string>/custom/node</string>");
+  });
+});
+
+describe("daemon install smart defaults", () => {
+  it("detects OpenClaw sessions dir and generates correct ProgramArguments", async () => {
+    const home = await makeTempDir();
+    const openclawDir = path.join(home, ".openclaw", "agents", "main", "sessions");
+    await fs.mkdir(openclawDir, { recursive: true });
+
+    const result = await runDaemonInstallCommand(
+      { force: true },
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        argvFn: () => ["node", "/tmp/dist/cli.js"],
+        execFileFn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    const plist = await fs.readFile(plistPath, "utf8");
+    expect(plist).toContain("--dir");
+    expect(plist).toContain(openclawDir);
+    expect(plist).toContain("--platform");
+    expect(plist).toContain("openclaw");
+  });
+
+  it("falls back to Codex if OpenClaw not found", async () => {
+    const home = await makeTempDir();
+    const codexDir = path.join(home, ".codex", "sessions");
+    await fs.mkdir(codexDir, { recursive: true });
+
+    const result = await runDaemonInstallCommand(
+      { force: true },
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        argvFn: () => ["node", "/tmp/dist/cli.js"],
+        execFileFn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    const plist = await fs.readFile(plistPath, "utf8");
+    expect(plist).toContain(codexDir);
+    expect(plist).toContain("codex");
+  });
+
+  it("falls back to Claude Code if OpenClaw and Codex not found", async () => {
+    const home = await makeTempDir();
+    const claudeDir = path.join(home, ".claude", "projects");
+    await fs.mkdir(claudeDir, { recursive: true });
+
+    const result = await runDaemonInstallCommand(
+      { force: true },
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        argvFn: () => ["node", "/tmp/dist/cli.js"],
+        execFileFn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    const plist = await fs.readFile(plistPath, "utf8");
+    expect(plist).toContain(claudeDir);
+    expect(plist).toContain("claude-code");
+  });
+
+  it("errors when no platform detected", async () => {
+    const home = await makeTempDir();
+    await expect(
+      runDaemonInstallCommand(
+        { force: true },
+        {
+          platformFn: () => "darwin",
+          homedirFn: () => home,
+          uidFn: () => 501,
+          argvFn: () => ["node", "/tmp/dist/cli.js"],
+          execFileFn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+        },
+      ),
+    ).rejects.toThrow(
+      "No supported platform detected. Use --dir <path> --platform <name> to specify manually.",
+    );
+  });
+
+  it("--platform without --dir resolves default directory", async () => {
+    const home = await makeTempDir();
+    const codexDir = path.join(home, ".codex", "sessions");
+    await fs.mkdir(codexDir, { recursive: true });
+
+    const result = await runDaemonInstallCommand(
+      { force: true, platform: "codex" },
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        argvFn: () => ["node", "/tmp/dist/cli.js"],
+        execFileFn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    const plist = await fs.readFile(plistPath, "utf8");
+    expect(plist).toContain(codexDir);
+    expect(plist).toContain("codex");
+  });
+
+  it("--dir and --platform passed through to ProgramArguments", async () => {
+    const home = await makeTempDir();
+    const sessionsDir = path.join(home, "my-sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const result = await runDaemonInstallCommand(
+      { force: true, dir: sessionsDir, platform: "claude-code" },
+      {
+        platformFn: () => "darwin",
+        homedirFn: () => home,
+        uidFn: () => 501,
+        argvFn: () => ["node", "/tmp/dist/cli.js"],
+        execFileFn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const plistPath = path.join(home, "Library", "LaunchAgents", "com.agenr.watch.plist");
+    const plist = await fs.readFile(plistPath, "utf8");
+    expect(plist).toContain(sessionsDir);
+    expect(plist).toContain("claude-code");
   });
 });


### PR DESCRIPTION
Closes #3

Adds daemon management commands (start/stop/restart) and improves the install process with smarter defaults and proper node path detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daemon start, stop, and restart commands for explicit lifecycle control.

* **New Options**
  * Install now supports --dir, --platform, and --node-path for custom configuration.

* **Updates**
  * Install uses smarter platform/session defaults and prefers stable Node binaries when possible.
  * Daemon status/start/stop/restart provide clearer detection messages and behavior.
  * DB stats now include schema version.

* **Tests**
  * Expanded tests covering install, start/stop/restart flows and node-path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->