### PR TITLE
docs: add pnpm install option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ export OPENAI_API_KEY=sk-...  # for embeddings + extraction
 ```bash
 # Install
 npm install -g agenr
+# or
+pnpm add -g agenr
 
 # Configure (picks your LLM provider, walks you through auth)
 agenr setup


### PR DESCRIPTION
Adds `pnpm add -g agenr` as an alternative to `npm install -g agenr`. Both work - pnpm global bin (`~/Library/pnpm`) resolves correctly as long as it appears in PATH before any npm global bin path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pnpm-based global installation option to the setup guide alongside the existing npm method, providing an alternative package manager choice for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->