### PR TITLE
feat: v0.6.2 elaborative encoding pre-fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [0.6.2] - 2026-02-19
 
 ### Added
-- feat(extractor): elaborative encoding pre-fetch now runs before each chunk extraction, retrieves top related memories from the vector index, and injects up to 3 references into the extractor prompt
+- feat(extractor): elaborative encoding pre-fetch now runs before each chunk extraction, retrieves top-related memories from the vector index, and injects up to 3 references into the extractor prompt
 - feat(cli): `--no-pre-fetch` flag added to `agenr extract`, `agenr ingest`, and `agenr watch` to opt out of prompt memory pre-fetch
+- feat(cli): `--db` flag added to `agenr extract`, `agenr ingest`, and `agenr watch` for database path overrides
 - feat(recall): exported `fetchRelatedEntries()` thin wrapper for direct ANN vector candidate queries
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.6.2] - 2026-02-19
+
+### Added
+- feat(extractor): elaborative encoding pre-fetch now runs before each chunk extraction, retrieves top related memories from the vector index, and injects up to 3 references into the extractor prompt
+- feat(cli): `--no-pre-fetch` flag added to `agenr extract`, `agenr ingest`, and `agenr watch` to opt out of prompt memory pre-fetch
+- feat(recall): exported `fetchRelatedEntries()` thin wrapper for direct ANN vector candidate queries
+
+### Changed
+- tuning(extractor): pre-fetch similarity threshold set to `0.78` for `text-embedding-3-small` (1024 dimensions)
+- tuning(extractor): fresh-install pre-fetch skip threshold set to 20 non-superseded entries
+- tuning(extractor): pre-fetch timeout set to 5000ms to avoid chunk extraction stalls on hanging embedding calls
+
+### Safety
+- prompt: injected related memories are explicitly reference-only and do not lower the SKIP threshold
+- runtime: pre-fetch is always best-effort and silently degrades to empty related-memory context on any error
+
 ## [0.6.1] - 2026-02-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - tuning(extractor): fresh-install pre-fetch skip threshold set to 20 non-superseded entries
 - tuning(extractor): pre-fetch timeout set to 5000ms to avoid chunk extraction stalls on hanging embedding calls
 
-### Safety
+### Security
 - prompt: injected related memories are explicitly reference-only and do not lower the SKIP threshold
 - runtime: pre-fetch is always best-effort and silently degrades to empty related-memory context on any error
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -53,7 +53,9 @@ agenr extract [options] <files...>
 - `--format <type>`: `json|markdown` (default `markdown`).
 - `--output <file>`: write output file (or directory with `--split`).
 - `--split`: one output file per input transcript.
+- `--db <path>`: database path override for pre-fetch memory lookup.
 - `--no-dedup`: skip post-extraction LLM dedup pass.
+- `--no-pre-fetch`: disable elaborative encoding pre-fetch (injecting related memories before extraction).
 - `--model <model>`: override model.
 - `--provider <name>`: `anthropic|openai|openai-codex`.
 - `--verbose`: detailed extraction progress.
@@ -226,6 +228,7 @@ agenr watch [file] [options]
 - `--db <path>`: database path override.
 - `--model <model>`: override model.
 - `--provider <name>`: `anthropic|openai|openai-codex`.
+- `--no-pre-fetch`: disable elaborative encoding pre-fetch in watch extraction cycles.
 - `--verbose`: verbose progress.
 - `--context <path>`: write or refresh context files (`--context` path, `context-mini.md`, and `context-hot.md`) after successful stores.
 - `--dry-run`: extract only, do not store.
@@ -343,6 +346,7 @@ agenr ingest [options] <paths...>
 - `--json`: emit JSON summary.
 - `--concurrency <n>`: parallel chunk extractions (default `5`).
 - `--skip-ingested`: skip already-ingested file/hash pairs (default `true`).
