### PR TITLE
feat: v0.6.2.1 - agenr db reset --full command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.6.2.1
+
+### Added
+- agenr db reset --full --confirm-reset: full clean-slate reset
+  - Deletes watch-state.json and review-queue.json after DB schema reset
+  - Creates a pre-reset DB backup before any destructive operation
+  - Prints backup path to stdout
+  - Dry-run mode when --confirm-reset is omitted
+- Extracted resetDb() into src/db/schema.ts (shared by db reset and db reset --full)
+- Added backupDb() helper in src/db/client.ts
+
 ## [0.6.2] - 2026-02-19
 
 ### Added

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -734,7 +734,7 @@ agenr db reset [options]
 
 ### Options
 - `--confirm`: required to execute the legacy schema-only reset path.
-- `--full`: include side-file cleanup (`watch-state.json`, `review-queue.json`) after schema reset.
+- `--full`: include side-file cleanup (`watch-state.json`, `review-queue.json`, and `context*.md`) after schema reset.
 - `--confirm-reset`: required to execute when `--full` is present. Without it, command prints a dry-run summary and exits 0.
 - `--db <path>`: database path override.
 
@@ -764,7 +764,19 @@ Database reset and migrations reapplied.
   - Drop and recreate DB schema (all data erased, file retained)
   - Delete: /Users/you/.agenr/watch-state.json
   - Delete: /Users/you/.agenr/review-queue.json
+  - Delete: /Users/you/.agenr/context*.md (any matching files)
 Run with --confirm-reset to execute.
+```
+
+```text
+WARNING: If the agenr watcher daemon is running, stop it before proceeding. Reset will not abort if the daemon is running.
+Backup created: /Users/you/.agenr/knowledge.db.backup-pre-reset-2026-02-19T12-01-10-111Z
+Reset complete.
+  DB schema dropped and recreated: /Users/you/.agenr/knowledge.db
+  watch-state.json deleted (or was not present)
+  review-queue.json deleted (or was not present)
+  context-mini.md deleted
+  context-hot.md deleted
 ```
 
 ## `db path`

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -733,7 +733,9 @@ agenr db reset [options]
 ```
 
 ### Options
-- `--confirm`: required to execute reset.
+- `--confirm`: required to execute the legacy schema-only reset path.
+- `--full`: include side-file cleanup (`watch-state.json`, `review-queue.json`) after schema reset.
+- `--confirm-reset`: required to execute when `--full` is present. Without it, command prints a dry-run summary and exits 0.
 - `--db <path>`: database path override.
 
 ### Example
@@ -742,10 +744,27 @@ agenr db reset [options]
 $A db reset --confirm
 ```
 
+```bash
+$A db reset --full
+```
+
+```bash
+$A db reset --full --confirm-reset
+```
+
 ### Example Output
 
 ```text
 Database reset and migrations reapplied.
