### PR TITLE
fix: address CodeRabbit review findings for platform isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changed
 - `agenr db stats` output now includes schema version
+- `agenr db stats` now includes per-platform breakdown
 - `agenr daemon install` now uses smart platform defaults and writes `watch --dir <path> --platform <name>` instead of `watch --auto`
 - `agenr daemon install` now prefers stable node symlinks (Homebrew) when `process.execPath` is version-specific; use `--node-path` to override
 - `agenr watch --auto` is deprecated; `agenr watch --platform <name>` is now the standard invocation and auto-resolves the default platform directory when `--dir` is omitted

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Deep dive: [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 
 ## Status
 
-Alpha. The core pipeline is stable and tested (369 tests). We use it daily managing thousands of knowledge entries across OpenClaw sessions.
+Alpha. The core pipeline is stable and tested (445 tests). We use it daily managing thousands of knowledge entries across OpenClaw sessions.
 
 What works: extraction, storage, recall, MCP integration, online dedup, consolidation, smart filtering, live watching, daemon mode.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -84,11 +84,10 @@ agenr store [options] [files...]
 
 ### Options
 - `--db <path>`: database path override.
-- `--platform <name>`: filter stats by platform.
 - `--dry-run`: show write decisions without persisting.
 - `--verbose`: show per-entry dedup decisions.
 - `--force`: bypass dedup checks and insert all as new.
-- `--platform <name>`: platform tag (`openclaw|claude-code|codex`).
+- `--platform <name>`: platform tag (`openclaw|claude-code|claude|codex`).
 - `--online-dedup`: enable online LLM dedup at write time (default `true`).
 - `--no-online-dedup`: disable online LLM dedup.
 - `--dedup-threshold <n>`: similarity threshold for online dedup (`0.0..1.0`, default `0.8`).
@@ -125,7 +124,7 @@ agenr recall [options] [query]
 - `--min-importance <n>`: minimum importance (1-10).
 - `--since <duration>`: recency filter (`1h`, `7d`, `30d`, `1y`, or ISO timestamp).
 - `--expiry <level>`: `core|permanent|temporary`.
-- `--platform <name>`: platform filter (`openclaw|claude-code|codex`).
+- `--platform <name>`: platform filter (`openclaw|claude-code|claude|codex`).
 - `--json`: emit JSON.
 - `--db <path>`: database path override.
 - `--budget <tokens>`: approximate token budget cap.
@@ -159,7 +158,7 @@ agenr watch [file] [options]
 
 ### Options
 - `--dir <path>`: watch a sessions directory and auto-follow active session file.
-- `--platform <name>`: resolver selection (`openclaw|claude-code|codex|mtime`). When used without `--dir`, agenr resolves the platform default directory automatically.
+- `--platform <name>`: resolver selection (`openclaw|claude-code|claude|codex|mtime`). When used without `--dir`, agenr resolves the platform default directory automatically.
 - `--auto`: deprecated. Equivalent to `--platform openclaw` (prints a warning).
 - `--interval <seconds>`: polling interval (default `300`).
 - `--min-chunk <chars>`: min appended chars before extract (default `2000`).
@@ -212,7 +211,7 @@ agenr daemon <subcommand> [options]
   - `--force`: overwrite existing plist.
   - `--interval <seconds>`: watch interval (default `120`).
   - `--dir <path>`: sessions directory to watch (overrides auto-detection).
-  - `--platform <name>`: platform name (`openclaw|codex|claude-code`). If provided without `--dir`, uses the platform default directory.
+  - `--platform <name>`: platform name (`openclaw|claude-code|claude|codex`). If provided without `--dir`, uses the platform default directory.
   - `--node-path <path>`: node binary path override (useful for nvm/fnm/volta setups without stable symlinks).
 - `start`: start the daemon if installed.
 - `stop`: stop the daemon without uninstalling (plist remains on disk).
@@ -249,7 +248,7 @@ agenr ingest [options] <paths...>
 - `--db <path>`: database path override.
 - `--model <model>`: override model.
 - `--provider <name>`: `anthropic|openai|openai-codex`.
-- `--platform <name>`: platform tag (`openclaw|claude-code|codex`).
+- `--platform <name>`: platform tag (`openclaw|claude-code|claude|codex`).
 - `--verbose`: per-file details.
 - `--dry-run`: extract without storing.
 - `--json`: emit JSON summary.
@@ -287,7 +286,7 @@ agenr consolidate [options]
 ### Options
 - `--rules-only`: run only Tier 1 rule cleanup.
 - `--dry-run`: report actions without writing.
-- `--platform <name>`: scope consolidation to platform (`openclaw|claude-code|codex`).
+- `--platform <name>`: scope consolidation to platform (`openclaw|claude-code|claude|codex`).
 - `--min-cluster <n>`: min cluster size for LLM phases (default `2`).
 - `--sim-threshold <n>`: Phase 1 clustering threshold (default `0.82`). Phase 2 uses `max(value, 0.88)`.
 - `--max-cluster-size <n>`: max cluster size for LLM phases. Defaults: Phase 1 `8`, Phase 2 `6`.
@@ -465,6 +464,7 @@ agenr db stats [options]
 
 ### Options
 - `--db <path>`: database path override.
+- `--platform <name>`: filter stats by platform (`openclaw|claude-code|claude|codex`).
 
 ### Example
 
@@ -482,6 +482,11 @@ Entries: 42
 By Type
 - decision: 10
 - fact: 9
+By Platform
+- openclaw: 20
+- claude-code: 12
+- codex: 3
+- (untagged): 7
 Top Tags
 - tooling: 6
 ```
@@ -524,7 +529,7 @@ agenr db export [options]
 - `--json`: export JSON.
 - `--md`: export markdown.
 - `--db <path>`: database path override.
-- `--platform <name>`: platform filter (`openclaw|claude-code|codex`).
+- `--platform <name>`: platform filter (`openclaw|claude-code|claude|codex`).
 
 Exactly one of `--json` or `--md` is required.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -122,6 +122,7 @@ Parameters:
 - `types` (string, optional): comma-separated entry types
 - `since` (string, optional): ISO date or relative (`7d`, `24h`, `1m`, `1y`)
 - `threshold` (number, optional, default `0`): minimum score `0.0..1.0`
+- `platform` (string, optional): platform filter (`openclaw`, `claude-code`, `codex`)
 
 Example call payload:
 
@@ -154,6 +155,7 @@ Store structured entries in the memory DB.
 
 Parameters:
 - `entries` (array, required)
+- `platform` (string, optional): platform tag applied to all stored entries (`openclaw`, `claude-code`, `codex`)
 - Each entry supports:
 - `content` (string, required)
 - `type` (enum, required): `fact|decision|preference|todo|relationship|event|lesson`

--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -12,6 +12,7 @@ import { createLlmClient } from "../llm/client.js";
 import { formatWarn } from "../ui.js";
 import { installSignalHandlers, isShutdownRequested, onShutdown } from "../shutdown.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
+import { KNOWLEDGE_PLATFORMS } from "../types.js";
 import type { KnowledgePlatform } from "../types.js";
 
 export interface ConsolidateCommandOptions {
@@ -171,7 +172,7 @@ export async function runConsolidateCommand(
   const platformRaw = options.platform?.trim();
   const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
   if (platformRaw && !platform) {
-    throw new Error("--platform must be one of: openclaw, claude-code, codex");
+    throw new Error(`--platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`);
   }
 
   if (dbFilePath === ":memory:") {
@@ -200,7 +201,7 @@ export async function runConsolidateCommand(
         rulesOnly: options.rulesOnly,
         dryRun: options.dryRun,
         verbose: options.verbose,
-        platform: (platform ?? undefined) as KnowledgePlatform | undefined,
+        platform: platform ?? undefined,
         minCluster: options.minCluster,
         simThreshold: options.simThreshold,
         maxClusterSize: options.maxClusterSize,

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -8,6 +8,7 @@ import { closeDb, getDb, initDb } from "../db/client.js";
 import { sessionStartRecall } from "../db/session-start.js";
 import { resolveEmbeddingApiKey } from "../embeddings/client.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
+import { KNOWLEDGE_PLATFORMS } from "../types.js";
 import type { RecallCommandResult, RecallQuery } from "../types.js";
 import type { KnowledgePlatform } from "../types.js";
 
@@ -240,7 +241,7 @@ export async function runContextCommand(
   const platformRaw = options.platform?.trim();
   const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
   if (platformRaw && !platform) {
-    throw new Error("--platform must be one of: openclaw, claude-code, codex");
+    throw new Error(`--platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`);
   }
 
   // Suppress clack output when explicitly quiet, or when stderr is not a TTY.

--- a/src/commands/db.ts
+++ b/src/commands/db.ts
@@ -9,6 +9,7 @@ import { rebuildVectorIndex } from "../db/vector-index.js";
 import { banner, formatLabel, ui } from "../ui.js";
 import { APP_VERSION } from "../version.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
+import { KNOWLEDGE_PLATFORMS } from "../types.js";
 import type { KnowledgePlatform } from "../types.js";
 
 interface DbRow {
@@ -287,7 +288,7 @@ export async function runDbStatsCommand(
   const platformRaw = options.platform?.trim();
   const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
   if (platformRaw && !platform) {
-    throw new Error("--platform must be one of: openclaw, claude-code, codex");
+    throw new Error(`--platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`);
   }
   const platformClause = platform ? "AND platform = ?" : "";
   const platformArgs = platform ? [platform] : [];
@@ -332,11 +333,10 @@ export async function runDbStatsCommand(
       SELECT platform, COUNT(*) AS count
       FROM entries
       WHERE superseded_by IS NULL
-        ${platformClause}
       GROUP BY platform
       ORDER BY count DESC
     `,
-      args: platformArgs,
+      args: [],
     });
     const byPlatform = byPlatformResult.rows.map((row) => {
       const raw = (row as DbRow).platform;
@@ -358,7 +358,7 @@ export async function runDbStatsCommand(
       ORDER BY count DESC, t.tag ASC
       LIMIT 20
     `,
-      args: platform ? [platform] : [],
+      args: platformArgs,
     });
     const topTags = tagsResult.rows.map((row) => ({
       tag: toStringValue((row as DbRow).tag),
@@ -498,7 +498,7 @@ export async function runDbExportCommand(
   const platformRaw = options.platform?.trim();
   const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
   if (platformRaw && !platform) {
-    throw new Error("--platform must be one of: openclaw, claude-code, codex");
+    throw new Error(`--platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`);
   }
 
   try {

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -13,8 +13,8 @@ import { extractKnowledgeFromChunks } from "../extractor.js";
 import { createLlmClient } from "../llm/client.js";
 import { expandInputFiles, parseTranscriptFile } from "../parser.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
+import { KNOWLEDGE_PLATFORMS } from "../types.js";
 import type { KnowledgeEntry } from "../types.js";
-import type { KnowledgePlatform } from "../types.js";
 import { banner, formatError, formatWarn, ui } from "../ui.js";
 import { installSignalHandlers, isShutdownRequested, onShutdown } from "../shutdown.js";
 import {
@@ -492,7 +492,7 @@ export async function runIngestCommand(
   const platformRaw = options.platform?.trim();
   const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
   if (platformRaw && !platform) {
-    throw new Error("--platform must be one of: openclaw, claude-code, codex");
+    throw new Error(`--platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`);
   }
   const retrySummaries: string[] = [];
   let stoppedForShutdown = false;
@@ -713,7 +713,7 @@ export async function runIngestCommand(
       const processChunkEntries = async (chunkEntries: KnowledgeEntry[]): Promise<void> => {
         const normalizedEntries = chunkEntries.map((entry) => ({
           ...entry,
-          ...(platform ? { platform: platform as KnowledgePlatform } : {}),
+          ...(platform ? { platform } : {}),
           source: {
             ...entry.source,
             file: target.file,

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -6,7 +6,7 @@ import { estimateEntryTokens, sessionStartRecall } from "../db/session-start.js"
 import type { SessionCategory } from "../db/session-start.js";
 import { resolveEmbeddingApiKey } from "../embeddings/client.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
-import { EXPIRY_LEVELS, IMPORTANCE_MAX, IMPORTANCE_MIN, KNOWLEDGE_TYPES, SCOPE_LEVELS } from "../types.js";
+import { EXPIRY_LEVELS, IMPORTANCE_MAX, IMPORTANCE_MIN, KNOWLEDGE_PLATFORMS, KNOWLEDGE_TYPES, SCOPE_LEVELS } from "../types.js";
 import type {
   Expiry,
   KnowledgePlatform,
@@ -294,7 +294,7 @@ export async function runRecallCommand(
   if (options.platform) {
     const normalized = normalizeKnowledgePlatform(options.platform);
     if (!normalized) {
-      throw new Error("--platform must be one of: openclaw, claude-code, codex");
+      throw new Error(`--platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`);
     }
     platform = normalized;
   }

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -9,8 +9,8 @@ import { resolveEmbeddingApiKey } from "../embeddings/client.js";
 import { createLlmClient } from "../llm/client.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
 import { expandInputFiles } from "../parser.js";
-import { EXPIRY_LEVELS, IMPORTANCE_MAX, IMPORTANCE_MIN, KNOWLEDGE_TYPES } from "../types.js";
-import type { ExtractionReport, KnowledgeEntry, KnowledgePlatform, StoreResult } from "../types.js";
+import { EXPIRY_LEVELS, IMPORTANCE_MAX, IMPORTANCE_MIN, KNOWLEDGE_PLATFORMS, KNOWLEDGE_TYPES } from "../types.js";
+import type { ExtractionReport, KnowledgeEntry, StoreResult } from "../types.js";
 import { banner, formatLabel, formatWarn, ui } from "../ui.js";
 import { installSignalHandlers, isShutdownRequested, onShutdown } from "../shutdown.js";
 
@@ -296,7 +296,7 @@ export async function runStoreCommand(
   const platformRaw = options.platform?.trim();
   const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
   if (platformRaw && !platform) {
-    throw new Error("--platform must be one of: openclaw, claude-code, codex");
+    throw new Error(`--platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`);
   }
 
   const hasAnyEntries = totalInputEntries > 0;
@@ -334,9 +334,7 @@ export async function runStoreCommand(
         break;
       }
 
-      const entries: KnowledgeEntry[] = platform
-        ? input.entries.map((entry) => ({ ...entry, platform: platform as KnowledgePlatform }))
-        : input.entries;
+      const entries: KnowledgeEntry[] = platform ? input.entries.map((entry) => ({ ...entry, platform })) : input.entries;
 
       const result = await resolvedDeps.storeEntriesFn(db, entries, apiKey, {
         dryRun: options.dryRun,

--- a/src/consolidate/orchestrate.ts
+++ b/src/consolidate/orchestrate.ts
@@ -8,7 +8,7 @@ import { rebuildVectorIndex } from "../db/vector-index.js";
 import type { KnowledgePlatform, LlmClient } from "../types.js";
 import { buildClusters, type Cluster } from "./cluster.js";
 import { mergeCluster } from "./merge.js";
-import { consolidateRules, type ConsolidationStats } from "./rules.js";
+import { consolidateRules, countActiveEntries, type ConsolidationStats } from "./rules.js";
 import { isShutdownRequested } from "../shutdown.js";
 
 export const CONSOLIDATION_CHECKPOINT_PATH = path.join(os.homedir(), ".agenr", "consolidation-checkpoint.json");
@@ -172,25 +172,6 @@ function defaultClusterStats(): ClusterProcessingStats {
     entriesConsolidatedFrom: 0,
     canonicalEntriesCreated: 0,
   };
-}
-
-async function countActiveEntries(db: Client, platform?: KnowledgePlatform): Promise<number> {
-  const args: unknown[] = [];
-  if (platform) {
-    args.push(platform);
-  }
-
-  const result = await db.execute({
-    sql: `
-      SELECT COUNT(*) AS count
-      FROM entries
-      WHERE superseded_by IS NULL
-        ${platform ? "AND platform = ?" : ""}
-    `,
-    args,
-  });
-  const count = toNumber(result.rows[0]?.count);
-  return Number.isFinite(count) ? count : 0;
 }
 
 async function countActiveEmbeddedEntries(db: Client, typeFilter?: string, platform?: KnowledgePlatform): Promise<number> {

--- a/src/consolidate/rules.ts
+++ b/src/consolidate/rules.ts
@@ -95,7 +95,7 @@ function parseDaysOld(now: Date, createdAt: string): number {
   return Math.max(days, 0);
 }
 
-async function countActiveEntries(db: Client, platform?: KnowledgePlatform): Promise<number> {
+export async function countActiveEntries(db: Client, platform?: KnowledgePlatform): Promise<number> {
   const args: unknown[] = [];
   if (platform) {
     args.push(platform);
@@ -117,14 +117,14 @@ async function countActiveEntries(db: Client, platform?: KnowledgePlatform): Pro
 async function countOrphanedRelations(db: Client): Promise<number> {
   const result = await db.execute({
     sql: `
-	    SELECT COUNT(*) AS count
-	    FROM relations
-	    WHERE relation_type <> 'supersedes'
-	      AND (
-	        source_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
-	        OR target_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
-	      )
-	    `,
+      SELECT COUNT(*) AS count
+      FROM relations
+      WHERE relation_type <> 'supersedes'
+        AND (
+          source_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
+          OR target_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
+        )
+    `,
     args: [],
   });
   const count = toNumber(result.rows[0]?.count);
@@ -402,13 +402,13 @@ async function cleanOrphanedRelations(db: Client, dryRun: boolean): Promise<numb
 
   await db.execute({
     sql: `
-	    DELETE FROM relations
-	    WHERE relation_type <> 'supersedes'
-	      AND (
-	        source_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
-	        OR target_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
-	      )
-	    `,
+      DELETE FROM relations
+      WHERE relation_type <> 'supersedes'
+        AND (
+          source_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
+          OR target_id IN (SELECT id FROM entries WHERE superseded_by IS NOT NULL)
+        )
+    `,
     args: [],
   });
 

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -113,7 +113,7 @@ function mapStoredEntry(row: Row, tags: string[]): StoredEntry {
   const scope = scopeRaw || "private";
   const importanceRaw = toNumber(row.importance);
   const importance = Number.isFinite(importanceRaw) ? Math.min(10, Math.max(1, Math.round(importanceRaw))) : 5;
-  const platformRaw = toStringValue((row as Row & { platform?: unknown }).platform);
+  const platformRaw = toStringValue(row.platform);
   const platform = platformRaw.trim().length > 0 ? platformRaw : undefined;
 
   return {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,7 +13,7 @@ import { resolveEmbeddingApiKey } from "../embeddings/client.js";
 import { extractKnowledgeFromChunks } from "../extractor.js";
 import { createLlmClient } from "../llm/client.js";
 import { parseTranscriptFile } from "../parser.js";
-import { KNOWLEDGE_TYPES, SCOPE_LEVELS } from "../types.js";
+import { KNOWLEDGE_PLATFORMS, KNOWLEDGE_TYPES, SCOPE_LEVELS } from "../types.js";
 import type { KnowledgeEntry, RecallResult, Scope, StoreResult } from "../types.js";
 import { APP_VERSION } from "../version.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
@@ -723,7 +723,10 @@ export function createMcpServer(
     const platformRaw = typeof args.platform === "string" ? args.platform.trim() : "";
     const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
     if (platformRaw && !platform) {
-      throw new RpcError(JSON_RPC_INVALID_PARAMS, "--platform must be one of: openclaw, claude-code, codex");
+      throw new RpcError(
+        JSON_RPC_INVALID_PARAMS,
+        `platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`,
+      );
     }
 
     const db = await ensureDb();
@@ -782,7 +785,10 @@ export function createMcpServer(
     const platformRaw = typeof args.platform === "string" ? args.platform.trim() : "";
     const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
     if (platformRaw && !platform) {
-      throw new RpcError(JSON_RPC_INVALID_PARAMS, "--platform must be one of: openclaw, claude-code, codex");
+      throw new RpcError(
+        JSON_RPC_INVALID_PARAMS,
+        `platform must be one of: ${KNOWLEDGE_PLATFORMS.join(", ")}`,
+      );
     }
 
     const parsed = parseStoreEntries(args.entries);

--- a/src/watch/platform-defaults.ts
+++ b/src/watch/platform-defaults.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import type { WatchPlatform } from "./resolvers/index.js";
 
-export function getDefaultPlatformDir(platform: WatchPlatform, homeDir = os.homedir()): string {
+export function getDefaultPlatformDir(platform: Exclude<WatchPlatform, "mtime">, homeDir = os.homedir()): string {
   if (platform === "openclaw") {
     return path.join(homeDir, ".openclaw", "agents", "main", "sessions");
   }
@@ -15,4 +15,3 @@ export function getDefaultPlatformDir(platform: WatchPlatform, homeDir = os.home
 
   throw new Error(`No default directory for platform: ${platform}`);
 }
-

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -11,6 +11,7 @@ import { resolveEmbeddingApiKey } from "../embeddings/client.js";
 import { extractKnowledgeFromChunks } from "../extractor.js";
 import { createLlmClient } from "../llm/client.js";
 import { parseTranscriptFile } from "../parser.js";
+import { normalizeKnowledgePlatform } from "../platform.js";
 import { installSignalHandlers, isShutdownRequested } from "../shutdown.js";
 import type { KnowledgeEntry, KnowledgePlatform, WatchState } from "../types.js";
 import type { SessionResolver } from "./session-resolver.js";
@@ -454,7 +455,9 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
 
         const processChunkEntries = async (chunkEntries: KnowledgeEntry[]): Promise<void> => {
           const platformTag: KnowledgePlatform | undefined =
-            currentPlatform && currentPlatform !== "mtime" ? (currentPlatform as KnowledgePlatform) : undefined;
+            currentPlatform && currentPlatform !== "mtime"
+              ? normalizeKnowledgePlatform(currentPlatform) ?? undefined
+              : undefined;
           const taggedEntries = platformTag ? chunkEntries.map((entry) => ({ ...entry, platform: platformTag })) : chunkEntries;
 
           cycleResult.entriesExtracted += taggedEntries.length;

--- a/tests/commands/db.test.ts
+++ b/tests/commands/db.test.ts
@@ -160,7 +160,14 @@ describe("db command", () => {
     const stats = await runDbStatsCommand({ platform: "openclaw" }, makeDeps(client));
     expect(stats.total).toBe(1);
     expect(stats.byType).toEqual([{ type: "fact", count: 1 }]);
-    expect(stats.byPlatform).toEqual([{ platform: "openclaw", count: 1 }]);
+    expect(stats.byPlatform).toHaveLength(3);
+    expect(stats.byPlatform).toEqual(
+      expect.arrayContaining([
+        { platform: "openclaw", count: 1 },
+        { platform: "codex", count: 1 },
+        { platform: "(untagged)", count: 1 },
+      ]),
+    );
     expect(stats.topTags).toEqual([{ tag: "openclaw-tag", count: 1 }]);
   });
 

--- a/tests/db/migration.test.ts
+++ b/tests/db/migration.test.ts
@@ -255,6 +255,8 @@ describe("db schema migrations", () => {
     await initSchema(client);
 
     const row = await client.execute({ sql: "SELECT platform FROM entries WHERE id = ?", args: ["legacy-1"] });
+    expect(row.rows.length).toBeGreaterThan(0);
+    expect(row.rows[0]).toBeDefined();
     expect((row.rows[0] as { platform?: unknown } | undefined)?.platform ?? null).toBe(null);
   });
 

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -305,11 +305,16 @@ describe("mcp server", () => {
     expect(harness.initDbFn).toHaveBeenCalledTimes(1);
     expect(harness.recallFn).toHaveBeenCalledTimes(1);
 
-    const recallQuery = harness.recallFn.mock.calls[0]?.[1] as { text?: string; types?: string[]; limit?: number };
+    const recallQuery = harness.recallFn.mock.calls[0]?.[1] as {
+      text?: string;
+      types?: string[];
+      limit?: number;
+      platform?: string;
+    };
     expect(recallQuery.text).toBe("Jim's diet");
     expect(recallQuery.limit).toBe(5);
     expect(recallQuery.types).toEqual(["preference", "fact"]);
-    expect((recallQuery as any).platform).toBe("openclaw");
+    expect(recallQuery.platform).toBe("openclaw");
   });
 
   it("uses two-pass session-start recall and returns grouped ordering", async () => {
@@ -628,7 +633,7 @@ describe("mcp server", () => {
 
     const storedEntries = harness.storeEntriesFn.mock.calls[0]?.[1] as KnowledgeEntry[];
     expect(storedEntries).toHaveLength(1);
-    expect((storedEntries[0] as any).platform).toBe("codex");
+    expect(storedEntries[0]?.platform).toBe("codex");
   });
 
   it("calls agenr_extract and optionally stores extracted entries", async () => {

--- a/tests/watch/platform-defaults.test.ts
+++ b/tests/watch/platform-defaults.test.ts
@@ -12,5 +12,10 @@ describe("platform defaults", () => {
     expect(getDefaultPlatformDir("codex", home)).toBe(path.join(home, ".codex", "sessions"));
     expect(getDefaultPlatformDir("claude-code", home)).toBe(path.join(home, ".claude", "projects"));
   });
-});
 
+  it("throws for an unsupported platform", () => {
+    expect(() => getDefaultPlatformDir("unknown-platform" as never)).toThrow(
+      "No default directory for platform: unknown-platform",
+    );
+  });
+});


### PR DESCRIPTION
Cleanup pass addressing all CodeRabbit findings from PR #11.

## Changes

**Docs:**
- CLI.md: Fixed duplicate `--platform` on store, added to db stats, documented "claude" alias
- MCP.md: Documented `platform` parameter on agenr_recall and agenr_store
- README: Updated stale test count (369 -> 445)
- CHANGELOG: Added db stats per-platform breakdown note

**Type safety:**
- Removed `as any` casts in MCP tests
- Removed redundant `as KnowledgePlatform` casts in store, ingest, consolidate
- Narrowed `getDefaultPlatformDir` param to `Exclude<WatchPlatform, "mtime">`
- Used `normalizeKnowledgePlatform()` in watcher instead of unsafe cast
- Fixed recall.ts row cast to use Row index signature directly

**Deduplication:**
- Removed duplicate `countActiveEntries` from orchestrate.ts (imports from rules.ts)
- Used `KNOWLEDGE_PLATFORMS.join()` for all error messages instead of hardcoded strings

**Behavior:**
- db stats `byPlatform` shows full breakdown even when filtered
- db stats tags query uses shared `platformArgs`
- MCP error messages reference JSON param names, not CLI flags

**Code style:**
- Fixed tab/space mix in consolidate rules.ts
- Merged imports in ingest.ts
- Added missing test for unsupported platform in platform-defaults

445 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "claude" as a supported platform across CLI commands (store, recall, ingest, consolidate, db stats, db export, daemon, watch)
  * Database stats output now includes per-platform entry breakdown in addition to existing metrics

* **Documentation**
  * Updated CLI documentation with expanded platform support options
  * Updated MCP tool documentation with new platform filtering capabilities

* **Tests**
  * Enhanced test coverage for platform validation and multi-platform scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->