### PR TITLE
feat(platform): deprecate --auto, add platform column + filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 *.log
 .DS_Store
 dist
-docs/design/
-docs/plans/
-docs/prompts/
 node_modules
 
 docs/internal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,23 @@
 - `agenr db version` command to print schema version metadata
 - `agenr daemon start|stop|restart` commands
 - `agenr daemon install --dir/--platform/--node-path` options for explicit daemon configuration
+- `entries.platform` column (with index) to tag knowledge by platform (`openclaw|claude-code|codex`, NULL for legacy entries)
+- `--platform` filters/tags across commands:
+  - `agenr recall --platform`
+  - `agenr context --platform`
+  - `agenr store --platform`
+  - `agenr ingest --platform`
+  - `agenr consolidate --platform`
+  - `agenr db export --platform`
+- MCP tool support for platform:
+  - `agenr_recall` accepts optional `platform` filter
+  - `agenr_store` accepts optional `platform` tag
 
 ### Changed
 - `agenr db stats` output now includes schema version
 - `agenr daemon install` now uses smart platform defaults and writes `watch --dir <path> --platform <name>` instead of `watch --auto`
 - `agenr daemon install` now prefers stable node symlinks (Homebrew) when `process.execPath` is version-specific; use `--node-path` to override
+- `agenr watch --auto` is deprecated; `agenr watch --platform <name>` is now the standard invocation and auto-resolves the default platform directory when `--dir` is omitted
 
 ## 0.4.1 (2026-02-17)
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ agenr recall "package manager"
 The watcher keeps your memory current as you work. It tails your session files, extracts new knowledge every few minutes, and stores it. If you ingested history first, watch resumes right where ingest left off - no re-processing.
 
 ```bash
-# Watch your OpenClaw sessions directory
-agenr watch --dir ~/.openclaw/agents/main/sessions/
+# Watch your OpenClaw sessions directory (auto-resolves the default path)
+agenr watch --platform openclaw
 
-# Auto-detect your session directory
+# Deprecated: --auto still works (defaults to OpenClaw) but will be removed in a future version
 agenr watch --auto
 
 # Install as a background daemon (macOS launchd)
@@ -128,7 +128,7 @@ agenr daemon logs
 You can also auto-refresh a context file that AI tools read on startup:
 
 ```bash
-agenr watch --auto --context ~/.agenr/CONTEXT.md
+agenr watch --platform openclaw --context ~/.agenr/CONTEXT.md
 ```
 
 ## How it works

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -84,6 +84,7 @@ agenr store [options] [files...]
 
 ### Options
 - `--db <path>`: database path override.
+- `--platform <name>`: filter stats by platform.
 - `--dry-run`: show write decisions without persisting.
 - `--verbose`: show per-entry dedup decisions.
 - `--force`: bypass dedup checks and insert all as new.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,6 +87,7 @@ agenr store [options] [files...]
 - `--dry-run`: show write decisions without persisting.
 - `--verbose`: show per-entry dedup decisions.
 - `--force`: bypass dedup checks and insert all as new.
+- `--platform <name>`: platform tag (`openclaw|claude-code|codex`).
 - `--online-dedup`: enable online LLM dedup at write time (default `true`).
 - `--no-online-dedup`: disable online LLM dedup.
 - `--dedup-threshold <n>`: similarity threshold for online dedup (`0.0..1.0`, default `0.8`).
@@ -123,6 +124,7 @@ agenr recall [options] [query]
 - `--min-importance <n>`: minimum importance (1-10).
 - `--since <duration>`: recency filter (`1h`, `7d`, `30d`, `1y`, or ISO timestamp).
 - `--expiry <level>`: `core|permanent|temporary`.
+- `--platform <name>`: platform filter (`openclaw|claude-code|codex`).
 - `--json`: emit JSON.
 - `--db <path>`: database path override.
 - `--budget <tokens>`: approximate token budget cap.
@@ -156,8 +158,8 @@ agenr watch [file] [options]
 
 ### Options
 - `--dir <path>`: watch a sessions directory and auto-follow active session file.
-- `--platform <name>`: resolver selection (`openclaw|claude-code|codex|mtime`).
-- `--auto`: discover supported platform roots and follow the globally most-recent session.
+- `--platform <name>`: resolver selection (`openclaw|claude-code|codex|mtime`). When used without `--dir`, agenr resolves the platform default directory automatically.
+- `--auto`: deprecated. Equivalent to `--platform openclaw` (prints a warning).
 - `--interval <seconds>`: polling interval (default `300`).
 - `--min-chunk <chars>`: min appended chars before extract (default `2000`).
 - `--db <path>`: database path override.
@@ -171,7 +173,7 @@ agenr watch [file] [options]
 Pick exactly one mode:
 - file mode: `agenr watch <file>`
 - directory mode: `agenr watch --dir <path> [--platform ...]`
-- auto mode: `agenr watch --auto`
+- platform mode: `agenr watch --platform <name>`
 
 Watch mode runs online dedup during store.
 
@@ -186,7 +188,7 @@ $A watch --dir ~/.openclaw/agents/main/sessions --platform openclaw
 ```
 
 ```bash
-$A watch --auto --interval 120
+$A watch --platform openclaw --interval 120
 ```
 
 ### Example Output
