### PR TITLE
fix(ingestion): byteOffset uses actual bytes read, atomic state save (v0.5.2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   - Session-start permanent window widened to 30 days (temporary remains shorter)
   - Dynamic budget allocation based on available categories
   - Recency tiebreaking within a 0.05 score dead-band applied to the recent category only
+- Watch ingestion now advances `byteOffset` by bytes actually read in each cycle, preventing duplicate processing when files grow during read.
+- Watch state saves are now atomic (temp file + rename), preventing partial-write corruption on process crashes.
 
 ## 0.5.0 (2026-02-17)
 

--- a/src/watch/state.ts
+++ b/src/watch/state.ts
@@ -126,10 +126,12 @@ export async function saveWatchState(state: WatchState, configDir?: string): Pro
     normalized.files[resolvedPath] = sanitizeFileState(resolvedPath, fileState);
   }
 
-  await fs.writeFile(statePath, `${JSON.stringify(normalized, null, 2)}\n`, {
+  const tmpPath = `${statePath}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(normalized, null, 2)}\n`, {
     encoding: "utf8",
     mode: CONFIG_FILE_MODE,
   });
+  await fs.rename(tmpPath, statePath);
 
   try {
     await fs.chmod(statePath, CONFIG_FILE_MODE);

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -545,7 +545,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
 
         const latestState = getFileState(state, targetFilePath);
         updateFileState(state, targetFilePath, {
-          byteOffset: stat.size,
+          byteOffset: byteOffset + newBytes.byteLength,
           lastRunAt: resolvedDeps.nowFn().toISOString(),
           totalEntriesStored: (latestState?.totalEntriesStored ?? 0) + cycleResult.entriesStored,
           totalRunCount: (latestState?.totalRunCount ?? 0) + 1,


### PR DESCRIPTION
## Summary

Two targeted reliability fixes for the file watcher.

## Fix 1: byteOffset race condition (CRITICAL)

After processing a file cycle, the watcher was saving `stat.size` (from the outer stat at the top of the function) as the new byteOffset. `readFileFn` does its own inner stat on the file handle — if the file grows between those two calls (common during live AI sessions), `readFileFn` returns more bytes than the outer stat predicted, but we saved the stale outer `stat.size`. This caused double-processing on the next cycle, leading to duplicate entries in the DB.

**Fix:** `byteOffset: byteOffset + newBytes.byteLength` — save exactly how many bytes were consumed.

## Fix 2: Atomic watch state write

`saveWatchState` was writing directly to the state file with `fs.writeFile`. A crash mid-write corrupts the file, causing the watcher to lose all byte offsets on restart and re-process everything from 0.

**Fix:** Write to a `.tmp` file first, then `fs.rename` atomically over the target. On POSIX the rename is atomic — either the old file survives intact or the new file replaces it cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file watching to prevent duplicate event processing when watched files grow during read operations.
  * Improved watch state persistence with atomic writes to prevent corruption during unexpected process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->