### PR TITLE
fix: patch v0.6.1 - watch context db close and remove agenr_done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.1] - 2026-02-19
+
+### Fixed
+- fix(watch): context file generation failed with CLIENT_CLOSED when context path is configured
+- fix(mcp): remove agenr_done tool (was not removed in v0.6.0 as intended)
+
 ## [0.6.0] - 2026-02-18
 
 ### Added
@@ -22,7 +28,7 @@
 - fix(watch): use real recall score breakdown in generated context variants
 
 ### Removed
-- agenr_done MCP tool removed (breaking change) -- use agenr_retire instead. agenr_retire accepts an entry ID from agenr_recall output and works on all entry types, not just todos.
+- `agenr_done` MCP tool removed; use `agenr_retire` instead (supports all entry types, not just todos)
 
 ## [0.5.3] - 2026-02-18
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ export OPENAI_API_KEY=sk-...  # for embeddings + extraction
 ```bash
 # Install
 npm install -g agenr
+# or
+pnpm add -g agenr
 
 # Configure (picks your LLM provider, walks you through auth)
 agenr setup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",
   "bin": {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -1,7 +1,6 @@
 import { PassThrough } from "node:stream";
-import { createClient, type Client } from "@libsql/client";
+import type { Client } from "@libsql/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { initDb } from "../../src/db/client.js";
 import { createMcpServer } from "../../src/mcp/server.js";
 import type { McpServerDeps } from "../../src/mcp/server.js";
 import type { KnowledgeEntry, LlmClient, RecallResult, StoreResult, TranscriptChunk } from "../../src/types.js";
@@ -238,19 +237,6 @@ async function runServer(
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
-async function seedTodo(client: Client, params: { id: string; subject: string; content: string; importance?: number }): Promise<void> {
-  const now = "2026-02-14T00:00:00.000Z";
-  await client.execute({
-    sql: `
-      INSERT INTO entries (
-        id, type, subject, content, importance, expiry, scope, source_file, source_context, created_at, updated_at
-      )
-      VALUES (?, 'todo', ?, ?, ?, 'temporary', 'private', 'seed.jsonl', 'test', ?, ?)
-    `,
-    args: [params.id, params.subject, params.content, params.importance ?? 5, now, now],
-  });
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -305,125 +291,6 @@ describe("mcp server", () => {
 
     expect(toolNames).toEqual(["agenr_extract", "agenr_recall", "agenr_retire", "agenr_store"]);
     expect(result.tools?.every((tool) => tool.inputSchema?.type === "object")).toBe(true);
-  });
-
-  it("agenr_done with confirm=true marks matching todo as done", async () => {
-    const harness = makeHarness();
-    const client = createClient({ url: ":memory:" });
-    await initDb(client);
-    await seedTodo(client, { id: "todo-1", subject: "fix client test", content: "Fix flaky test", importance: 9 });
-
-    harness.deps.getDbFn = vi.fn(() => client) as unknown as McpServerDeps["getDbFn"];
-    harness.deps.initDbFn = vi.fn(async () => undefined);
-    harness.deps.closeDbFn = vi.fn(() => undefined);
-
-    const server = createMcpServer({ serverVersion: "9.9.9-test" }, harness.deps);
-    const response = await server.handleRequest({
-      jsonrpc: "2.0",
-      id: 200,
-      method: "tools/call",
-      params: {
-        name: "agenr_done",
-        arguments: {
-          subject: "fix client test",
-          confirm: true,
-        },
-      },
-    });
-
-    expect(response).toMatchObject({
-      jsonrpc: "2.0",
-      id: 200,
-      result: {
-        content: [{ type: "text", text: "Marked done: fix client test" }],
-      },
-    });
-
-    const row = await client.execute({
-      sql: "SELECT superseded_by FROM entries WHERE id = ?",
-      args: ["todo-1"],
-    });
-    expect(String(row.rows[0]?.superseded_by)).toBe("todo-1");
-
-    await server.stop();
-    client.close();
-  });
-
-  it("agenr_done with confirm=false and multiple matches returns candidates without mutation", async () => {
-    const harness = makeHarness();
-    const client = createClient({ url: ":memory:" });
-    await initDb(client);
-    await seedTodo(client, { id: "todo-1", subject: "fix client test", content: "Fix flaky test", importance: 9 });
-    await seedTodo(client, { id: "todo-2", subject: "fix client auth", content: "Fix auth flow", importance: 8 });
-
-    harness.deps.getDbFn = vi.fn(() => client) as unknown as McpServerDeps["getDbFn"];
-    harness.deps.initDbFn = vi.fn(async () => undefined);
-    harness.deps.closeDbFn = vi.fn(() => undefined);
-
-    const server = createMcpServer({ serverVersion: "9.9.9-test" }, harness.deps);
-    const response = await server.handleRequest({
-      jsonrpc: "2.0",
-      id: 201,
-      method: "tools/call",
-      params: {
-        name: "agenr_done",
-        arguments: {
-          subject: "client",
-        },
-      },
-    });
-
-    const result = (response as { result?: { content?: Array<{ text?: string }> } }).result;
-    const text = result?.content?.[0]?.text ?? "";
-    expect(text).toContain('Multiple active todos match "client":');
-    expect(text).toContain("fix client test");
-    expect(text).toContain("fix client auth");
-
-    const rows = await client.execute({
-      sql: "SELECT id, superseded_by FROM entries WHERE id IN ('todo-1', 'todo-2') ORDER BY id ASC",
-      args: [],
-    });
-    expect(rows.rows[0]?.superseded_by).toBeNull();
-    expect(rows.rows[1]?.superseded_by).toBeNull();
-
-    await server.stop();
-    client.close();
-  });
-
-  it("agenr_done with no match returns tool error payload", async () => {
-    const harness = makeHarness();
-    const client = createClient({ url: ":memory:" });
-    await initDb(client);
-    await seedTodo(client, { id: "todo-1", subject: "fix client test", content: "Fix flaky test" });
-
-    harness.deps.getDbFn = vi.fn(() => client) as unknown as McpServerDeps["getDbFn"];
-    harness.deps.initDbFn = vi.fn(async () => undefined);
-    harness.deps.closeDbFn = vi.fn(() => undefined);
-
-    const server = createMcpServer({ serverVersion: "9.9.9-test" }, harness.deps);
-    const response = await server.handleRequest({
-      jsonrpc: "2.0",
-      id: 202,
-      method: "tools/call",
-      params: {
-        name: "agenr_done",
-        arguments: {
-          subject: "nonexistent",
-        },
-      },
-    });
-
-    expect(response).toMatchObject({
-      jsonrpc: "2.0",
-      id: 202,
-      result: {
-        content: [{ type: "text", text: "No active todo matching: nonexistent" }],
-        isError: true,
-      },
-    });
-
-    await server.stop();
-    client.close();
   });
 
   it("calls agenr_recall and formats results", async () => {


### PR DESCRIPTION
## v0.6.1 Patch

Two bug fixes found during v0.6.0 dogfooding:

### Fix 1: Remove `agenr_done` from MCP server
`agenr_done` was removed from the design in v0.6.0 (consolidated into `agenr_retire`) but the tool definition, handler, and dispatch remained registered in the MCP server. Removed:
- Tool definition
- `callDoneTool` function
- Dispatch case in handler
- 3 stale tests in server.test.ts
- CHANGELOG Removed section entry

### Fix 2: No-op `closeDbFn` when watch context is set
When `agenr watch` runs with a `--context` flag, the context chain runs after the watcher closes the DB, causing `CLIENT_CLOSED` errors. Fix: pass a no-op `closeDbFn` when `contextEnabled` is true so the watcher doesn't close the DB before the context chain finishes.

### Tests
557 passing, 68 files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pnpm as an alternative installation option for the CLI.

* **Bug Fixes**
  * Fixed watch context file generation failure when context path is configured.
  * Removed the deprecated `agenr_done` tool.

* **Chores**
  * Version bumped to 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->