@@ -246,6 +248,7 @@ agenr ingest [options] <paths...>
 - `--db <path>`: database path override.
 - `--model <model>`: override model.
 - `--provider <name>`: `anthropic|openai|openai-codex`.
+- `--platform <name>`: platform tag (`openclaw|claude-code|codex`).
 - `--verbose`: per-file details.
 - `--dry-run`: extract without storing.
 - `--json`: emit JSON summary.
@@ -283,6 +286,7 @@ agenr consolidate [options]
 ### Options
 - `--rules-only`: run only Tier 1 rule cleanup.
 - `--dry-run`: report actions without writing.
+- `--platform <name>`: scope consolidation to platform (`openclaw|claude-code|codex`).
 - `--min-cluster <n>`: min cluster size for LLM phases (default `2`).
 - `--sim-threshold <n>`: Phase 1 clustering threshold (default `0.82`). Phase 2 uses `max(value, 0.88)`.
 - `--max-cluster-size <n>`: max cluster size for LLM phases. Defaults: Phase 1 `8`, Phase 2 `6`.
@@ -519,6 +523,7 @@ agenr db export [options]
 - `--json`: export JSON.
 - `--md`: export markdown.
 - `--db <path>`: database path override.
+- `--platform <name>`: platform filter (`openclaw|claude-code|codex`).
 
 Exactly one of `--json` or `--md` is required.
 
