### PR TITLE
chore: add sandbox setup script for isolated dev testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ docs/prompts/
 node_modules
 
 docs/internal/
+
+# Sandbox environment
+sandbox/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Before opening a PR:
 - TypeScript with strict typing expectations.
 - ESM module format (`"type": "module"`).
 - Prefer small, focused functions and explicit error messages.
-- Keep CLI behavior consistent with `/Users/jmartin/Code/agenr/src/cli.ts` command contracts.
+- Keep CLI behavior consistent with `src/cli.ts` command contracts.
 
 ## Pull Request Process
 
@@ -79,4 +79,19 @@ Migration history is tracked in the `_migrations` table. See `src/db/schema.ts` 
 By contributing, you agree your contributions are licensed under AGPL-3.0.
 
 - CLA is not required.
-- See `/Users/jmartin/Code/agenr/LICENSE` and `/Users/jmartin/Code/agenr/LICENSE-FAQ.md`.
+- See `LICENSE` and `LICENSE-FAQ.md`.
+
+## Sandbox Environment
+
+For manual CLI testing without touching your live `~/.agenr/` data:
+
+```bash
+bash scripts/sandbox-setup.sh
+source sandbox/env.sh
+
+sandbox-agenr db stats        # Empty isolated DB
+sandbox-agenr recall "test"   # Query sandbox only
+sandbox-reset                 # Nuke and recreate
+```
+
+The sandbox creates an isolated config and DB under `sandbox/data/` (gitignored). Your live knowledge DB is never touched.

--- a/scripts/sandbox-setup.sh
+++ b/scripts/sandbox-setup.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Sandbox environment for agenr development.
+# Creates an isolated config + DB so you can test without touching your live data.
+#
+# Usage:
+#   bash scripts/sandbox-setup.sh
+#   source sandbox/env.sh
+#   sandbox-agenr db stats
+#
+# Reset:
+#   sandbox-reset
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SANDBOX_ROOT="$REPO_ROOT/sandbox"
+DATA_DIR="$SANDBOX_ROOT/data"
+AGENR_SANDBOX_DIR="$DATA_DIR/agenr"
+
+echo "=== Setting up agenr sandbox ==="
+
+mkdir -p "$AGENR_SANDBOX_DIR"
+
+# Create sandbox config
+if [ ! -f "$AGENR_SANDBOX_DIR/config.json" ]; then
+  LIVE_CONFIG="$HOME/.agenr/config.json"
+  if [ -f "$LIVE_CONFIG" ]; then
+    # Copy auth from live config, redirect DB to sandbox
+    node -e "
+      const live = JSON.parse(require(fs).readFileSync(, utf8));
+      live.db = { path: /knowledge.db };
+      console.log(JSON.stringify(live, null, 2));
+    " > "$AGENR_SANDBOX_DIR/config.json"
+    echo "  Copied auth from $LIVE_CONFIG"
+  else
+    # No live config - create minimal sandbox config
+    cat > "$AGENR_SANDBOX_DIR/config.json" << EOF
+{
+  "db": { "path": "$AGENR_SANDBOX_DIR/knowledge.db" }
+}
+EOF
+    echo "  Created minimal config (no auth - run agenr auth to configure)"
+  fi
+  chmod 600 "$AGENR_SANDBOX_DIR/config.json"
+  echo "  Config: $AGENR_SANDBOX_DIR/config.json"
+  echo "  DB:     $AGENR_SANDBOX_DIR/knowledge.db"
+else
+  echo "  Sandbox config already exists"
+fi
+
+# Generate env.sh
+cat > "$SANDBOX_ROOT/env.sh" << ENVEOF
+# Source this to load sandbox commands: source sandbox/env.sh
+
+_SANDBOX_REPO_ROOT="$REPO_ROOT"
+_SANDBOX_CONFIG="$AGENR_SANDBOX_DIR/config.json"
+
+sandbox-agenr() {
+  AGENR_CONFIG_PATH="\$_SANDBOX_CONFIG" node "\$_SANDBOX_REPO_ROOT/dist/cli.js" "\$@"
+}
+
+sandbox-reset() {
+  echo "Nuking sandbox data..."
+  rm -rf "$SANDBOX_ROOT/data"
+  bash "$REPO_ROOT/scripts/sandbox-setup.sh"
+  source "$SANDBOX_ROOT/env.sh"
+  echo "Done."
+}
+
+echo "Sandbox loaded. Commands: sandbox-agenr, sandbox-reset"
+echo "  DB: $AGENR_SANDBOX_DIR/knowledge.db"
+ENVEOF
+
+echo ""
+echo "=== Done ==="
+echo ""
+echo "  source sandbox/env.sh"
+echo "  sandbox-agenr db stats"


### PR DESCRIPTION
Adds `scripts/sandbox-setup.sh` for creating an isolated dev/test environment.

- Creates separate config + DB under `sandbox/data/` (gitignored)
- Copies auth credentials from live config but redirects DB to sandbox
- Provides `sandbox-agenr` and `sandbox-reset` shell commands
- Updated CONTRIBUTING.md with sandbox docs
- Fixed local path leaks in CONTRIBUTING.md

No production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sandbox environment setup capability with dedicated commands for isolated testing and operations.

* **Documentation**
  * Introduced sandbox environment setup guide with initialization steps and sample commands.
  * Updated contributing documentation with improved path references.

* **Chores**
  * Added sandbox directory to version control ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->