+- `--no-pre-fetch`: disable elaborative encoding pre-fetch before per-chunk extraction.
 - `--no-retry`: disable auto-retry for failed files.
 - `--max-retries <n>`: maximum auto-retry attempts (default `3`).
 - `--force`: clean re-ingest each matched file by deleting previous rows for that source file first.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",
   "bin": {

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -167,9 +167,12 @@ export async function runExtractCommand(
         embeddingApiKey = resolvedDeps.resolveEmbeddingApiKeyFn(config, process.env);
         db = resolvedDeps.getDbFn(dbPath);
         await resolvedDeps.initDbFn(db);
-      } catch {
+      } catch (error) {
         db = undefined;
         embeddingApiKey = undefined;
+        if (verbose) {
+          stderrLine(`[pre-fetch] init skipped: ${error instanceof Error ? error.message : String(error)}`);
+        }
       }
     }
   }

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -602,8 +602,16 @@ export async function runIngestCommand(
     if (!options.noPreFetch) {
       try {
         embeddingApiKey = resolvedDeps.resolveEmbeddingApiKeyFn(config, process.env);
-      } catch {
+      } catch (error) {
         embeddingApiKey = null;
+        if (verbose) {
+          clack.log.warn(
+            formatWarn(
+              `Pre-fetch disabled - embedding API key not available: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+            clackOutput,
+          );
+        }
       }
     }
     let watchStateLoaded = false;

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -463,6 +463,7 @@ export async function runWatchCommand(
         raw,
         once,
         onlineDedup: options.onlineDedup !== false,
+        noPreFetch: options.noPreFetch === true,
         model: options.model,
         provider: options.provider,
         dbPath: options.db,

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -9,7 +9,7 @@ import type { KnowledgePlatform, RecallQuery, RecallResult, Scope, StoredEntry }
 const DEFAULT_VECTOR_CANDIDATE_LIMIT = 50;
 const DEFAULT_LIMIT = 10;
 
-interface CandidateRow {
+export interface CandidateRow {
   entry: StoredEntry;
   vectorSim: number;
 }
@@ -440,6 +440,14 @@ async function fetchVectorCandidates(
       vectorSim: clamp01(cosineSimilarity(queryEmbedding, rowEmbedding)),
     };
   });
+}
+
+export async function fetchRelatedEntries(
+  db: Client,
+  queryEmbedding: number[],
+  limit: number,
+): Promise<CandidateRow[]> {
+  return fetchVectorCandidates(db, queryEmbedding, limit);
 }
 
 async function fetchSessionCandidates(

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,6 +308,7 @@ export interface WatchOptions {
   platform?: string;
   auto?: boolean;
   onlineDedup?: boolean;
+  noPreFetch?: boolean;
   verbose?: boolean;
   dryRun?: boolean;
   once?: boolean;

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -281,8 +281,11 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
   if (!options.noPreFetch) {
     try {
       embeddingApiKey = resolvedDeps.resolveEmbeddingApiKeyFn(config, process.env);
-    } catch {
+    } catch (error) {
       embeddingApiKey = null;
+      options.onWarn?.(
+        `Pre-fetch disabled - embedding API key not available: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -385,6 +385,8 @@ describe("runExtractCommand", () => {
     const getDbFn = vi.fn(() => {
       throw new Error("db should not be initialized");
     });
+    const initDbFn = vi.fn(async () => undefined);
+    const closeDbFn = vi.fn();
 
     const deps: Partial<CliDeps> = {
       expandInputFilesFn: vi.fn().mockResolvedValue(["/tmp/a.jsonl"]),
@@ -393,11 +395,11 @@ describe("runExtractCommand", () => {
       parseTranscriptFileFn: vi.fn((file: string) => Promise.resolve(parsedTranscript(file))) as unknown as CliDeps["parseTranscriptFileFn"],
       extractKnowledgeFromChunksFn: extractSpy as unknown as CliDeps["extractKnowledgeFromChunksFn"],
       writeOutputFn: vi.fn(() => Promise.resolve([])) as unknown as CliDeps["writeOutputFn"],
-      readConfigFn: vi.fn(() => null) as unknown as CliDeps["readConfigFn"],
+      readConfigFn: vi.fn(() => ({ db: { path: "/tmp/test.db" } })) as unknown as CliDeps["readConfigFn"],
       resolveEmbeddingApiKeyFn: resolveEmbeddingApiKeyFn as unknown as CliDeps["resolveEmbeddingApiKeyFn"],
       getDbFn: getDbFn as unknown as CliDeps["getDbFn"],
-      initDbFn: vi.fn(async () => undefined) as unknown as CliDeps["initDbFn"],
-      closeDbFn: vi.fn() as unknown as CliDeps["closeDbFn"],
+      initDbFn: initDbFn as unknown as CliDeps["initDbFn"],
+      closeDbFn: closeDbFn as unknown as CliDeps["closeDbFn"],
     };
 
     await runExtractCommand(
@@ -413,7 +415,57 @@ describe("runExtractCommand", () => {
 
     expect(resolveEmbeddingApiKeyFn).not.toHaveBeenCalled();
     expect(getDbFn).not.toHaveBeenCalled();
+    expect(initDbFn).not.toHaveBeenCalled();
+    expect(closeDbFn).not.toHaveBeenCalled();
     expect(extractSpy.mock.calls[0]?.[0]?.noPreFetch).toBe(true);
+  });
+
+  it("initializes pre-fetch dependencies when noPreFetch is false", async () => {
+    const extractSpy = vi.fn((_params) =>
+      Promise.resolve({
+        entries: [],
+        successfulChunks: 1,
+        failedChunks: 0,
+        warnings: [],
+      }),
+    );
+    const dbClient = {} as unknown;
+    const resolveEmbeddingApiKeyFn = vi.fn(() => "sk-test");
+    const getDbFn = vi.fn(() => dbClient);
+    const initDbFn = vi.fn(async () => undefined);
+    const closeDbFn = vi.fn();
+
+    const deps: Partial<CliDeps> = {
+      expandInputFilesFn: vi.fn().mockResolvedValue(["/tmp/a.jsonl"]),
+      assertReadableFileFn: vi.fn().mockResolvedValue(undefined),
+      createLlmClientFn: vi.fn().mockReturnValue(fakeClient()) as unknown as CliDeps["createLlmClientFn"],
+      parseTranscriptFileFn: vi.fn((file: string) => Promise.resolve(parsedTranscript(file))) as unknown as CliDeps["parseTranscriptFileFn"],
+      extractKnowledgeFromChunksFn: extractSpy as unknown as CliDeps["extractKnowledgeFromChunksFn"],
+      writeOutputFn: vi.fn(() => Promise.resolve([])) as unknown as CliDeps["writeOutputFn"],
+      readConfigFn: vi.fn(() => ({ db: { path: "/tmp/test.db" } })) as unknown as CliDeps["readConfigFn"],
+      resolveEmbeddingApiKeyFn: resolveEmbeddingApiKeyFn as unknown as CliDeps["resolveEmbeddingApiKeyFn"],
+      getDbFn: getDbFn as unknown as CliDeps["getDbFn"],
+      initDbFn: initDbFn as unknown as CliDeps["initDbFn"],
+      closeDbFn: closeDbFn as unknown as CliDeps["closeDbFn"],
+    };
+
+    await runExtractCommand(
+      ["/tmp/a.jsonl"],
+      {
+        format: "json",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      deps,
+    );
+
+    expect(resolveEmbeddingApiKeyFn).toHaveBeenCalledTimes(1);
+    expect(getDbFn).toHaveBeenCalledTimes(1);
+    expect(initDbFn).toHaveBeenCalledTimes(1);
+    expect(extractSpy.mock.calls[0]?.[0]?.db).toBe(dbClient);
+    expect(extractSpy.mock.calls[0]?.[0]?.embeddingApiKey).toBe("sk-test");
+    expect(closeDbFn).toHaveBeenCalledTimes(1);
+    expect(closeDbFn).toHaveBeenCalledWith(dbClient);
   });
 });
 


### PR DESCRIPTION
## v0.6.2 - Elaborative Encoding Pre-fetch

Implements pre-fetch of related entries during extraction to enable elaborative encoding - the memory science principle that connecting new information to existing knowledge improves retention and retrieval.

### Key Changes
- `preFetchRelated()` in extractor.ts: fetches semantically related entries before extraction
- `buildUserPrompt(chunk, related)`: injects related context into the LLM extraction prompt
- `fetchRelatedEntries()` exported from recall.ts
- `noPreFetch` flag propagated through extraction pipeline (7 sites)
- Similarity threshold: 0.78
- DB skip threshold: 20 entries (skip pre-fetch for small DBs)

### Tests
Full test suite passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --db <path> and --no-pre-fetch flags to extract, watch, and ingest; CHANGELOG updated to v0.6.2.

* **Changed**
  * Extraction now pre-fetches related memories (up to 3) with similarity tuning (0.78), skip threshold (20), and 5s timeout; behavior is configurable.

* **Security**
  * Related memories are reference-only; pre-fetch degrades gracefully on errors.

* **Tests**
  * Expanded unit and end-to-end tests covering pre-fetch and CLI flag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->