+```
+
+```text
+[dry run] agenr db reset --full would perform the following actions:
+  - Backup database to: /Users/you/.agenr/knowledge.db.backup-pre-reset-2026-02-19T12-00-00-000Z
+  - Drop and recreate DB schema (all data erased, file retained)
+  - Delete: /Users/you/.agenr/watch-state.json
+  - Delete: /Users/you/.agenr/review-queue.json
+Run with --confirm-reset to execute.
 ```
 
 ## `db path`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.2",
+  "version": "0.6.2.1",
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",
   "bin": {

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -853,7 +853,7 @@ export function createProgram(): Command {
     .description("Drop all database objects and recreate schema")
     .option("--confirm", "Required confirmation flag", false)
     .option("--full", "Also delete watch and review side files", false)
-    .option("--confirm-reset", "Execute full reset when used with --full", false)
+    .option("--confirm-reset", "Execute full reset when used with --full")
     .option("--db <path>", "Database path override")
     .action(async (opts: { db?: string; confirm?: boolean; full?: boolean; confirmReset?: boolean }) => {
       const result = await runDbResetCommand({

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -852,10 +852,17 @@ export function createProgram(): Command {
     .command("reset")
     .description("Drop all database objects and recreate schema")
     .option("--confirm", "Required confirmation flag", false)
+    .option("--full", "Also delete watch and review side files", false)
+    .option("--confirm-reset", "Execute full reset when used with --full", false)
     .option("--db <path>", "Database path override")
-    .action(async (opts: { db?: string; confirm?: boolean }) => {
-      await runDbResetCommand({ db: opts.db, confirm: opts.confirm });
-      process.exitCode = 0;
+    .action(async (opts: { db?: string; confirm?: boolean; full?: boolean; confirmReset?: boolean }) => {
+      const result = await runDbResetCommand({
+        db: opts.db,
+        confirm: opts.confirm,
+        full: opts.full,
+        confirmReset: opts.confirmReset,
+      });
+      process.exitCode = result.exitCode;
     });
 
   dbCommand

--- a/src/commands/reset.test.ts
+++ b/src/commands/reset.test.ts
@@ -1,0 +1,160 @@
+import path from "node:path";
+import type { Client } from "@libsql/client";
+import { describe, expect, it, vi } from "vitest";
+import { REVIEW_QUEUE_PATH } from "../consolidate/verify.js";
+import { resolveConfigDir } from "../watch/state.js";
+import { runResetCommand, type ResetCommandDeps } from "./reset.js";
+
+function makeErrnoError(code: string, message: string): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+function createDeps(overrides?: Partial<ResetCommandDeps>): { deps: ResetCommandDeps; db: Client } {
+  const db = {} as Client;
+  const deps: ResetCommandDeps = {
+    resolveDbPathFn: vi.fn(() => "/tmp/knowledge.db"),
+    backupDbFn: vi.fn(async () => "/tmp/knowledge.db.backup-pre-reset-2026-02-19T10-00-00-000Z"),
+    resetDbFn: vi.fn(async () => undefined),
+    getDbFn: vi.fn(() => db),
+    closeDbFn: vi.fn(() => undefined),
+    deleteFileFn: vi.fn(async () => undefined),
+    stdoutLine: vi.fn(() => undefined),
+    stderrLine: vi.fn(() => undefined),
+    ...overrides,
+  };
+
+  return { deps, db };
+}
+
+describe("runResetCommand", () => {
+  const watchStatePath = path.join(resolveConfigDir(), "watch-state.json");
+
+  it("prints dry-run summary and exits 0 when --confirm-reset is missing", async () => {
+    const { deps } = createDeps();
+
+    const result = await runResetCommand({ db: "/tmp/knowledge.db", confirmReset: false }, deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.backupDbFn).not.toHaveBeenCalled();
+    expect(deps.resetDbFn).not.toHaveBeenCalled();
+    expect(deps.deleteFileFn).not.toHaveBeenCalled();
+
+    const stdoutLines = (deps.stdoutLine as ReturnType<typeof vi.fn>).mock.calls.map((call) => String(call[0]));
+    expect(stdoutLines[0]).toBe("[dry run] agenr db reset --full would perform the following actions:");
+    expect(stdoutLines[1]).toMatch(/^  - Backup database to: \/tmp\/knowledge\.db\.backup-pre-reset-.+Z$/);
+    expect(stdoutLines).toContain("  - Drop and recreate DB schema (all data erased, file retained)");
+    expect(stdoutLines).toContain(`  - Delete: ${watchStatePath}`);
+    expect(stdoutLines).toContain(`  - Delete: ${REVIEW_QUEUE_PATH}`);
+    expect(stdoutLines.at(-1)).toBe("Run with --confirm-reset to execute.");
+  });
+
+  it("runs full reset successfully and closes DB exactly once", async () => {
+    const { deps, db } = createDeps();
+
+    const result = await runResetCommand({ db: "/tmp/knowledge.db", confirmReset: true }, deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.backupDbFn).toHaveBeenCalledWith("/tmp/knowledge.db");
+    expect(deps.getDbFn).toHaveBeenCalledWith("/tmp/knowledge.db");
+    expect(deps.resetDbFn).toHaveBeenCalledWith(db);
+    expect(deps.closeDbFn).toHaveBeenCalledTimes(1);
+    expect(deps.deleteFileFn).toHaveBeenCalledTimes(2);
+    expect(deps.deleteFileFn).toHaveBeenNthCalledWith(1, watchStatePath);
+    expect(deps.deleteFileFn).toHaveBeenNthCalledWith(2, REVIEW_QUEUE_PATH);
+
+    const stdoutLines = (deps.stdoutLine as ReturnType<typeof vi.fn>).mock.calls.map((call) => String(call[0]));
+    expect(stdoutLines).toContain(
+      "WARNING: If the agenr watcher daemon is running, stop it before proceeding. Reset will not abort if the daemon is running.",
+    );
+    expect(stdoutLines).toContain("Backup created: /tmp/knowledge.db.backup-pre-reset-2026-02-19T10-00-00-000Z");
+    expect(stdoutLines).toContain("Reset complete.");
+    expect(stdoutLines).toContain("  DB schema dropped and recreated: /tmp/knowledge.db");
+    expect(stdoutLines).toContain("  watch-state.json deleted (or was not present)");
+    expect(stdoutLines).toContain("  review-queue.json deleted (or was not present)");
+  });
+
+  it("treats missing watch-state.json (ENOENT) as success", async () => {
+    const { deps } = createDeps({
+      deleteFileFn: vi.fn(async (filePath: string) => {
+        if (filePath === watchStatePath) {
+          throw makeErrnoError("ENOENT", "missing watch-state");
+        }
+      }),
+    });
+
+    const result = await runResetCommand({ confirmReset: true }, deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.stderrLine).not.toHaveBeenCalled();
+    expect(deps.stdoutLine).toHaveBeenCalledWith("Reset complete.");
+  });
+
+  it("treats missing review-queue.json (ENOENT) as success", async () => {
+    const { deps } = createDeps({
+      deleteFileFn: vi.fn(async (filePath: string) => {
+        if (filePath === REVIEW_QUEUE_PATH) {
+          throw makeErrnoError("ENOENT", "missing review queue");
+        }
+      }),
+    });
+
+    const result = await runResetCommand({ confirmReset: true }, deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.stderrLine).not.toHaveBeenCalled();
+    expect(deps.stdoutLine).toHaveBeenCalledWith("Reset complete.");
+  });
+
+  it("returns exit 1 on backup failure without resetting DB or deleting files", async () => {
+    const { deps } = createDeps({
+      backupDbFn: vi.fn(async () => {
+        throw new Error("backup failed");
+      }),
+    });
+
+    const result = await runResetCommand({ confirmReset: true }, deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(deps.stderrLine).toHaveBeenCalledWith("backup failed");
+    expect(deps.resetDbFn).not.toHaveBeenCalled();
+    expect(deps.deleteFileFn).not.toHaveBeenCalled();
+  });
+
+  it("returns exit 1 on DB reset failure, still closes DB, and skips side file deletes", async () => {
+    const { deps, db } = createDeps({
+      resetDbFn: vi.fn(async () => {
+        throw new Error("reset failed");
+      }),
+    });
+
+    const result = await runResetCommand({ confirmReset: true }, deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(deps.stderrLine).toHaveBeenCalledWith("reset failed");
+    expect(deps.getDbFn).toHaveBeenCalled();
+    expect(deps.resetDbFn).toHaveBeenCalledWith(db);
+    expect(deps.closeDbFn).toHaveBeenCalledTimes(1);
+    expect(deps.deleteFileFn).not.toHaveBeenCalled();
+  });
+
+  it("warns on non-ENOENT side-file deletion errors and still exits 0", async () => {
+    const { deps } = createDeps({
+      deleteFileFn: vi.fn(async (filePath: string) => {
+        if (filePath === watchStatePath) {
+          throw makeErrnoError("EPERM", "permission denied");
+        }
+      }),
+    });
+
+    const result = await runResetCommand({ confirmReset: true }, deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(deps.deleteFileFn).toHaveBeenCalledTimes(2);
+    expect(deps.stderrLine).toHaveBeenCalledWith(
+      expect.stringContaining(`Warning: failed to delete ${watchStatePath}: permission denied`),
+    );
+    expect(deps.stdoutLine).toHaveBeenCalledWith("Reset complete.");
+  });
+});

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Client } from "@libsql/client";
+import { readConfig } from "../config.js";
+import { REVIEW_QUEUE_PATH } from "../consolidate/verify.js";
+import { backupDb, closeDb, DEFAULT_DB_PATH, getDb } from "../db/client.js";
+import { resetDb } from "../db/schema.js";
+import { resolveConfigDir } from "../watch/state.js";
+
+export interface ResetCommandOptions {
+  db?: string;
+  confirmReset?: boolean;
+}
+
+export interface ResetCommandDeps {
+  resolveDbPathFn: (options: ResetCommandOptions) => string;
+  backupDbFn: (dbPath: string) => Promise<string>;
+  resetDbFn: (db: Client) => Promise<void>;
+  getDbFn: (dbPath: string) => Client;
+  closeDbFn: (db: Client) => void;
+  deleteFileFn: (filePath: string) => Promise<void>;
+  stdoutLine: (msg: string) => void;
+  stderrLine: (msg: string) => void;
+}
+
+export interface ResetCommandResult {
+  exitCode: number;
+}
+
+function stdoutLine(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function stderrLine(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+function resolveDbPath(options: ResetCommandOptions): string {
+  return options.db?.trim() || readConfig(process.env)?.db?.path || DEFAULT_DB_PATH;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function buildPreResetBackupPath(dbPath: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").replace(/Z$/, "");
+  return path.join(path.dirname(dbPath), `${path.basename(dbPath)}.backup-pre-reset-${timestamp}Z`);
+}
+
+function isEnoent(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+async function deleteSideFile(filePath: string, deps: ResetCommandDeps): Promise<void> {
+  try {
+    await deps.deleteFileFn(filePath);
+  } catch (error) {
+    if (isEnoent(error)) {
+      return;
+    }
+    deps.stderrLine(`Warning: failed to delete ${filePath}: ${errorMessage(error)}`);
+  }
+}
+
+function resolveDeps(deps?: Partial<ResetCommandDeps>): ResetCommandDeps {
+  return {
+    resolveDbPathFn: deps?.resolveDbPathFn ?? resolveDbPath,
+    backupDbFn: deps?.backupDbFn ?? backupDb,
+    resetDbFn: deps?.resetDbFn ?? resetDb,
+    getDbFn: deps?.getDbFn ?? getDb,
+    closeDbFn: deps?.closeDbFn ?? closeDb,
+    deleteFileFn: deps?.deleteFileFn ?? (async (filePath: string) => fs.unlink(filePath)),
+    stdoutLine: deps?.stdoutLine ?? stdoutLine,
+    stderrLine: deps?.stderrLine ?? stderrLine,
+  };
+}
+
+export async function runResetCommand(
+  options: ResetCommandOptions,
+  deps?: Partial<ResetCommandDeps>,
+): Promise<ResetCommandResult> {
+  const resolvedDeps = resolveDeps(deps);
+  const resolvedDbPath = resolvedDeps.resolveDbPathFn(options);
+  const watchStatePath = path.join(resolveConfigDir(), "watch-state.json");
+  const reviewQueuePath = REVIEW_QUEUE_PATH;
+
+  if (!options.confirmReset) {
+    resolvedDeps.stdoutLine("[dry run] agenr db reset --full would perform the following actions:");
+    resolvedDeps.stdoutLine(`  - Backup database to: ${buildPreResetBackupPath(resolvedDbPath)}`);
+    resolvedDeps.stdoutLine("  - Drop and recreate DB schema (all data erased, file retained)");
+    resolvedDeps.stdoutLine(`  - Delete: ${watchStatePath}`);
+    resolvedDeps.stdoutLine(`  - Delete: ${reviewQueuePath}`);
+    resolvedDeps.stdoutLine("Run with --confirm-reset to execute.");
+    return { exitCode: 0 };
+  }
+
+  resolvedDeps.stdoutLine(
+    "WARNING: If the agenr watcher daemon is running, stop it before proceeding. Reset will not abort if the daemon is running.",
+  );
+
+  let backupPath: string;
+  try {
+    backupPath = await resolvedDeps.backupDbFn(resolvedDbPath);
+  } catch (error) {
+    resolvedDeps.stderrLine(errorMessage(error));
+    return { exitCode: 1 };
+  }
+
+  resolvedDeps.stdoutLine(`Backup created: ${backupPath}`);
+
+  const db = resolvedDeps.getDbFn(resolvedDbPath);
+  try {
+    await resolvedDeps.resetDbFn(db);
+  } catch (error) {
+    resolvedDeps.stderrLine(errorMessage(error));
+    return { exitCode: 1 };
+  } finally {
+    resolvedDeps.closeDbFn(db);
+  }
+
+  await deleteSideFile(watchStatePath, resolvedDeps);
+  await deleteSideFile(reviewQueuePath, resolvedDeps);
+
+  resolvedDeps.stdoutLine("Reset complete.");
+  resolvedDeps.stdoutLine(`  DB schema dropped and recreated: ${resolvedDbPath}`);
+  resolvedDeps.stdoutLine("  watch-state.json deleted (or was not present)");
+  resolvedDeps.stdoutLine("  review-queue.json deleted (or was not present)");
+
+  return { exitCode: 0 };
+}

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -1,0 +1,8 @@
+import { DEFAULT_DB_PATH } from "../db/client.js";
+
+export function resolveDbPathFromOptions(
+  dbOption: string | undefined,
+  configPath: string | undefined,
+): string {
+  return dbOption?.trim() || configPath || DEFAULT_DB_PATH;
+}

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -8,6 +8,8 @@ export const DEFAULT_DB_PATH = path.join(os.homedir(), ".agenr", "knowledge.db")
 
 const walInitByClient = new WeakMap<Client, Promise<void>>();
 let didWarnVectorIndexCorruption = false;
+const WAL_CHECKPOINT_MAX_ATTEMPTS = 5;
+const WAL_CHECKPOINT_RETRY_MS = 50;
 
 function resolveUserPath(inputPath: string): string {
   if (!inputPath.startsWith("~")) {
@@ -73,8 +75,56 @@ export async function initDb(client: Client): Promise<void> {
   }
 }
 
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function extractBusyFromCheckpointRow(row: unknown): number | null {
+  if (!row || typeof row !== "object") {
+    return null;
+  }
+
+  const record = row as Record<string, unknown>;
+  const busyValue = record.busy ?? Object.values(record)[0];
+  return toFiniteNumber(busyValue);
+}
+
+async function validatedWalCheckpoint(client: Client): Promise<void> {
+  for (let attempt = 1; attempt <= WAL_CHECKPOINT_MAX_ATTEMPTS; attempt += 1) {
+    const result = await client.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+    const busy = extractBusyFromCheckpointRow(result.rows[0]);
+
+    if (busy === null) {
+      throw new Error("WAL checkpoint returned an unexpected result and could not be validated.");
+    }
+
+    if (busy === 0) {
+      return;
+    }
+
+    if (attempt < WAL_CHECKPOINT_MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, WAL_CHECKPOINT_RETRY_MS * attempt));
+      continue;
+    }
+
+    throw new Error(
+      `WAL checkpoint did not finish (busy=${busy}). Active readers are blocking backup safety.`,
+    );
+  }
+}
+
 export async function walCheckpoint(client: Client): Promise<void> {
-  await client.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+  await validatedWalCheckpoint(client);
 }
 
 export async function backupDb(dbPath: string): Promise<string> {
@@ -84,7 +134,7 @@ export async function backupDb(dbPath: string): Promise<string> {
 
   const checkpointClient = getDb(dbPath);
   try {
-    await checkpointClient.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+    await walCheckpoint(checkpointClient);
   } finally {
     closeDb(checkpointClient);
   }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -406,17 +406,18 @@ export async function resetDb(db: Client): Promise<void> {
       if (!type || !name) {
         continue;
       }
+      const safeName = name.replace(/"/g, "\"\"");
 
       if (type === "trigger") {
-        await db.execute(`DROP TRIGGER IF EXISTS "${name}"`);
+        await db.execute(`DROP TRIGGER IF EXISTS "${safeName}"`);
         continue;
       }
       if (type === "index") {
-        await db.execute(`DROP INDEX IF EXISTS "${name}"`);
+        await db.execute(`DROP INDEX IF EXISTS "${safeName}"`);
         continue;
       }
       if (type === "table") {
-        await db.execute(`DROP TABLE IF EXISTS "${name}"`);
+        await db.execute(`DROP TABLE IF EXISTS "${safeName}"`);
       }
     }
 

--- a/src/watch/state.ts
+++ b/src/watch/state.ts
@@ -7,7 +7,7 @@ const WATCH_STATE_FILE = "watch-state.json";
 const CONFIG_DIR_MODE = 0o700;
 const CONFIG_FILE_MODE = 0o600;
 
-function resolveConfigDir(configDir?: string): string {
+export function resolveConfigDir(configDir?: string): string {
   if (configDir && configDir.trim().length > 0) {
     return configDir;
   }

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -181,4 +181,17 @@ describe("db schema", () => {
       "ingest_log",
     ]);
   });
+
+  it("resetDb restores foreign_keys pragma to its previous value", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await client.execute("PRAGMA foreign_keys=ON");
+
+    await resetDb(client);
+
+    const foreignKeysResult = await client.execute("PRAGMA foreign_keys");
+    const foreignKeysRow = foreignKeysResult.rows[0] as Record<string, unknown> | undefined;
+    const foreignKeysValue = Number(foreignKeysRow?.foreign_keys ?? (foreignKeysRow ? Object.values(foreignKeysRow)[0] : 0));
+    expect(foreignKeysValue).toBe(1);
+  });
 });


### PR DESCRIPTION
## v0.6.2.1 - Full Reset Command

Extends `agenr db reset` with a `--full` flag that deletes stale side files after a DB schema reset.

### Problem
`agenr db reset` drops and recreates the DB schema but leaves behind:
- `watch-state.json` - stale offsets cause watcher to skip re-ingest entirely
- `review-queue.json` - stale entry IDs no longer exist after reset

### Changes
- `agenr db reset --full --confirm-reset`: full clean-slate reset
- Deletes `watch-state.json` and `review-queue.json` after DB schema reset
- Creates pre-reset DB backup before any destructive operation (prints backup path to stdout)
- Dry-run mode when `--confirm-reset` is omitted
- Extracted `resetDb()` into `src/db/schema.ts` (shared by both reset paths)
- Added `backupDb()` helper in `src/db/client.ts`

### Tests
7 test cases in `src/commands/reset.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added db reset --full and --confirm-reset for a complete, confirmable reset.
  * Creates a timestamped DB backup, prints its path to stdout, and deletes watch/review side files on full reset.
  * Dry-run mode (omit confirm) previews backup, schema reset, and file deletions.

* **Documentation**
  * CLI docs updated with new options, examples, and dry-run previews.

* **Tests**
  * New tests covering backup, dry-run, full reset flows, and error cases.

* **Chores**
  * Version bumped to v0.6.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->