@@ -527,6 +532,7 @@ Exactly one of `--json` or `--md` is required.
 ```bash
 $A db export --json > export.json
 $A db export --md > export.md
+$A db export --json --platform openclaw > export.openclaw.json
 ```
 
 ### Example Output (`--md`)

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -658,8 +658,9 @@ export function createProgram(): Command {
     .command("stats")
     .description("Show database statistics")
     .option("--db <path>", "Database path override")
-    .action(async (opts: { db?: string }) => {
-      await runDbStatsCommand({ db: opts.db });
+    .option("--platform <name>", "Filter stats by platform")
+    .action(async (opts: { db?: string; platform?: string }) => {
+      await runDbStatsCommand({ db: opts.db, platform: opts.platform });
       process.exitCode = 0;
     });
 

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -402,6 +402,7 @@ export function createProgram(): Command {
     .option("--dry-run", "Show what would be stored without writing", false)
     .option("--verbose", "Show per-entry dedup decisions", false)
     .option("--force", "Skip dedup and store all entries as new", false)
+    .option("--platform <name>", "Platform tag: openclaw, claude-code, codex")
     .option("--online-dedup", "Enable online LLM dedup at write time", true)
     .option("--no-online-dedup", "Disable online LLM dedup at write time")
     .option("--dedup-threshold <n>", "Similarity threshold for online dedup (0.0-1.0)")
@@ -413,6 +414,7 @@ export function createProgram(): Command {
           dryRun?: boolean;
           verbose?: boolean;
           force?: boolean;
+          platform?: string;
           onlineDedup?: boolean;
           dedupThreshold?: string;
         },
@@ -432,6 +434,7 @@ export function createProgram(): Command {
     .option("--min-importance <n>", "Minimum importance: 1-10")
     .option("--since <duration>", "Filter by recency (1h, 7d, 30d, 1y) or ISO timestamp")
     .option("--expiry <level>", "Filter by expiry: core|permanent|temporary")
+    .option("--platform <name>", "Filter by platform: openclaw, claude-code, codex")
     .option("--json", "Output JSON", false)
     .option("--db <path>", "Database path override")
     .option("--budget <tokens>", "Approximate token budget", parseIntOption)
@@ -447,6 +450,7 @@ export function createProgram(): Command {
         minImportance: opts.minImportance as string | undefined,
         since: opts.since as string | undefined,
         expiry: opts.expiry as string | undefined,
+        platform: opts.platform as string | undefined,
         json: opts.json === true,
         db: opts.db as string | undefined,
         budget: opts.budget as number | undefined,
@@ -467,6 +471,7 @@ export function createProgram(): Command {
     .option("--budget <tokens>", "Approximate token budget", parseIntOption, 2000)
     .option("--limit <n>", "Max entries per category", parseIntOption, 10)
     .option("--db <path>", "Database path override")
+    .option("--platform <name>", "Filter by platform: openclaw, claude-code, codex")
     .option("--json", "Output JSON", false)
     .option("--quiet", "Suppress stderr output", false)
     .action(
@@ -475,6 +480,7 @@ export function createProgram(): Command {
         budget?: number;
         limit?: number;
         db?: string;
+        platform?: string;
         json?: boolean;
         quiet?: boolean;
       }) => {
@@ -482,6 +488,7 @@ export function createProgram(): Command {
         output: opts.output,
         budget: opts.budget,
         limit: opts.limit,
+        platform: opts.platform,
         db: opts.db,
         json: opts.json === true,
         quiet: opts.quiet === true,
@@ -496,7 +503,7 @@ export function createProgram(): Command {
     .argument("[file]", "Transcript file to watch (.jsonl, .md, .txt)")
     .option("--dir <path>", "Sessions directory to watch (resolver picks active file)")
     .option("--platform <name>", "Session platform: openclaw, claude-code, codex, mtime")
-    .option("--auto", "Auto-detect installed platforms and watch the globally most active session", false)
+    .option("--auto", "Deprecated: use --platform <name> instead", false)
     .option("--interval <seconds>", "Polling interval in seconds", parseIntOption, 300)
     .option("--min-chunk <chars>", "Minimum new chars before extraction", parseIntOption, 2000)
     .option("--context <path>", "Regenerate context file after each cycle")
@@ -521,6 +528,7 @@ export function createProgram(): Command {
     .option("--db <path>", "Database path override")
     .option("--model <model>", "LLM model to use")
     .option("--provider <name>", "LLM provider: anthropic, openai, openai-codex")
+    .option("--platform <name>", "Platform tag: openclaw, claude-code, codex")
     .option("--verbose", "Show per-file details", false)
     .option("--raw", "Bypass adapter filtering (pass transcripts through unmodified)", false)
     .option("--dry-run", "Extract without storing", false)
@@ -540,6 +548,7 @@ export function createProgram(): Command {
     .description("Consolidate and clean up the knowledge database")
     .option("--rules-only", "Only run rule-based cleanup (no LLM)", false)
     .option("--dry-run", "Show what would happen without making changes", false)
+    .option("--platform <name>", "Scope consolidation to platform: openclaw, claude-code, codex")
     .option("--min-cluster <n>", "Minimum cluster size for merge (default: 2)", (value: string) =>
       Number.parseInt(value, 10),
     )
@@ -669,11 +678,13 @@ export function createProgram(): Command {
     .option("--json", "Export JSON", false)
     .option("--md", "Export markdown", false)
     .option("--db <path>", "Database path override")
-    .action(async (opts: { db?: string; json?: boolean; md?: boolean }) => {
+    .option("--platform <name>", "Filter by platform: openclaw, claude-code, codex")
+    .action(async (opts: { db?: string; json?: boolean; md?: boolean; platform?: string }) => {
       await runDbExportCommand({
         db: opts.db,
         json: opts.json,
         md: opts.md,
+        platform: opts.platform,
       });
       process.exitCode = 0;
     });

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -328,19 +328,20 @@ export async function runStoreCommand(
     let totalEntries = 0;
     let stoppedForShutdown = false;
 
-	    for (const input of inputs) {
-	      if (resolvedDeps.shouldShutdownFn()) {
-	        stoppedForShutdown = true;
-	        break;
-	      }
-	      const entries: KnowledgeEntry[] = platform
-	        ? input.entries.map((entry) => ({ ...entry, platform: platform as KnowledgePlatform }))
-	        : input.entries;
+    for (const input of inputs) {
+      if (resolvedDeps.shouldShutdownFn()) {
+        stoppedForShutdown = true;
+        break;
+      }
 
-	      const result = await resolvedDeps.storeEntriesFn(db, entries, apiKey, {
-	        dryRun: options.dryRun,
-	        force: options.force,
-	        verbose: options.verbose,
+      const entries: KnowledgeEntry[] = platform
+        ? input.entries.map((entry) => ({ ...entry, platform: platform as KnowledgePlatform }))
+        : input.entries;
+
+      const result = await resolvedDeps.storeEntriesFn(db, entries, apiKey, {
+        dryRun: options.dryRun,
+        force: options.force,
+        verbose: options.verbose,
         onlineDedup,
         dedupThreshold,
         llmClient,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -27,6 +27,7 @@ const CREATE_TABLE_AND_TRIGGER_STATEMENTS: readonly string[] = [
     importance INTEGER NOT NULL,
     expiry TEXT NOT NULL,
     scope TEXT DEFAULT 'private',
+    platform TEXT DEFAULT NULL,
     source_file TEXT,
     source_context TEXT,
     embedding F32_BLOB(1024),
@@ -115,6 +116,7 @@ const CREATE_INDEX_STATEMENTS: readonly string[] = [
   "CREATE INDEX IF NOT EXISTS idx_entries_type_canonical_key ON entries(type, canonical_key)",
   "CREATE INDEX IF NOT EXISTS idx_entries_expiry ON entries(expiry)",
   "CREATE INDEX IF NOT EXISTS idx_entries_scope ON entries(scope)",
+  "CREATE INDEX IF NOT EXISTS idx_entries_platform ON entries(platform)",
   "CREATE INDEX IF NOT EXISTS idx_entries_created ON entries(created_at)",
   "CREATE INDEX IF NOT EXISTS idx_entries_superseded ON entries(superseded_by)",
   "CREATE INDEX IF NOT EXISTS idx_entries_content_hash ON entries(content_hash)",
@@ -151,6 +153,11 @@ const COLUMN_MIGRATIONS: readonly ColumnMigration[] = [
     table: "entries",
     column: "consolidated_at",
     sql: "ALTER TABLE entries ADD COLUMN consolidated_at TEXT",
+  },
+  {
+    table: "entries",
+    column: "platform",
+    sql: "ALTER TABLE entries ADD COLUMN platform TEXT DEFAULT NULL",
   },
   {
     table: "ingest_log",

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -661,6 +661,7 @@ export async function insertEntry(
         content,
         importance,
         expiry,
+        platform,
         source_file,
         source_context,
         content_hash,
@@ -668,7 +669,7 @@ export async function insertEntry(
         created_at,
         updated_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, ?)
     `,
     args: [
       id,
@@ -678,6 +679,7 @@ export async function insertEntry(
       entry.content,
       entry.importance,
       entry.expiry,
+      entry.platform ?? null,
       entry.source.file,
       entry.source.context,
       contentHash,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,19 @@
+import type { KnowledgePlatform } from "./types.js";
+
+export function normalizeKnowledgePlatform(value: string | undefined): KnowledgePlatform | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "openclaw") {
+    return "openclaw";
+  }
+  if (normalized === "claude-code" || normalized === "claude") {
+    return "claude-code";
+  }
+  if (normalized === "codex") {
+    return "codex";
+  }
+  return null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,11 +17,15 @@ export const EXPIRY_LEVELS = ["core", "permanent", "temporary"] as const;
 
 export const SCOPE_LEVELS = ["private", "personal", "public"] as const;
 
+export const KNOWLEDGE_PLATFORMS = ["openclaw", "claude-code", "codex"] as const;
+
 export type KnowledgeType = (typeof KNOWLEDGE_TYPES)[number];
 
 export type Expiry = (typeof EXPIRY_LEVELS)[number];
 
 export type Scope = (typeof SCOPE_LEVELS)[number];
+
+export type KnowledgePlatform = (typeof KNOWLEDGE_PLATFORMS)[number];
 
 export type AgenrProvider = "anthropic" | "openai" | "openai-codex";
 export type AgenrAuthMethod =
@@ -58,6 +62,7 @@ export interface KnowledgeEntry {
   content: string;
   subject: string;
   canonical_key?: string;
+  platform?: KnowledgePlatform;
   importance: number;
   expiry: Expiry;
   scope?: Scope;
@@ -207,6 +212,7 @@ export interface RecallQuery {
   budget?: number;
   noBoost?: boolean;
   noUpdate?: boolean;
+  platform?: KnowledgePlatform;
 }
 
 export interface RecallCommandResult extends RecallResult {

--- a/src/watch/platform-defaults.ts
+++ b/src/watch/platform-defaults.ts
@@ -1,0 +1,18 @@
+import os from "node:os";
+import path from "node:path";
+import type { WatchPlatform } from "./resolvers/index.js";
+
+export function getDefaultPlatformDir(platform: WatchPlatform, homeDir = os.homedir()): string {
+  if (platform === "openclaw") {
+    return path.join(homeDir, ".openclaw", "agents", "main", "sessions");
+  }
+  if (platform === "codex") {
+    return path.join(homeDir, ".codex", "sessions");
+  }
+  if (platform === "claude-code") {
+    return path.join(homeDir, ".claude", "projects");
+  }
+
+  throw new Error(`No default directory for platform: ${platform}`);
+}
+

--- a/src/watch/resolvers/auto.ts
+++ b/src/watch/resolvers/auto.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type { WatchPlatform } from "./index.js";
 import { getResolver } from "./index.js";
+import { getDefaultPlatformDir } from "../platform-defaults.js";
 
 export interface AutoWatchTarget {
   dir: string;
@@ -26,13 +26,6 @@ export interface AutoSessionResult {
   watchTargets: AutoWatchTarget[];
 }
 
-function resolveUserPath(inputPath: string): string {
-  if (!inputPath.startsWith("~")) {
-    return inputPath;
-  }
-  return path.join(os.homedir(), inputPath.slice(1));
-}
-
 async function isDirectory(dirPath: string): Promise<boolean> {
   try {
     const stat = await fs.stat(dirPath);
@@ -40,36 +33,6 @@ async function isDirectory(dirPath: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-async function findMostRecentSubdirectory(dirPath: string): Promise<string | null> {
-  let entries: Array<import("node:fs").Dirent> = [];
-  try {
-    entries = await fs.readdir(dirPath, { withFileTypes: true });
-  } catch {
-    return null;
-  }
-
-  let best: { dirPath: string; mtimeMs: number } | null = null;
-  for (const entry of entries) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-
-    const fullPath = path.join(dirPath, entry.name);
-    let stat: Awaited<ReturnType<typeof fs.stat>>;
-    try {
-      stat = await fs.stat(fullPath);
-    } catch {
-      continue;
-    }
-
-    if (!best || stat.mtimeMs > best.mtimeMs) {
-      best = { dirPath: fullPath, mtimeMs: stat.mtimeMs };
-    }
-  }
-
-  return best?.dirPath ?? null;
 }
 
 async function statMtime(filePath: string): Promise<number | null> {
@@ -85,55 +48,43 @@ async function statMtime(filePath: string): Promise<number | null> {
 }
 
 export async function resolveAutoSession(): Promise<AutoSessionResult> {
-  const openclawDir = path.resolve(resolveUserPath("~/.openclaw/agents/main/sessions"));
-  const claudeProjectsDir = path.resolve(resolveUserPath("~/.claude/projects"));
-  const codexDir = path.resolve(resolveUserPath("~/.codex/sessions"));
+  // Legacy helper retained for backwards compatibility. Multi-platform scanning is deprecated.
+  const openclawDir = path.resolve(getDefaultPlatformDir("openclaw"));
 
   const discoveredRoots: AutoWatchTarget[] = [];
   const watchTargets: AutoWatchTarget[] = [];
-
-  if (await isDirectory(openclawDir)) {
-    discoveredRoots.push({ dir: openclawDir, platform: "openclaw" });
-    watchTargets.push({ dir: openclawDir, platform: "openclaw" });
-  }
-
-  if (await isDirectory(claudeProjectsDir)) {
-    watchTargets.push({ dir: claudeProjectsDir, platform: "claude-code" });
-    const recentProject = await findMostRecentSubdirectory(claudeProjectsDir);
-    if (recentProject) {
-      discoveredRoots.push({ dir: recentProject, platform: "claude-code" });
-      watchTargets.push({ dir: recentProject, platform: "claude-code", recursive: true });
-    }
-  }
-
-  if (await isDirectory(codexDir)) {
-    discoveredRoots.push({ dir: codexDir, platform: "codex" });
-    watchTargets.push({ dir: codexDir, platform: "codex", recursive: true });
-  }
-
   const candidates: AutoSessionCandidate[] = [];
-  for (const root of discoveredRoots) {
-    const resolver = getResolver(root.platform, root.dir);
-    const activeFile = await resolver.resolveActiveSession(root.dir);
-    const resolvedActive = activeFile ? path.resolve(activeFile) : null;
-    const mtimeMs = resolvedActive ? await statMtime(resolvedActive) : null;
 
-    candidates.push({
-      platform: root.platform,
-      rootDir: root.dir,
-      activeFile: resolvedActive,
-      mtimeMs,
-    });
+  if (!(await isDirectory(openclawDir))) {
+    return {
+      activeFile: null,
+      platform: null,
+      mtimeMs: null,
+      candidates,
+      discoveredRoots,
+      watchTargets,
+    };
   }
 
-  const winningCandidate = candidates
-    .filter((candidate) => candidate.activeFile && candidate.mtimeMs !== null)
-    .sort((a, b) => (b.mtimeMs ?? 0) - (a.mtimeMs ?? 0))[0];
+  const root: AutoWatchTarget = { dir: openclawDir, platform: "openclaw" };
+  discoveredRoots.push(root);
+  watchTargets.push(root);
+
+  const resolver = getResolver(root.platform, root.dir);
+  const activeFile = await resolver.resolveActiveSession(root.dir);
+  const resolvedActive = activeFile ? path.resolve(activeFile) : null;
+  const mtimeMs = resolvedActive ? await statMtime(resolvedActive) : null;
+  candidates.push({
+    platform: root.platform,
+    rootDir: root.dir,
+    activeFile: resolvedActive,
+    mtimeMs,
+  });
 
   return {
-    activeFile: winningCandidate?.activeFile ?? null,
-    platform: winningCandidate?.platform ?? null,
-    mtimeMs: winningCandidate?.mtimeMs ?? null,
+    activeFile: resolvedActive,
+    platform: "openclaw" as WatchPlatform,
+    mtimeMs,
     candidates,
     discoveredRoots,
     watchTargets,

--- a/tests/commands/context.test.ts
+++ b/tests/commands/context.test.ts
@@ -188,6 +188,27 @@ describe("context command", () => {
     expect(options?.coreCandidateLimit).toBe(7);
   });
 
+  it("passes --platform into session-start recall when provided", async () => {
+    const sessionStartRecallFn = vi.fn(async () => ({ results: [], budgetUsed: 0 }));
+    await runContextCommand(
+      { output: "/tmp/agenr-context-test.md", quiet: true, platform: "codex" },
+      {
+        readConfigFn: vi.fn(() => ({ db: { path: ":memory:" } })),
+        getDbFn: vi.fn(() => ({}) as any),
+        initDbFn: vi.fn(async () => undefined),
+        closeDbFn: vi.fn(() => undefined),
+        sessionStartRecallFn: sessionStartRecallFn as any,
+        mkdirFn: vi.fn(async () => undefined) as any,
+        writeFileFn: vi.fn(async () => undefined) as any,
+        renameFn: vi.fn(async () => undefined) as any,
+        nowFn: () => new Date("2026-02-17T00:00:00.000Z"),
+      },
+    );
+
+    const call = (sessionStartRecallFn.mock.calls as any[][])[0] as any[] | undefined;
+    expect(call?.[1]?.query?.platform).toBe("codex");
+  });
+
   it("works with an empty DB (no entries, no error)", async () => {
     const dir = await makeTempDir();
     const outPath = path.join(dir, "CONTEXT.md");

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -163,4 +163,14 @@ describe("recall command", () => {
     const firstCallQuery = firstCall?.[1];
     expect(firstCallQuery?.text).toBe("[topic: health] what is Jim's diet");
   });
+
+  it("passes --platform into recall query when provided", async () => {
+    const recallFn = vi.fn(async () => []);
+    const deps = makeDeps({ recallFn });
+
+    await runRecallCommand("work", { context: "default", json: true, platform: "openclaw" }, deps);
+
+    const firstCall = (recallFn.mock.calls as unknown[][])[0] as [unknown, { platform?: string }] | undefined;
+    expect(firstCall?.[1]?.platform).toBe("openclaw");
+  });
 });

--- a/tests/commands/watch-platform.test.ts
+++ b/tests/commands/watch-platform.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agenr-watch-platform-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+async function setupWatcherMock(): Promise<{
+  runWatcherSpy: ReturnType<typeof vi.fn>;
+  getLastOptions: () => Record<string, unknown> | null;
+}> {
+  let lastOptions: Record<string, unknown> | null = null;
+  const runWatcherSpy = vi.fn(async (opts: Record<string, unknown>) => {
+    lastOptions = opts;
+    const now = new Date("2026-02-15T00:00:00.000Z");
+    return { cycles: 0, entriesStored: 0, startedAt: now, endedAt: now, durationMs: 0 };
+  });
+
+  vi.doMock("../../src/watch/watcher.js", () => {
+    return {
+      readFileFromOffset: vi.fn(async () => Buffer.alloc(0)),
+      runWatcher: runWatcherSpy,
+    };
+  });
+
+  return {
+    runWatcherSpy,
+    getLastOptions: () => lastOptions,
+  };
+}
+
+describe("watch command platform defaults and --auto deprecation", () => {
+  it("--auto without --platform warns, defaults to openclaw, and runs in dir mode", async () => {
+    const home = await makeTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(home);
+    await fs.mkdir(path.join(home, ".openclaw", "agents", "main", "sessions"), { recursive: true });
+
+    const { runWatcherSpy, getLastOptions } = await setupWatcherMock();
+    const { runWatchCommand } = await import("../../src/commands/watch.js");
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await runWatchCommand(undefined, { auto: true, once: true }, {
+      statFileFn: fs.stat as any,
+      loadWatchStateFn: vi.fn(async () => ({ version: 1 as const, files: {} })),
+      saveWatchStateFn: vi.fn(async () => undefined),
+      readConfigFn: vi.fn(() => ({ db: { path: ":memory:" } })),
+    } as any);
+
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+    expect(stderr).toContain("Warning: --auto is deprecated. Use --platform <name> instead.");
+    expect(stderr).toContain("Defaulting to --platform openclaw.");
+
+    expect(runWatcherSpy).toHaveBeenCalledTimes(1);
+    const opts = getLastOptions();
+    expect(opts?.directoryMode).toBe(true);
+    expect(opts?.sessionsDir).toBe(path.join(home, ".openclaw", "agents", "main", "sessions"));
+    expect(opts?.platform).toBe("openclaw");
+  });
+
+  it("--auto with --platform uses the specified platform (no defaulting warning)", async () => {
+    const home = await makeTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(home);
+    await fs.mkdir(path.join(home, ".codex", "sessions"), { recursive: true });
+
+    const { runWatcherSpy, getLastOptions } = await setupWatcherMock();
+    const { runWatchCommand } = await import("../../src/commands/watch.js");
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await runWatchCommand(undefined, { auto: true, platform: "codex", once: true }, {
+      statFileFn: fs.stat as any,
+      loadWatchStateFn: vi.fn(async () => ({ version: 1 as const, files: {} })),
+      saveWatchStateFn: vi.fn(async () => undefined),
+      readConfigFn: vi.fn(() => ({ db: { path: ":memory:" } })),
+    } as any);
+
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+    expect(stderr).toContain("Warning: --auto is deprecated. Use --platform <name> instead.");
+    expect(stderr).not.toContain("Defaulting to --platform openclaw.");
+
+    expect(runWatcherSpy).toHaveBeenCalledTimes(1);
+    const opts = getLastOptions();
+    expect(opts?.directoryMode).toBe(true);
+    expect(opts?.sessionsDir).toBe(path.join(home, ".codex", "sessions"));
+    expect(opts?.platform).toBe("codex");
+  });
+
+  it("--platform <name> without --dir resolves the default directory and runs in dir mode", async () => {
+    const home = await makeTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(home);
+    await fs.mkdir(path.join(home, ".openclaw", "agents", "main", "sessions"), { recursive: true });
+
+    const { runWatcherSpy, getLastOptions } = await setupWatcherMock();
+    const { runWatchCommand } = await import("../../src/commands/watch.js");
+
+    await runWatchCommand(undefined, { platform: "openclaw", once: true }, {
+      statFileFn: fs.stat as any,
+      loadWatchStateFn: vi.fn(async () => ({ version: 1 as const, files: {} })),
+      saveWatchStateFn: vi.fn(async () => undefined),
+      readConfigFn: vi.fn(() => ({ db: { path: ":memory:" } })),
+    } as any);
+
+    expect(runWatcherSpy).toHaveBeenCalledTimes(1);
+    const opts = getLastOptions();
+    expect(opts?.directoryMode).toBe(true);
+    expect(opts?.sessionsDir).toBe(path.join(home, ".openclaw", "agents", "main", "sessions"));
+    expect(opts?.platform).toBe("openclaw");
+  });
+
+  it("errors when --platform directory is missing", async () => {
+    const home = await makeTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(home);
+
+    await setupWatcherMock();
+    const { runWatchCommand } = await import("../../src/commands/watch.js");
+
+    await expect(
+      runWatchCommand(undefined, { platform: "codex", once: true }, {
+        statFileFn: fs.stat as any,
+        loadWatchStateFn: vi.fn(async () => ({ version: 1 as const, files: {} })),
+        saveWatchStateFn: vi.fn(async () => undefined),
+        readConfigFn: vi.fn(() => ({ db: { path: ":memory:" } })),
+      } as any),
+    ).rejects.toThrow("Platform directory not found:");
+  });
+});
+

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -33,6 +33,7 @@ describe("db schema", () => {
       "idx_entries_type_canonical_key",
       "idx_entries_expiry",
       "idx_entries_scope",
+      "idx_entries_platform",
       "idx_entries_created",
       "idx_entries_superseded",
       "idx_entries_content_hash",
@@ -84,6 +85,7 @@ describe("db schema", () => {
         'idx_entries_type_canonical_key',
         'idx_entries_expiry',
         'idx_entries_scope',
+        'idx_entries_platform',
         'idx_entries_created',
         'idx_entries_superseded',
         'idx_entries_content_hash',
@@ -97,7 +99,7 @@ describe("db schema", () => {
       )
       GROUP BY name
     `);
-    expect(namesResult.rows).toHaveLength(21);
+    expect(namesResult.rows).toHaveLength(22);
     for (const row of namesResult.rows as Array<{ count?: unknown }>) {
       expect(Number(row.count)).toBe(1);
     }
@@ -118,6 +120,7 @@ describe("db schema", () => {
     expect(entryColumns.has("canonical_key")).toBe(true);
     expect(entryColumns.has("merged_from")).toBe(true);
     expect(entryColumns.has("consolidated_at")).toBe(true);
+    expect(entryColumns.has("platform")).toBe(true);
     expect(ingestColumns.has("content_hash")).toBe(true);
     expect(ingestColumns.has("entries_superseded")).toBe(true);
     expect(ingestColumns.has("dedup_llm_calls")).toBe(true);

--- a/tests/watch/platform-defaults.test.ts
+++ b/tests/watch/platform-defaults.test.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { getDefaultPlatformDir } from "../../src/watch/platform-defaults.js";
+
+describe("platform defaults", () => {
+  it("returns default directories for supported platforms", () => {
+    const home = "/tmp/fake-home";
+
+    expect(getDefaultPlatformDir("openclaw", home)).toBe(
+      path.join(home, ".openclaw", "agents", "main", "sessions"),
+    );
+    expect(getDefaultPlatformDir("codex", home)).toBe(path.join(home, ".codex", "sessions"));
+    expect(getDefaultPlatformDir("claude-code", home)).toBe(path.join(home, ".claude", "projects"));
+  });
+});
+

--- a/tests/watch/resolvers/auto.test.ts
+++ b/tests/watch/resolvers/auto.test.ts
@@ -26,25 +26,15 @@ afterEach(async () => {
 });
 
 describe("auto session resolver", () => {
-  it("picks the most recently active session across supported platforms", async () => {
+  it("resolves the active OpenClaw session (legacy auto resolver)", async () => {
     const fakeHome = await makeTempDir();
     vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
 
     const openclawDir = path.join(fakeHome, ".openclaw", "agents", "main", "sessions");
-    const claudeProject = path.join(fakeHome, ".claude", "projects", "project-a");
-    const codexDir = path.join(fakeHome, ".codex", "sessions", "2026", "02", "16");
-
     await fs.mkdir(openclawDir, { recursive: true });
-    await fs.mkdir(claudeProject, { recursive: true });
-    await fs.mkdir(codexDir, { recursive: true });
 
     const openclawFile = path.join(openclawDir, "openclaw.jsonl");
-    const claudeFile = path.join(claudeProject, "claude.jsonl");
-    const codexFile = path.join(codexDir, "codex.jsonl");
-
     await fs.writeFile(openclawFile, "{}\n", "utf8");
-    await fs.writeFile(claudeFile, "{}\n", "utf8");
-    await fs.writeFile(codexFile, "{}\n", "utf8");
 
     await fs.writeFile(
       path.join(openclawDir, "sessions.json"),
@@ -53,14 +43,12 @@ describe("auto session resolver", () => {
     );
 
     await setMtime(openclawFile, "2026-02-10T00:00:00.000Z");
-    await setMtime(codexFile, "2026-02-11T00:00:00.000Z");
-    await setMtime(claudeFile, "2026-02-12T00:00:00.000Z");
 
     const result = await resolveAutoSession();
 
-    expect(result.discoveredRoots.map((root) => root.platform).sort()).toEqual(["claude-code", "codex", "openclaw"]);
-    expect(result.platform).toBe("claude-code");
-    expect(result.activeFile).toBe(path.resolve(claudeFile));
+    expect(result.discoveredRoots.map((root) => root.platform).sort()).toEqual(["openclaw"]);
+    expect(result.platform).toBe("openclaw");
+    expect(result.activeFile).toBe(path.resolve(openclawFile));
   });
 
   it("returns no active file when no platform roots are present", async () => {


### PR DESCRIPTION
Closes #4

## What

- Deprecates `--auto` mode in the watcher - `--platform <name>` is now the primary flag
- Adds `platform TEXT DEFAULT NULL` column to entries table with safe migration
- Tags extracted entries with source platform during watch
- Adds `--platform` filter to: recall, context, store, ingest, consolidate, db stats, db export
- Adds `platform` parameter to MCP tools (agenr_recall, agenr_store)
- Platform-aware stats with per-platform breakdown in `db stats`
- Cleans up auto.ts / watcher autoMode code path
- New shared `normalizeKnowledgePlatform()` utility

## Migration

Safe `ALTER TABLE ADD COLUMN` - existing entries get `NULL` platform. No data loss, no breaking changes.

## Backward Compatibility

- No `--platform` flag = all entries returned (same as before)
- `--auto` still works with deprecation warning, defaults to `--platform openclaw`

## Tests

444 tests passing across 61 test files. New tests for: migration, platform-filtered recall, platform-filtered stats, watch platform tagging, MCP platform params, store/ingest/context platform options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global --platform option for recall, store, context, ingest, consolidate, db export, and related tools.
  * Knowledge entries can be tagged/filtered by platform (openclaw, claude-code, codex); DB stats and exports show per-platform breakdowns.
  * Watch command auto-resolves platform-specific default session directories when --platform is used.

* **Deprecated**
  * agenr watch --auto is deprecated; use agenr watch --platform <platform-name>.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->