### PR TITLE
feat(scoring): freshnessBoost, smooth todo decay, dynamic budget, eval command (v0.5.2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
 - MCP tool support for project:
   - `agenr_recall` accepts optional `project` filter (comma-separated for multiple)
   - `agenr_store` accepts optional `project` tag
+- `agenr eval recall` command for scoring regression checks (baseline save and compare)
+
+### Fixed
+- Recall scoring and session-start recall:
+  - Freshness boost for importance >= 6 (clamped to avoid amplifying noisy entries)
+  - Smooth exponential todo staleness decay (half-life 7 days; floors at 0.10 or 0.40 for importance >= 8)
+  - Session-start permanent window widened to 30 days (temporary remains shorter)
+  - Dynamic budget allocation based on available categories
+  - Recency tiebreaking within a 0.05 score dead-band applied to the recent category only
 
 ## 0.5.0 (2026-02-17)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -694,7 +694,7 @@ The `--context` flag changes how recall behaves:
   - **Preferences**: preferences and decisions
   - **Recent**: everything else, sorted by recency
   
-  When used with `--budget`, allocates tokens across categories (30% active, 30% preferences, remainder to recent) with overflow redistribution.
+  When used with `--budget`, allocates tokens across categories dynamically via `computeBudgetSplit()` based on category counts: active receives ~10-30%, preferences ~20-40%, and the remainder goes to recent (with a minimum 20% floor for recent), with overflow redistribution.
 
 - **`topic:<query>`**: Prepends `[topic: <query>]` to the search text before embedding, biasing results toward that topic. Useful for scoping recall to a specific area (e.g., `--context topic:authentication`).
 
@@ -704,7 +704,7 @@ The `--budget <tokens>` flag caps the total approximate token count of returned 
 
 In **default** mode: entries are ranked by score, then consumed in order until the budget is exhausted.
 
-In **session-start** mode: the budget is split across categories (30% active, 30% preferences, remaining to recent). Each category consumes entries in score order until its quota is full. Leftover budget is redistributed to remaining entries across all categories.
+In **session-start** mode: the budget is split across categories dynamically via `computeBudgetSplit()` based on category counts (active ~10-30%, preferences ~20-40%, remainder to recent with a 20% minimum floor for recent). Each category consumes entries in score order until its quota is full. Leftover budget is redistributed to remaining entries across all categories.
 
 This is useful for keeping context windows manageable — e.g., `agenr recall --context session-start --budget 2000` loads ≈2000 tokens of the most relevant memories.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -152,6 +152,29 @@ $A recall "which package manager did we choose?" --limit 3
    tags: tooling, package-manager
 ```
 
+## `eval recall`
+
+Behavioral regression testing for the current recall scoring algorithm. This command is read-only and does not make model calls.
+
+### Syntax
+
+```bash
+agenr eval recall [options]
+```
+
+### Options
+- `--save-baseline`: save current results to `~/.agenr/eval-baseline.json`.
+- `--compare`: compare current results against the saved baseline.
+- `--queries <path>`: custom query set JSON path (default `~/.agenr/eval-queries.json`).
+- `--limit <n>`: results per query (default `10`).
+- `--budget <n>`: token budget passed to session-start recall (default `2000`).
+
+### Example
+
+```bash
+$A eval recall --limit 5
+```
+
 ## `context`
 
 Generate a context file for AI tool integration using session-start recall (no embedding API calls).

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -1,0 +1,526 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Client } from "@libsql/client";
+import { readConfig } from "../config.js";
+import { closeDb, getDb, initDb } from "../db/client.js";
+import { scoreEntry } from "../db/recall.js";
+import { sessionStartRecall } from "../db/session-start.js";
+import type { StoredEntry } from "../types.js";
+import { APP_VERSION } from "../version.js";
+
+const DEFAULT_LIMIT = 10;
+const DEFAULT_BUDGET = 2000;
+const DEFAULT_QUERIES_PATH = "~/.agenr/eval-queries.json";
+const BASELINE_PATH = "~/.agenr/eval-baseline.json";
+
+interface DbRow {
+  [key: string]: unknown;
+}
+
+export interface EvalRecallQuery {
+  id: string;
+  query: string;
+}
+
+export interface EvalRecallCommandOptions {
+  saveBaseline?: boolean;
+  compare?: boolean;
+  queries?: string;
+  limit?: number | string;
+  budget?: number | string;
+}
+
+export interface EvalRecallCommandDeps {
+  readConfigFn: typeof readConfig;
+  getDbFn: typeof getDb;
+  initDbFn: typeof initDb;
+  closeDbFn: typeof closeDb;
+  sessionStartRecallFn: typeof sessionStartRecall;
+  scoreEntryFn: typeof scoreEntry;
+  readFileFn: typeof fs.readFile;
+  writeFileFn: typeof fs.writeFile;
+  mkdirFn: typeof fs.mkdir;
+  accessFn: typeof fs.access;
+  homedirFn: () => string;
+  nowFn: () => Date;
+}
+
+interface EvalResultRow {
+  entry: StoredEntry;
+  score: number;
+}
+
+interface BaselineRow {
+  entry_id: string;
+  score: number;
+  type: StoredEntry["type"];
+  importance: number;
+  created_at: string;
+  updated_at: string;
+  subject: string;
+  content: string;
+}
+
+interface EvalBaseline {
+  saved_at: string;
+  version: string;
+  limit: number;
+  queries: Array<{ id: string; query: string; results: BaselineRow[] }>;
+}
+
+const DEFAULT_QUERIES: EvalRecallQuery[] = [
+  { id: "session-start", query: "session context startup recall" },
+  { id: "recent-decisions", query: "decisions made recently" },
+  { id: "active-todos", query: "active todos and tasks" },
+  { id: "preferences", query: "user preferences and configuration" },
+  { id: "architecture", query: "architecture and technical decisions" },
+];
+
+function parsePositiveInt(value: number | string | undefined, fallback: number, label: string): number {
+  if (value === undefined || value === null || String(value).trim() === "") {
+    return fallback;
+  }
+
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive number.`);
+  }
+  return Math.floor(parsed);
+}
+
+function resolveTildePath(inputPath: string, homedirFn: () => string): string {
+  return inputPath.replace(/^~(?=$|\/)/, homedirFn());
+}
+
+function toStringValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  return "";
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string" && value.trim()) return Number(value);
+  return Number.NaN;
+}
+
+function formatPreview(entry: StoredEntry): string {
+  const blob = `${entry.subject}: ${entry.content}`.replace(/\s+/g, " ").trim();
+  if (blob.length <= 120) return blob;
+  return `${blob.slice(0, 117)}...`;
+}
+
+function ageDays(now: Date, iso: string): number {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return 0;
+  return Math.max(0, Math.floor((now.getTime() - parsed.getTime()) / (1000 * 60 * 60 * 24)));
+}
+
+async function fileExists(filePath: string, accessFn: typeof fs.access): Promise<boolean> {
+  try {
+    await accessFn(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function loadQueries(
+  rawPath: string,
+  deps: Pick<EvalRecallCommandDeps, "readFileFn" | "accessFn" | "homedirFn">,
+): Promise<EvalRecallQuery[]> {
+  const resolved = path.resolve(resolveTildePath(rawPath, deps.homedirFn));
+  const exists = await fileExists(resolved, deps.accessFn);
+  if (!exists) {
+    return DEFAULT_QUERIES;
+  }
+
+  const content = await deps.readFileFn(resolved, "utf8");
+  const parsed = JSON.parse(content) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error("--queries must be a JSON array of { id, query }.");
+  }
+
+  const queries: EvalRecallQuery[] = [];
+  for (const item of parsed) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const id = toStringValue((item as Record<string, unknown>).id).trim();
+    const query = toStringValue((item as Record<string, unknown>).query).trim();
+    if (!id || !query) {
+      continue;
+    }
+    queries.push({ id, query });
+  }
+
+  return queries.length > 0 ? queries : DEFAULT_QUERIES;
+}
+
+async function getTagsByEntryIds(db: Client, ids: string[]): Promise<Map<string, string[]>> {
+  if (ids.length === 0) {
+    return new Map();
+  }
+
+  const placeholders = ids.map(() => "?").join(", ");
+  const result = await db.execute({
+    sql: `SELECT entry_id, tag FROM tags WHERE entry_id IN (${placeholders})`,
+    args: ids,
+  });
+
+  const tagsById = new Map<string, string[]>();
+  for (const row of result.rows) {
+    const entryId = toStringValue((row as DbRow).entry_id);
+    const tag = toStringValue((row as DbRow).tag);
+    if (!entryId || !tag) continue;
+    const tags = tagsById.get(entryId) ?? [];
+    tags.push(tag.toLowerCase());
+    tagsById.set(entryId, tags);
+  }
+
+  for (const [entryId, tags] of tagsById.entries()) {
+    tagsById.set(entryId, Array.from(new Set(tags)));
+  }
+
+  return tagsById;
+}
+
+function mapStoredEntry(row: DbRow, tags: string[]): StoredEntry {
+  const importance = Number.isFinite(toNumber(row.importance)) ? toNumber(row.importance) : 5;
+  const scope = (toStringValue(row.scope) || "private") as StoredEntry["scope"];
+  const platform = toStringValue(row.platform).trim();
+  const project = toStringValue(row.project).trim();
+  const canonicalKey = toStringValue(row.canonical_key).trim();
+
+  return {
+    id: toStringValue(row.id),
+    type: toStringValue(row.type) as StoredEntry["type"],
+    subject: toStringValue(row.subject),
+    content: toStringValue(row.content),
+    ...(canonicalKey ? { canonical_key: canonicalKey } : {}),
+    importance,
+    expiry: toStringValue(row.expiry) as StoredEntry["expiry"],
+    scope,
+    ...(platform ? { platform: platform as StoredEntry["platform"] } : {}),
+    ...(project ? { project: project.toLowerCase() } : {}),
+    tags,
+    source: {
+      file: toStringValue(row.source_file) || "",
+      context: toStringValue(row.source_context) || "",
+    },
+    created_at: toStringValue(row.created_at),
+    updated_at: toStringValue(row.updated_at),
+    last_recalled_at: toStringValue(row.last_recalled_at) || undefined,
+    recall_count: Number.isFinite(toNumber(row.recall_count)) ? toNumber(row.recall_count) : 0,
+    confirmations: Number.isFinite(toNumber(row.confirmations)) ? toNumber(row.confirmations) : 0,
+    contradictions: Number.isFinite(toNumber(row.contradictions)) ? toNumber(row.contradictions) : 0,
+    superseded_by: toStringValue(row.superseded_by) || undefined,
+  };
+}
+
+async function runFtsEval(db: Client, text: string, now: Date, limit: number, scoreEntryFn: typeof scoreEntry): Promise<EvalResultRow[]> {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const result = await db.execute({
+    sql: `
+      SELECT
+        e.id,
+        e.type,
+        e.subject,
+        e.canonical_key,
+        e.content,
+        e.importance,
+        e.expiry,
+        e.scope,
+        e.platform,
+        e.project,
+        e.source_file,
+        e.source_context,
+        e.created_at,
+        e.updated_at,
+        e.last_recalled_at,
+        e.recall_count,
+        e.confirmations,
+        e.contradictions,
+        e.superseded_by
+      FROM entries_fts
+      JOIN entries AS e ON e.rowid = entries_fts.rowid
+      WHERE entries_fts MATCH ?
+        AND e.superseded_by IS NULL
+      LIMIT 250
+    `,
+    args: [trimmed],
+  });
+
+  const ids = result.rows.map((row) => toStringValue((row as DbRow).id)).filter((id) => id.length > 0);
+  const tagsById = await getTagsByEntryIds(db, ids);
+
+  const scored = result.rows
+    .map((row) => mapStoredEntry(row as DbRow, tagsById.get(toStringValue((row as DbRow).id)) ?? []))
+    .map((entry) => ({ entry, score: scoreEntryFn(entry, 1.0, true, now) }))
+    .sort((a, b) => b.score - a.score);
+
+  return scored.slice(0, limit);
+}
+
+async function runSessionStartEval(
+  db: Client,
+  now: Date,
+  limit: number,
+  budget: number,
+  deps: Pick<EvalRecallCommandDeps, "sessionStartRecallFn">,
+): Promise<EvalResultRow[]> {
+  const query = {
+    context: "session-start" as const,
+    text: "",
+    noUpdate: true,
+    scope: "private" as const,
+    budget,
+  };
+
+  const grouped = await deps.sessionStartRecallFn(db, {
+    query,
+    apiKey: "",
+    budget,
+    nonCoreLimit: Math.max(limit * 3, limit),
+    coreCandidateLimit: limit,
+  });
+
+  return grouped.results
+    .slice()
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((row) => ({ entry: row.entry, score: row.score }));
+}
+
+function printQueryResults(params: { id: string; query: string; rows: EvalResultRow[]; now: Date }): void {
+  process.stdout.write(`${params.id}\n`);
+  const header = `query="${params.query}"`;
+  process.stdout.write(`${header}\n`);
+  if (params.rows.length === 0) {
+    process.stdout.write("(no results)\n\n");
+    return;
+  }
+
+  let rank = 1;
+  for (const row of params.rows) {
+    const days = ageDays(params.now, row.entry.created_at);
+    process.stdout.write(
+      `${rank}. ${row.score.toFixed(4)} ${row.entry.type} importance=${row.entry.importance} age=${days}d ${formatPreview(row.entry)}\n`,
+    );
+    rank += 1;
+  }
+  process.stdout.write("\n");
+}
+
+function diffBaseline(baseline: BaselineRow[], current: EvalResultRow[]): {
+  up: Array<{ id: string; delta: number }>;
+  down: Array<{ id: string; delta: number }>;
+  fresh: string[];
+  dropped: string[];
+} {
+  const baselineRank = new Map<string, number>();
+  for (let i = 0; i < baseline.length; i += 1) {
+    baselineRank.set(baseline[i]!.entry_id, i + 1);
+  }
+
+  const currentRank = new Map<string, number>();
+  for (let i = 0; i < current.length; i += 1) {
+    currentRank.set(current[i]!.entry.id, i + 1);
+  }
+
+  const up: Array<{ id: string; delta: number }> = [];
+  const down: Array<{ id: string; delta: number }> = [];
+  const fresh: string[] = [];
+  const dropped: string[] = [];
+
+  for (const [id, rank] of currentRank.entries()) {
+    const prior = baselineRank.get(id);
+    if (!prior) {
+      fresh.push(id);
+      continue;
+    }
+    const delta = prior - rank;
+    if (delta > 0) up.push({ id, delta });
+    if (delta < 0) down.push({ id, delta: Math.abs(delta) });
+  }
+
+  for (const [id] of baselineRank.entries()) {
+    if (!currentRank.has(id)) {
+      dropped.push(id);
+    }
+  }
+
+  up.sort((a, b) => b.delta - a.delta);
+  down.sort((a, b) => b.delta - a.delta);
+  return { up, down, fresh, dropped };
+}
+
+function printDiff(params: {
+  id: string;
+  query: string;
+  baseline: BaselineRow[];
+  current: EvalResultRow[];
+}): { up: number; down: number; fresh: number; dropped: number } {
+  const diff = diffBaseline(params.baseline, params.current);
+
+  process.stdout.write(`${params.id}\n`);
+  process.stdout.write(`query="${params.query}"\n`);
+
+  const printIds = (label: string, ids: string[], prefix: string) => {
+    if (ids.length === 0) return;
+    process.stdout.write(`${label}:\n`);
+    for (const id of ids) {
+      process.stdout.write(`${prefix}${id}\n`);
+    }
+  };
+
+  if (diff.up.length > 0) {
+    process.stdout.write("Up:\n");
+    for (const item of diff.up) {
+      process.stdout.write(`+${item.delta} ${item.id}\n`);
+    }
+  }
+  if (diff.down.length > 0) {
+    process.stdout.write("Down:\n");
+    for (const item of diff.down) {
+      process.stdout.write(`-${item.delta} ${item.id}\n`);
+    }
+  }
+  printIds("New", diff.fresh, "+ ");
+  printIds("Dropped", diff.dropped, "- ");
+
+  process.stdout.write("\n");
+
+  return { up: diff.up.length, down: diff.down.length, fresh: diff.fresh.length, dropped: diff.dropped.length };
+}
+
+export async function runEvalRecallCommand(
+  options: EvalRecallCommandOptions,
+  deps?: Partial<EvalRecallCommandDeps>,
+): Promise<{ exitCode: number }> {
+  if (options.saveBaseline && options.compare) {
+    throw new Error("Use either --save-baseline or --compare, not both.");
+  }
+
+  const resolvedDeps: EvalRecallCommandDeps = {
+    readConfigFn: deps?.readConfigFn ?? readConfig,
+    getDbFn: deps?.getDbFn ?? getDb,
+    initDbFn: deps?.initDbFn ?? initDb,
+    closeDbFn: deps?.closeDbFn ?? closeDb,
+    sessionStartRecallFn: deps?.sessionStartRecallFn ?? sessionStartRecall,
+    scoreEntryFn: deps?.scoreEntryFn ?? scoreEntry,
+    readFileFn: deps?.readFileFn ?? fs.readFile,
+    writeFileFn: deps?.writeFileFn ?? fs.writeFile,
+    mkdirFn: deps?.mkdirFn ?? fs.mkdir,
+    accessFn: deps?.accessFn ?? fs.access,
+    homedirFn: deps?.homedirFn ?? os.homedir,
+    nowFn: deps?.nowFn ?? (() => new Date()),
+  };
+
+  const now = resolvedDeps.nowFn();
+  const limit = parsePositiveInt(options.limit, DEFAULT_LIMIT, "--limit");
+  const budget = parsePositiveInt(options.budget, DEFAULT_BUDGET, "--budget");
+  const queriesPath = (options.queries?.trim() || DEFAULT_QUERIES_PATH).trim();
+  const baselinePath = path.resolve(resolveTildePath(BASELINE_PATH, resolvedDeps.homedirFn));
+
+  const queries = await loadQueries(queriesPath, resolvedDeps);
+
+  const config = resolvedDeps.readConfigFn(process.env);
+  const dbPath = config?.db?.path;
+  const db = resolvedDeps.getDbFn(dbPath);
+
+  try {
+    await resolvedDeps.initDbFn(db);
+
+    const resultsByQueryId = new Map<string, EvalResultRow[]>();
+    for (const q of queries) {
+      if (q.id === "session-start") {
+        resultsByQueryId.set(q.id, await runSessionStartEval(db, now, limit, budget, resolvedDeps));
+      } else {
+        resultsByQueryId.set(q.id, await runFtsEval(db, q.query, now, limit, resolvedDeps.scoreEntryFn));
+      }
+    }
+
+    if (options.compare) {
+      const baselineExists = await fileExists(baselinePath, resolvedDeps.accessFn);
+      if (!baselineExists) {
+        throw new Error(`Baseline not found: ${baselinePath}`);
+      }
+      const baselineRaw = await resolvedDeps.readFileFn(baselinePath, "utf8");
+      const baseline = JSON.parse(baselineRaw) as EvalBaseline;
+      const baselineById = new Map(baseline.queries.map((q) => [q.id, q] as const));
+
+      let totalUp = 0;
+      let totalDown = 0;
+      let totalNew = 0;
+      let totalDropped = 0;
+
+      for (const q of queries) {
+        const base = baselineById.get(q.id);
+        const current = resultsByQueryId.get(q.id) ?? [];
+        const summary = printDiff({
+          id: q.id,
+          query: q.query,
+          baseline: base?.results ?? [],
+          current,
+        });
+        totalUp += summary.up;
+        totalDown += summary.down;
+        totalNew += summary.fresh;
+        totalDropped += summary.dropped;
+      }
+
+      process.stdout.write(
+        `${totalUp} up, ${totalDown} down, ${totalNew} new, ${totalDropped} dropped across ${queries.length} queries\n`,
+      );
+      return { exitCode: 0 };
+    }
+
+    for (const q of queries) {
+      printQueryResults({
+        id: q.id,
+        query: q.query,
+        rows: resultsByQueryId.get(q.id) ?? [],
+        now,
+      });
+    }
+
+    if (options.saveBaseline) {
+      const baseline: EvalBaseline = {
+        saved_at: now.toISOString(),
+        version: APP_VERSION,
+        limit,
+        queries: queries.map((q) => {
+          const rows = resultsByQueryId.get(q.id) ?? [];
+          const results: BaselineRow[] = rows.map((row) => ({
+            entry_id: row.entry.id,
+            score: row.score,
+            type: row.entry.type,
+            importance: row.entry.importance,
+            created_at: row.entry.created_at,
+            updated_at: row.entry.updated_at,
+            subject: row.entry.subject,
+            content: row.entry.content,
+          }));
+          return { id: q.id, query: q.query, results };
+        }),
+      };
+
+      await resolvedDeps.mkdirFn(path.dirname(baselinePath), { recursive: true, mode: 0o700 });
+      await resolvedDeps.writeFileFn(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+
+      const totalResults = baseline.queries.reduce((sum, q) => sum + q.results.length, 0);
+      process.stdout.write(`Baseline saved: ${baseline.queries.length} queries, ${totalResults} total results\n`);
+    }
+
+    return { exitCode: 0 };
+  } finally {
+    resolvedDeps.closeDbFn(db);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,8 @@ export interface RecallResult {
     recency: number;
     importance: number;
     recall: number;
+    freshness: number;
+    todoPenalty: number;
     fts: number;
   };
 }
@@ -207,7 +209,7 @@ export interface RecallQuery {
   tags?: string[];
   minImportance?: number;
   since?: string;
-  expiry?: Expiry;
+  expiry?: Expiry | Expiry[];
   scope?: Scope;
   context?: string;
   budget?: number;

--- a/tests/commands/context.test.ts
+++ b/tests/commands/context.test.ts
@@ -38,7 +38,7 @@ function makeResult(category: RecallCommandResult["category"], overrides: Partia
   return {
     entry: makeEntry(overrides),
     score: 0.8,
-    scores: { vector: 0, recency: 0, importance: 0, recall: 0, fts: 0 },
+    scores: { vector: 0, recency: 0, importance: 0, recall: 0, freshness: 1, todoPenalty: 1, fts: 0 },
     category,
   };
 }

--- a/tests/commands/eval.test.ts
+++ b/tests/commands/eval.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runEvalRecallCommand } from "../../src/commands/eval.js";
+import { closeDb, getDb, initDb } from "../../src/db/client.js";
+import { scoreEntry } from "../../src/db/recall.js";
+import { sessionStartRecall } from "../../src/db/session-start.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agenr-eval-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+  vi.restoreAllMocks();
+});
+
+function makeDeps(homeDir: string) {
+  return {
+    readConfigFn: vi.fn(() => ({ db: { path: ":memory:" } })),
+    getDbFn: getDb,
+    initDbFn: initDb,
+    closeDbFn: closeDb,
+    sessionStartRecallFn: sessionStartRecall,
+    scoreEntryFn: scoreEntry,
+    readFileFn: fs.readFile,
+    writeFileFn: fs.writeFile,
+    mkdirFn: fs.mkdir,
+    accessFn: fs.access,
+    homedirFn: () => homeDir,
+    nowFn: () => new Date("2026-02-18T00:00:00.000Z"),
+  };
+}
+
+describe("eval recall command", () => {
+  it("runs without error on empty DB", async () => {
+    const home = await makeTempDir();
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const result = await runEvalRecallCommand({ limit: 5 }, makeDeps(home));
+
+    expect(result.exitCode).toBe(0);
+    expect(stdoutSpy).toHaveBeenCalled();
+  });
+
+  it("--save-baseline creates a file at the expected path", async () => {
+    const home = await makeTempDir();
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const result = await runEvalRecallCommand({ saveBaseline: true, limit: 3 }, makeDeps(home));
+    expect(result.exitCode).toBe(0);
+
+    const baselinePath = path.join(home, ".agenr", "eval-baseline.json");
+    const content = await fs.readFile(baselinePath, "utf8");
+    const parsed = JSON.parse(content) as { queries?: unknown[] };
+    expect(Array.isArray(parsed.queries)).toBe(true);
+  });
+
+  it("--compare loads baseline and produces diff output", async () => {
+    const home = await makeTempDir();
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runEvalRecallCommand({ saveBaseline: true, limit: 3 }, makeDeps(home));
+    const compareResult = await runEvalRecallCommand({ compare: true, limit: 3 }, makeDeps(home));
+
+    expect(compareResult.exitCode).toBe(0);
+    const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("across");
+  });
+});
+


### PR DESCRIPTION
## Summary

Implements v0.5.2a: corrected recall scoring algorithm and new `agenr eval recall` command.

## Scoring Changes (Area 8)

- **freshnessBoost**: importance >= 6 entries get a temporary score multiplier (1.5x <1h, 1.25x <6h, 1.1x <24h). Gated on importance to prevent low-quality entries flooding session-start.
- **todoStaleness**: replaced step function with exponential decay (half-life 7 days, floor 0.10). importance >= 8 todos get a 0.40 floor to stay relevant even when old.
- **scoreSessionEntry**: now calls `scoreEntry` directly, unifying the scoring path. Todos in session-start no longer bypass scoring fixes.
- **Session-start window**: 7-day hard cutoff replaced with 30-day window for permanent entries. Recency decay handles suppression.
- **Dynamic budget allocation**: replaces hardcoded 20/30/50 split. Zero active todos = zero budget to active, flows to recent/preferences.
- **Recency tiebreaker**: scoped to `recent` category only within 0.05 score dead-band.

## Eval Command (Area 9)

New `agenr eval recall` command for behavioral regression testing:
- `--save-baseline`: snapshot current rankings to disk
- `--compare`: diff current results against saved baseline
- No ground truth labels or model calls needed

## Tests

474 passing (up from 467). Deleted old step-function todoStaleness tests. Added: freshnessBoost, smooth decay, dynamic budget, 30-day window, eval command smoke tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agenr eval recall CLI command for read-only recall evaluation with baseline save/compare.

* **Fixed**
  * Refined recall scoring: controlled freshness boosts, smooth exponential todo staleness (7‑day half-life) with floors, smarter todo penalties, recency tiebreaking, and dynamic category budgeting. Session-start permanent window increased to 30 days. Scoring helpers are now exposed for diagnostics.

* **Documentation**
  * CLI docs and examples for the new command; updated recall budgeting and behavior notes.

* **Tests & Migrations**
  * New eval recall tests; migration adds numeric importance with legacy backfill and FTS rebuild handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->