### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps package.json version from 0.5.0 to 0.5.2 to reflect shipped releases (v0.5.1 project tagging, v0.5.2a scoring, v0.5.2b ingestion reliability).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Version bumped to 0.5.2 (patch release).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->