### PR TITLE
feat(todos): agenr todo done, agenr_done MCP, cross-type superseding (v0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.5.4] - 2026-02-18
+
+### Added
+- feat(todo): `agenr todo done` command to immediately retire resolved todos
+- feat(mcp): `agenr_done` MCP tool for agent-driven todo retirement
+- feat(extractor): todo completion detection in `SYSTEM_PROMPT`
+
+### Fixed
+- fix(store): cross-type canonical_key superseding allows events to retire todos
+
 ## [0.5.3] - 2026-02-18
 
 ### Added

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -259,6 +259,28 @@ $A watch --platform openclaw --interval 120
 Summary: 1 cycles | 1 entries stored | watched for 0s
 ```
 
+## `todo`
+
+Manage todo entries in the knowledge base.
+
+### Syntax
+
+```bash
+agenr todo <subcommand> <subject> [options]
+```
+
+### Options
+- `--db <path>`: database path override.
+
+### Subcommands
+- `done <subject>`: fuzzy-match active todos by subject and retire one by setting `superseded_by = id`.
+
+### Example
+
+```bash
+$A todo done "fix client test"
+```
+
 ## `daemon`
 
 ### Syntax

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -228,8 +228,11 @@ Stored: 1 new, 0 updated, 1 duplicates skipped, 0 superseded.
 Mark a todo as completed and remove it from active recall.
 
 Parameters:
-- `subject` (string, required): todo subject to match (partial/fuzzy matching supported)
-- `confirm` (boolean, optional, default `false`): if `true`, immediately marks the top match done when multiple candidates exist
+- `subject` (string, required): todo subject to match (partial/fuzzy matching supported). If multiple active todos match, the tool returns the candidate list so the caller can refine the subject.
+- `confirm` (boolean, optional, default `false`):
+  - `false`: do not pick a candidate silently when multiple matches exist; return a response listing candidates.
+  - `true`: immediately mark the single top match as done.
+    Top-match ordering is: `importance` descending, then `created_at` descending, then alphabetical `subject`.
 
 Example call payload:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -22,7 +22,7 @@ Protocol details:
 - transport: stdio
 - JSON-RPC: 2.0
 - MCP protocol version: `2024-11-05`
-- tools: `agenr_recall`, `agenr_store`, `agenr_extract`
+- tools: `agenr_recall`, `agenr_store`, `agenr_done`, `agenr_extract`
 
 ## Codex Setup (`~/.codex/config.toml`)
 
@@ -221,6 +221,32 @@ Extracted 2 entries from text:
 
 [1] (decision) We moved to pnpm.
 Stored: 1 new, 0 updated, 1 duplicates skipped, 0 superseded.
+```
+
+### `agenr_done`
+
+Mark a todo as completed and remove it from active recall.
+
+Parameters:
+- `subject` (string, required): todo subject to match (partial/fuzzy matching supported)
+- `confirm` (boolean, optional, default `false`): if `true`, immediately marks the top match done when multiple candidates exist
+
+Example call payload:
+
+```json
+{
+  "name": "agenr_done",
+  "arguments": {
+    "subject": "fix client test",
+    "confirm": true
+  }
+}
+```
+
+Typical response text:
+
+```text
+Marked done: fix client test
 ```
 
 ## Teach Your AI to Use agenr

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",
   "bin": {

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -563,7 +563,7 @@ export function createProgram(): Command {
   program
     .command("todo <subcommand> <subject>")
     .description("Manage todos in the knowledge base")
-    .option("--db <path>", "Path to database file")
+    .option("--db <path>", "Database path override")
     .action(async (subcommand: string, subject: string, opts: { db?: string }) => {
       const result = await runTodoCommand(subcommand, subject, { db: opts.db });
       process.exitCode = result.exitCode;

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -29,6 +29,7 @@ import { runContextCommand } from "./commands/context.js";
 import { runMcpCommand } from "./commands/mcp.js";
 import { runRecallCommand } from "./commands/recall.js";
 import { runStoreCommand } from "./commands/store.js";
+import { runTodoCommand } from "./commands/todo.js";
 import { runWatchCommand } from "./commands/watch.js";
 import { describeAuth, maskSecret, readConfig, setConfigKey, setStoredCredential, writeConfig } from "./config.js";
 import { deduplicateEntries } from "./dedup.js";
@@ -556,6 +557,15 @@ export function createProgram(): Command {
     .option("--json", "Output JSON results", false)
     .action(async (file: string | undefined, opts: WatchCommandOptions) => {
       const result = await runWatchCommand(file, opts);
+      process.exitCode = result.exitCode;
+    });
+
+  program
+    .command("todo <subcommand> <subject>")
+    .description("Manage todos in the knowledge base")
+    .option("--db <path>", "Path to database file")
+    .action(async (subcommand: string, subject: string, opts: { db?: string }) => {
+      const result = await runTodoCommand(subcommand, subject, { db: opts.db });
       process.exitCode = result.exitCode;
     });
 

--- a/src/commands/todo.ts
+++ b/src/commands/todo.ts
@@ -1,0 +1,158 @@
+import * as clack from "@clack/prompts";
+import { banner } from "../ui.js";
+import { closeDb, getDb, initDb } from "../db/client.js";
+
+interface TodoRow {
+  id: string;
+  subject: string;
+  content: string;
+}
+
+export interface TodoCommandOptions {
+  db?: string;
+}
+
+export interface TodoCommandDeps {
+  getDbFn: typeof getDb;
+  initDbFn: typeof initDb;
+  closeDbFn: typeof closeDb;
+  introFn: typeof clack.intro;
+  confirmFn: typeof clack.confirm;
+  selectFn: typeof clack.select;
+  outroFn: typeof clack.outro;
+  logInfoFn: typeof clack.log.info;
+}
+
+function toStringValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  return "";
+}
+
+function findMatches(rows: TodoRow[], query: string): TodoRow[] {
+  const normalizedQuery = query.toLowerCase();
+  return rows.filter((row) => {
+    const normalizedSubject = row.subject.toLowerCase();
+    return normalizedSubject.includes(normalizedQuery) || normalizedQuery.includes(normalizedSubject);
+  });
+}
+
+async function markDone(db: ReturnType<typeof getDb>, id: string): Promise<void> {
+  await db.execute({
+    sql: "UPDATE entries SET superseded_by = id, updated_at = datetime('now') WHERE id = ?",
+    args: [id],
+  });
+}
+
+export async function runTodoCommand(
+  subcommand: string,
+  subject: string,
+  opts: TodoCommandOptions,
+  deps: Partial<TodoCommandDeps> = {},
+): Promise<{ exitCode: number }> {
+  const resolvedDeps: TodoCommandDeps = {
+    getDbFn: deps.getDbFn ?? getDb,
+    initDbFn: deps.initDbFn ?? initDb,
+    closeDbFn: deps.closeDbFn ?? closeDb,
+    introFn: deps.introFn ?? clack.intro,
+    confirmFn: deps.confirmFn ?? clack.confirm,
+    selectFn: deps.selectFn ?? clack.select,
+    outroFn: deps.outroFn ?? clack.outro,
+    logInfoFn: deps.logInfoFn ?? clack.log.info,
+  };
+
+  const normalizedSubcommand = subcommand.trim().toLowerCase();
+  if (normalizedSubcommand !== "done") {
+    resolvedDeps.outroFn(`Unknown todo subcommand: ${subcommand}`);
+    return { exitCode: 1 };
+  }
+
+  const subjectQuery = subject.trim();
+  if (!subjectQuery) {
+    resolvedDeps.outroFn("Subject is required.");
+    return { exitCode: 1 };
+  }
+
+  resolvedDeps.introFn(banner(), { output: process.stderr });
+
+  const db = resolvedDeps.getDbFn(opts.db);
+  try {
+    await resolvedDeps.initDbFn(db);
+
+    const result = await db.execute({
+      sql: `
+        SELECT id, subject, content
+        FROM entries
+        WHERE type = 'todo' AND superseded_by IS NULL
+        ORDER BY importance DESC, created_at DESC
+      `,
+      args: [],
+    });
+
+    const rows = result.rows.map((row) => ({
+      id: toStringValue(row.id),
+      subject: toStringValue(row.subject),
+      content: toStringValue(row.content),
+    }));
+
+    const matches = findMatches(rows, subjectQuery);
+    if (matches.length === 0) {
+      resolvedDeps.outroFn(`No active todo matching: ${subjectQuery}`, { output: process.stderr });
+      return { exitCode: 1 };
+    }
+
+    if (matches.length === 1) {
+      const match = matches[0];
+      resolvedDeps.logInfoFn(`Todo: ${match.subject}`, { output: process.stderr });
+      resolvedDeps.logInfoFn(match.content, { output: process.stderr });
+      const confirmed = await resolvedDeps.confirmFn({ message: "Mark as done? [y/N]" });
+
+      if (confirmed !== true) {
+        resolvedDeps.outroFn("Cancelled.", { output: process.stderr });
+        return { exitCode: 1 };
+      }
+
+      await markDone(db, match.id);
+      resolvedDeps.outroFn(`Done: ${match.subject}`, { output: process.stderr });
+      return { exitCode: 0 };
+    }
+
+    const topMatches = matches.slice(0, 5);
+    for (let i = 0; i < topMatches.length; i += 1) {
+      const row = topMatches[i];
+      resolvedDeps.logInfoFn(`${i + 1}. ${row.subject}`, { output: process.stderr });
+    }
+
+    const selection = await resolvedDeps.selectFn({
+      message: `Select [1-${topMatches.length}] or 0 to cancel`,
+      options: [
+        ...topMatches.map((row, index) => ({
+          label: `${index + 1}. ${row.subject}`,
+          value: row.id,
+        })),
+        { label: "0. Cancel", value: "__cancel__" },
+      ],
+    });
+
+    if (selection === "__cancel__" || clack.isCancel(selection)) {
+      resolvedDeps.outroFn("Cancelled.", { output: process.stderr });
+      return { exitCode: 1 };
+    }
+
+    const selected = topMatches.find((row) => row.id === selection);
+    if (!selected) {
+      resolvedDeps.outroFn("Invalid selection.", { output: process.stderr });
+      return { exitCode: 1 };
+    }
+
+    await markDone(db, selected.id);
+    resolvedDeps.outroFn(`Done: ${selected.subject}`, { output: process.stderr });
+    return { exitCode: 0 };
+  } finally {
+    resolvedDeps.closeDbFn(db);
+  }
+}

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -27,7 +27,7 @@ When a todo, task, or action item is explicitly completed in the transcript:
 - Include in content: what was done and that it is now resolved
 - Do NOT re-emit the original todo as a new todo entry
 
-Examples of completion signals: "that's done", "it's fixed", "completed", "we shipped it", "all tests passing", "merged", "resolved", "closed", "out of the oven", "in the oven" (task started = progress, not done), "deployed", "published".
+Examples of completion signals: "that's done", "it's fixed", "completed", "we shipped it", "all tests passing", "merged", "resolved", "closed", "out of the oven", "deployed", "published".
 
 Do NOT emit a completion event for:
 - Tasks that are started but not finished ("working on it", "in progress", "in the oven")

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -18,6 +18,22 @@ EVENT — A significant milestone, launch, or completion. NOT "the assistant ran
 RELATIONSHIP — A connection between named entities. Content must include both entities and the relation.
 TODO — A persistent future action not completed in this chunk and not a one-step session instruction.
 
+## Todo Completion Detection
+
+When a todo, task, or action item is explicitly completed in the transcript:
+- Emit an "event" entry describing the completion
+- Use the same subject as the original todo (for example, if the todo was "fix client test", use subject "fix client test")
+- Set the same canonical_key as the original todo if you can infer it
+- Include in content: what was done and that it is now resolved
+- Do NOT re-emit the original todo as a new todo entry
+
+Examples of completion signals: "that's done", "it's fixed", "completed", "we shipped it", "all tests passing", "merged", "resolved", "closed", "out of the oven", "in the oven" (task started = progress, not done), "deployed", "published".
+
+Do NOT emit a completion event for:
+- Tasks that are started but not finished ("working on it", "in progress", "in the oven")
+- Ambiguous past tense ("we did some work on X")
+- Partial completions ("partially fixed")
+
 ## Durability Gate
 
 Only extract if useful in future conversations/tasks after the current immediate execution.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -918,7 +918,7 @@ export function createMcpServer(
         SELECT id, subject, content
         FROM entries
         WHERE type = 'todo' AND superseded_by IS NULL
-        ORDER BY importance DESC, created_at DESC
+        ORDER BY importance DESC, created_at DESC, subject ASC
       `,
       args: [],
     });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -189,6 +189,27 @@ const TOOL_DEFINITIONS: McpToolDefinition[] = [
     },
   },
   {
+    name: "agenr_done",
+    description:
+      "Mark a todo as completed and remove it from active recall. Use when you have resolved a task or confirmed something is no longer needed. Fuzzy-matches by subject.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["subject"],
+      properties: {
+        subject: {
+          type: "string",
+          description: "The subject of the todo to mark as done. Partial/fuzzy match is supported.",
+        },
+        confirm: {
+          type: "boolean",
+          description: "If true, skip confirmation prompt and mark done immediately. Default false.",
+          default: false,
+        },
+      },
+    },
+  },
+  {
     name: "agenr_extract",
     description: "Extract knowledge entries from raw text.",
     inputSchema: {
@@ -610,6 +631,39 @@ function formatExtractedText(entries: KnowledgeEntry[], stored?: StoreResult): s
   return lines.join("\n");
 }
 
+interface ActiveTodoEntry {
+  id: string;
+  subject: string;
+  content: string;
+}
+
+function toActiveTodoRows(rows: Array<Record<string, unknown>>): ActiveTodoEntry[] {
+  return rows.map((row) => ({
+    id: typeof row.id === "string" ? row.id : String(row.id ?? ""),
+    subject: typeof row.subject === "string" ? row.subject : String(row.subject ?? ""),
+    content: typeof row.content === "string" ? row.content : String(row.content ?? ""),
+  }));
+}
+
+function findTodoMatches(rows: ActiveTodoEntry[], subject: string): ActiveTodoEntry[] {
+  const normalizedSubject = subject.trim().toLowerCase();
+  return rows.filter((row) => {
+    const normalizedRow = row.subject.toLowerCase();
+    return normalizedRow.includes(normalizedSubject) || normalizedSubject.includes(normalizedRow);
+  });
+}
+
+function formatDoneCandidates(subject: string, candidates: ActiveTodoEntry[]): string {
+  const lines = [`Multiple active todos match "${subject}":`, ""];
+  for (let i = 0; i < candidates.length; i += 1) {
+    const candidate = candidates[i];
+    lines.push(`${i + 1}. ${candidate.subject}`);
+  }
+  lines.push("");
+  lines.push("Re-run with confirm=true to mark the top match.");
+  return lines.join("\n");
+}
+
 function extractIdForError(raw: unknown): JsonRpcId {
   if (!isRecord(raw) || !hasOwn(raw, "id")) {
     return null;
@@ -845,6 +899,57 @@ export function createMcpServer(
     return formatStoreSummary(result);
   }
 
+  async function callDoneTool(
+    args: { subject?: unknown; confirm?: unknown },
+  ): Promise<ToolCallResult> {
+    const subject = typeof args.subject === "string" ? args.subject.trim() : "";
+    if (!subject) {
+      throw new RpcError(JSON_RPC_INVALID_PARAMS, "subject is required");
+    }
+
+    if (args.confirm !== undefined && typeof args.confirm !== "boolean") {
+      throw new RpcError(JSON_RPC_INVALID_PARAMS, "confirm must be a boolean");
+    }
+    const confirm = args.confirm === true;
+
+    const db = await ensureDb();
+    const result = await db.execute({
+      sql: `
+        SELECT id, subject, content
+        FROM entries
+        WHERE type = 'todo' AND superseded_by IS NULL
+        ORDER BY importance DESC, created_at DESC
+      `,
+      args: [],
+    });
+
+    const todos = toActiveTodoRows(result.rows as Array<Record<string, unknown>>);
+    const matches = findTodoMatches(todos, subject);
+
+    if (matches.length === 0) {
+      return {
+        content: [{ type: "text", text: `No active todo matching: ${subject}` }],
+        isError: true,
+      };
+    }
+
+    if (matches.length > 1 && !confirm) {
+      return {
+        content: [{ type: "text", text: formatDoneCandidates(subject, matches.slice(0, 5)) }],
+      };
+    }
+
+    const selected = matches[0] as ActiveTodoEntry;
+    await db.execute({
+      sql: "UPDATE entries SET superseded_by = id, updated_at = datetime('now') WHERE id = ?",
+      args: [selected.id],
+    });
+
+    return {
+      content: [{ type: "text", text: `Marked done: ${selected.subject}` }],
+    };
+  }
+
   async function callExtractTool(args: Record<string, unknown>): Promise<string> {
     const text = typeof args.text === "string" ? args.text : "";
     if (!text.trim()) {
@@ -920,6 +1025,10 @@ export function createMcpServer(
         return {
           content: [{ type: "text", text: await callStoreTool(params.args) }],
         };
+      }
+
+      if (params.name === "agenr_done") {
+        return callDoneTool(params.args as { subject: string; confirm?: boolean });
       }
 
       if (params.name === "agenr_extract") {

--- a/tests/commands/todo.test.ts
+++ b/tests/commands/todo.test.ts
@@ -1,0 +1,176 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runTodoCommand, type TodoCommandDeps } from "../../src/commands/todo.js";
+import { initDb } from "../../src/db/client.js";
+
+const clients: Client[] = [];
+
+function makeClient(): Client {
+  const client = createClient({ url: ":memory:" });
+  clients.push(client);
+  return client;
+}
+
+async function seedTodo(client: Client, params: {
+  id: string;
+  subject: string;
+  content: string;
+  createdAt?: string;
+  updatedAt?: string;
+  importance?: number;
+}): Promise<void> {
+  const createdAt = params.createdAt ?? "2026-02-15T10:00:00.000Z";
+  const updatedAt = params.updatedAt ?? createdAt;
+  await client.execute({
+    sql: `
+      INSERT INTO entries (
+        id, type, subject, content, importance, expiry, scope, source_file, source_context, created_at, updated_at
+      )
+      VALUES (?, 'todo', ?, ?, ?, 'temporary', 'private', 'seed.jsonl', 'test', ?, ?)
+    `,
+    args: [params.id, params.subject, params.content, params.importance ?? 5, createdAt, updatedAt],
+  });
+}
+
+function makeDeps(client: Client, overrides: Partial<TodoCommandDeps> = {}): TodoCommandDeps {
+  return {
+    getDbFn: overrides.getDbFn ?? (() => client),
+    initDbFn: overrides.initDbFn ?? (async () => undefined),
+    closeDbFn: overrides.closeDbFn ?? (() => undefined),
+    introFn: overrides.introFn ?? vi.fn(),
+    confirmFn: overrides.confirmFn ?? (vi.fn(async () => true) as unknown as TodoCommandDeps["confirmFn"]),
+    selectFn: overrides.selectFn ?? (vi.fn(async () => "__cancel__") as unknown as TodoCommandDeps["selectFn"]),
+    outroFn: overrides.outroFn ?? vi.fn(),
+    logInfoFn: overrides.logInfoFn ?? vi.fn(),
+  };
+}
+
+afterEach(() => {
+  while (clients.length > 0) {
+    clients.pop()?.close();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("todo command", () => {
+  it("wires CLI arguments into runTodoCommand", async () => {
+    const { createProgram } = await import("../../src/cli-main.js");
+    const program = createProgram();
+    const todoCommand = program.commands.find((command) => command.name() === "todo");
+    const actionMock = vi.fn(async (..._args: unknown[]) => undefined);
+    todoCommand?.action(actionMock as any);
+
+    await program.parseAsync(["node", "agenr", "todo", "done", "fix client test", "--db", "/tmp/knowledge.db"]);
+
+    expect(actionMock).toHaveBeenCalledTimes(1);
+    const firstCall = (actionMock.mock.calls as unknown[][])[0] as [string, string, { db?: string }] | undefined;
+    expect(firstCall?.[0]).toBe("done");
+    expect(firstCall?.[1]).toBe("fix client test");
+    expect(firstCall?.[2].db).toBe("/tmp/knowledge.db");
+  });
+
+  it("done with exact match marks todo as superseded", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await seedTodo(client, {
+      id: "todo-1",
+      subject: "fix client test",
+      content: "Fix flaky client integration test",
+    });
+    const deps = makeDeps(client);
+
+    const result = await runTodoCommand("done", "fix client test", { db: ":memory:" }, deps);
+
+    expect(result.exitCode).toBe(0);
+    const row = await client.execute({
+      sql: "SELECT superseded_by FROM entries WHERE id = ?",
+      args: ["todo-1"],
+    });
+    expect(String(row.rows[0]?.superseded_by)).toBe("todo-1");
+  });
+
+  it("done supports substring fuzzy matching", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await seedTodo(client, {
+      id: "todo-1",
+      subject: "fix client test",
+      content: "Fix flaky client integration test",
+    });
+    const deps = makeDeps(client);
+
+    const result = await runTodoCommand("done", "client", { db: ":memory:" }, deps);
+
+    expect(result.exitCode).toBe(0);
+    const row = await client.execute({
+      sql: "SELECT superseded_by FROM entries WHERE id = ?",
+      args: ["todo-1"],
+    });
+    expect(String(row.rows[0]?.superseded_by)).toBe("todo-1");
+  });
+
+  it("done with no match returns exitCode 1 and prints error", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await seedTodo(client, {
+      id: "todo-1",
+      subject: "fix client test",
+      content: "Fix flaky client integration test",
+    });
+    const outroFn = vi.fn();
+    const deps = makeDeps(client, { outroFn });
+
+    const result = await runTodoCommand("done", "totally different", { db: ":memory:" }, deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(outroFn).toHaveBeenCalledWith("No active todo matching: totally different", { output: process.stderr });
+  });
+
+  it("done with multiple matches prompts selection and updates selected todo", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await seedTodo(client, { id: "todo-1", subject: "fix client test", content: "A", importance: 9 });
+    await seedTodo(client, { id: "todo-2", subject: "fix client auth", content: "B", importance: 8 });
+    await seedTodo(client, { id: "todo-3", subject: "client docs", content: "C", importance: 7 });
+
+    const selectFn = vi.fn(async () => "todo-2") as unknown as TodoCommandDeps["selectFn"];
+    const confirmFn = vi.fn(async () => true) as unknown as TodoCommandDeps["confirmFn"];
+    const deps = makeDeps(client, { selectFn, confirmFn });
+
+    const result = await runTodoCommand("done", "client", { db: ":memory:" }, deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(selectFn).toHaveBeenCalledTimes(1);
+    expect(confirmFn).not.toHaveBeenCalled();
+
+    const rows = await client.execute({
+      sql: "SELECT id, superseded_by FROM entries WHERE id IN ('todo-1', 'todo-2', 'todo-3') ORDER BY id ASC",
+      args: [],
+    });
+    const byId = new Map(rows.rows.map((row) => [String(row.id), row.superseded_by ? String(row.superseded_by) : null]));
+    expect(byId.get("todo-1")).toBeNull();
+    expect(byId.get("todo-2")).toBe("todo-2");
+    expect(byId.get("todo-3")).toBeNull();
+  });
+
+  it("done updates updated_at timestamp on the row", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await seedTodo(client, {
+      id: "todo-1",
+      subject: "fix client test",
+      content: "Fix flaky client integration test",
+      updatedAt: "2026-02-15T10:00:00.000Z",
+    });
+    const deps = makeDeps(client);
+
+    const result = await runTodoCommand("done", "fix client test", { db: ":memory:" }, deps);
+
+    expect(result.exitCode).toBe(0);
+    const row = await client.execute({
+      sql: "SELECT updated_at FROM entries WHERE id = ?",
+      args: ["todo-1"],
+    });
+    expect(String(row.rows[0]?.updated_at)).not.toBe("2026-02-15T10:00:00.000Z");
+  });
+});

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -114,6 +114,21 @@ describe("SYSTEM_PROMPT", () => {
     // This suite uses mocked model outputs, so we validate policy text in the prompt itself.
     expect(SYSTEM_PROMPT).toContain("Assistant messages don't constitute memory requests.");
   });
+
+  it("includes Todo Completion Detection guidance", () => {
+    expect(SYSTEM_PROMPT).toContain("Todo Completion Detection");
+    expect(SYSTEM_PROMPT).toContain("Emit an \"event\" entry describing the completion");
+  });
+
+  it("lists expected todo completion keywords", () => {
+    expect(SYSTEM_PROMPT).toMatch(/\bdone\b/i);
+    expect(SYSTEM_PROMPT).toMatch(/\bfixed\b/i);
+    expect(SYSTEM_PROMPT).toMatch(/\bresolved\b/i);
+    expect(SYSTEM_PROMPT).toMatch(/\bcompleted\b/i);
+    expect(SYSTEM_PROMPT).toMatch(/\bshipped\b/i);
+    expect(SYSTEM_PROMPT).toMatch(/\bclosed\b/i);
+    expect(SYSTEM_PROMPT).toMatch(/\bmerged\b/i);
+  });
 });
 
 describe("extractKnowledgeFromChunks", () => {


### PR DESCRIPTION
## Summary

Fixes stale todos polluting session-start recall by making resolved todos invisible immediately.

## Root Cause

Setting expiry/importance does not work — a same-day-resolved todo still scores ~0.825 due to freshnessBoost=1.5 and todoStaleness=1.0 (age=0). The correct mechanism is `superseded_by`: both SQL fetchers enforce `WHERE superseded_by IS NULL` and `passesFilters()` returns false immediately when set.

## Changes

### Fix 1 — `agenr todo done <subject>` CLI command
- Fuzzy substring match against active todos
- Confirms before marking done
- Multiple matches: shows candidates, lets user pick
- Sets `superseded_by = id` (self-reference) — entry invisible to all recall paths instantly

### Fix 2 — `agenr_done` MCP tool
- Same logic, non-interactive
- `confirm: true` flag for agent-driven auto-retirement mid-session
- Allows the AI agent to retire todos without human intervention

### Fix 3 — Store-layer cross-type superseding
- New entries with matching `canonical_key` can supersede todos regardless of type
- Auto-supersedes when content contains completion signals (done, fixed, resolved, shipped, etc.)
- No LLM call needed

### Fix 4 — Extractor prompt addition
- New Todo Completion Detection section in SYSTEM_PROMPT
- Instructs LLM to emit event entries with matching subject/canonical_key when a todo is completed

### Version
- Bumps to 0.5.4
- CHANGELOG updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `todo done` CLI to mark resolved todos (fuzzy match + confirmation).
  * Added MCP tool to retire todos programmatically (optional confirm).
  * Automatic detection of todo completion signals to retire related todos across entry types.

* **Bug Fixes**
  * Corrected cross-type superseding behavior so todos retire only when appropriate.

* **Documentation**
  * CLI and MCP docs updated with todo usage and tool details.

* **Tests**
  * Expanded test coverage for CLI, completion detection, cross-type behavior, and MCP tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->