### PR TITLE
feat(recall): spaced repetition recall strength via recall_intervals (v0.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.6.4] - 2026-02-19
+
+### Added
+- feat(recall): spaced repetition recall strength via recall_intervals tracking
+- feat(recall): computeSpacingFactor() rewards entries with proven long inter-recall gaps
+- feat(recall): spacingFactor applied at memoryStrength level, benefiting both high-importance and high-recall entries
+- feat(schema): recall_intervals column (TEXT/JSON) added via COLUMN_MIGRATIONS
+- feat(types): recall_intervals field on StoredEntry, spacing field on RecallResult.scores
+
+### Fixed
+- fix(recall): legacy entries (recall_count > 0, recall_intervals NULL) impute synthetic intervals from lifetime span to prevent permanent ranking distortion after migration
+- fix(recall): updateRecallMetadata uses json_insert SQLite built-in for atomic array append, avoiding read-modify-write concurrency race
+- fix(recall): recall_intervals timestamps stored as Unix integer seconds (not ISO string) to prevent x1000 unit error in gap calculations
+- fix(db): VACUUM database after db reset to reclaim freed pages immediately
+
 ## [0.6.3] - 2026-02-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@
 ### Added
 - feat(recall): spaced repetition recall strength via recall_intervals tracking
 - feat(recall): computeSpacingFactor() rewards entries with proven long inter-recall gaps
-- feat(recall): spacingFactor applied at memoryStrength level, benefiting both high-importance and high-recall entries
 - feat(schema): recall_intervals column (TEXT/JSON) added via COLUMN_MIGRATIONS
 - feat(types): recall_intervals field on StoredEntry, spacing field on RecallResult.scores
 
 ### Fixed
-- fix(recall): legacy entries (recall_count > 0, recall_intervals NULL) impute synthetic intervals from lifetime span to prevent permanent ranking distortion after migration
+- fix(recall): legacy spacing imputation now anchors at created_at and lands exactly on last_recalled_at (including recall_count=1), restoring expected spacing bonuses
+- fix(recall): spacingFactor now applies to the recall-base component before importance comparison, preventing early saturation while keeping memoryStrength clamped to <= 1.0
 - fix(recall): updateRecallMetadata uses json_insert SQLite built-in for atomic array append, avoiding read-modify-write concurrency race
 - fix(recall): recall_intervals timestamps stored as Unix integer seconds (not ISO string) to prevent x1000 unit error in gap calculations
+- fix(recall): removed unused getScoreComponents() refactor artifact to avoid divergence from the active scoring path
 - fix(db): VACUUM database after db reset to reclaim freed pages immediately
 
 ## [0.6.3] - 2026-02-19

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",
   "bin": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -232,6 +232,11 @@ const COLUMN_MIGRATIONS: readonly ColumnMigration[] = [
     column: "original_created_at",
     sql: "ALTER TABLE entry_sources ADD COLUMN original_created_at TEXT",
   },
+  {
+    table: "entries",
+    column: "recall_intervals",
+    sql: "ALTER TABLE entries ADD COLUMN recall_intervals TEXT DEFAULT NULL",
+  },
 ];
 
 export async function initSchema(client: Client): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,7 @@ export interface StoredEntry extends KnowledgeEntry {
   updated_at: string;
   last_recalled_at?: string;
   recall_count: number;
+  recall_intervals?: number[];
   confirmations: number;
   contradictions: number;
   superseded_by?: string;
@@ -212,6 +213,7 @@ export interface RecallResult {
     freshness: number;
     todoPenalty: number;
     fts: number;
+    spacing: number;
   };
 }
 

--- a/tests/commands/context.test.ts
+++ b/tests/commands/context.test.ts
@@ -38,7 +38,7 @@ function makeResult(category: RecallCommandResult["category"], overrides: Partia
   return {
     entry: makeEntry(overrides),
     score: 0.8,
-    scores: { vector: 0, recency: 0, importance: 0, recall: 0, freshness: 1, todoPenalty: 1, fts: 0 },
+    scores: { vector: 0, recency: 0, importance: 0, recall: 0, freshness: 1, todoPenalty: 1, fts: 0, spacing: 1 },
     category,
   };
 }

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -35,7 +35,10 @@ function makeResult(overrides: Partial<RecallResult> = {}): RecallResult {
       recency: 0.8,
       importance: 0.75,
       recall: 0.2,
+      freshness: 1,
+      todoPenalty: 1,
       fts: 0.15,
+      spacing: 1,
     },
     ...overrides,
   };

--- a/tests/db/migration.test.ts
+++ b/tests/db/migration.test.ts
@@ -44,6 +44,7 @@ describe("db schema migrations", () => {
     expect(entries.has("retired_at")).toBe(true);
     expect(entries.has("retired_reason")).toBe(true);
     expect(entries.has("suppressed_contexts")).toBe(true);
+    expect(entries.has("recall_intervals")).toBe(true);
 
     expect(ingest.has("content_hash")).toBe(true);
     expect(ingest.has("entries_superseded")).toBe(true);
@@ -199,6 +200,7 @@ describe("db schema migrations", () => {
     const retiredAt = entriesColumns.find((row) => toStringValue(row.name) === "retired_at");
     const retiredReason = entriesColumns.find((row) => toStringValue(row.name) === "retired_reason");
     const suppressedContexts = entriesColumns.find((row) => toStringValue(row.name) === "suppressed_contexts");
+    const recallIntervals = entriesColumns.find((row) => toStringValue(row.name) === "recall_intervals");
 
     expect(canonicalKey).toBeTruthy();
     expect(scope).toBeTruthy();
@@ -214,6 +216,7 @@ describe("db schema migrations", () => {
     expect(retiredAt).toBeTruthy();
     expect(retiredReason).toBeTruthy();
     expect(suppressedContexts).toBeTruthy();
+    expect(recallIntervals).toBeTruthy();
 
     const ingestInfo = await client.execute("PRAGMA table_info(ingest_log)");
     const ingestColumns = ingestInfo.rows as Array<{ name?: unknown; dflt_value?: unknown }>;

--- a/tests/db/recall-spacing.test.ts
+++ b/tests/db/recall-spacing.test.ts
@@ -1,0 +1,503 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { initDb } from "../../src/db/client.js";
+import {
+  computeSpacingFactor,
+  recall,
+  recallStrength,
+  recency,
+  scoreEntryWithBreakdown,
+  updateRecallMetadata,
+} from "../../src/db/recall.js";
+import { initSchema } from "../../src/db/schema.js";
+import { mapRawStoredEntry } from "../../src/db/stored-entry.js";
+import type { StoredEntry } from "../../src/types.js";
+
+const ONE_DAY_SECS = 86400;
+const SEVEN_DAYS_SECS = 86400 * 7;
+const t1 = 1708300000;
+
+function to1024(head: number[]): number[] {
+  return [...head, ...Array.from({ length: Math.max(0, 1024 - head.length) }, () => 0)];
+}
+
+function parseIntervals(raw: unknown): number[] {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return [];
+  }
+  const parsed = JSON.parse(raw) as unknown;
+  return Array.isArray(parsed) ? parsed.filter((value): value is number => typeof value === "number") : [];
+}
+
+function makeEntry(overrides: Partial<StoredEntry> = {}): StoredEntry {
+  return {
+    id: "test-id",
+    type: "fact",
+    subject: "test subject",
+    content: "test content",
+    importance: 7,
+    expiry: "permanent",
+    scope: "private",
+    tags: [],
+    source: { file: "", context: "" },
+    embedding: undefined,
+    created_at: new Date(Date.now() - 30 * ONE_DAY_SECS * 1000).toISOString(),
+    updated_at: new Date().toISOString(),
+    recall_count: 5,
+    recall_intervals: undefined,
+    confirmations: 0,
+    contradictions: 0,
+    ...overrides,
+  };
+}
+
+async function insertEntry(
+  db: Client,
+  id: string,
+  options: {
+    recallCount?: number;
+    recallIntervals?: string | null;
+    createdAt?: string;
+    updatedAt?: string;
+    lastRecalledAt?: string | null;
+    embedding?: number[];
+  } = {},
+): Promise<void> {
+  const createdAt = options.createdAt ?? "2026-01-01T00:00:00.000Z";
+  const updatedAt = options.updatedAt ?? createdAt;
+  const lastRecalledAt = options.lastRecalledAt ?? null;
+  const recallCount = options.recallCount ?? 0;
+  const recallIntervals = options.recallIntervals ?? null;
+
+  if (options.embedding) {
+    await db.execute({
+      sql: `
+        INSERT INTO entries (
+          id, type, subject, content, importance, expiry, scope, source_file, source_context,
+          embedding, created_at, updated_at, last_recalled_at, recall_count, recall_intervals,
+          confirmations, contradictions
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, vector32(?), ?, ?, ?, ?, ?, ?, ?)
+      `,
+      args: [
+        id,
+        "fact",
+        "Subject",
+        `Content ${id}`,
+        8,
+        "permanent",
+        "private",
+        "recall-spacing.test",
+        "test",
+        JSON.stringify(options.embedding),
+        createdAt,
+        updatedAt,
+        lastRecalledAt,
+        recallCount,
+        recallIntervals,
+        0,
+        0,
+      ],
+    });
+    return;
+  }
+
+  await db.execute({
+    sql: `
+      INSERT INTO entries (
+        id, type, subject, content, importance, expiry, scope, source_file, source_context,
+        created_at, updated_at, last_recalled_at, recall_count, recall_intervals, confirmations, contradictions
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    args: [
+      id,
+      "fact",
+      "Subject",
+      `Content ${id}`,
+      8,
+      "permanent",
+      "private",
+      "recall-spacing.test",
+      "test",
+      createdAt,
+      updatedAt,
+      lastRecalledAt,
+      recallCount,
+      recallIntervals,
+      0,
+      0,
+    ],
+  });
+}
+
+describe("recall spacing", () => {
+  const clients: Client[] = [];
+
+  afterEach(() => {
+    while (clients.length > 0) {
+      clients.pop()?.close();
+    }
+  });
+
+  function makeClient(): Client {
+    const client = createClient({ url: ":memory:" });
+    clients.push(client);
+    return client;
+  }
+
+  describe("computeSpacingFactor", () => {
+    it("returns 1.0 for empty arrays", () => {
+      expect(computeSpacingFactor([])).toBe(1.0);
+    });
+
+    it("returns 1.0 for a single timestamp", () => {
+      expect(computeSpacingFactor([t1])).toBe(1.0);
+    });
+
+    it("returns immediate bonus for a 1-day interval", () => {
+      expect(computeSpacingFactor([t1, t1 + ONE_DAY_SECS])).toBeCloseTo(Math.log1p(2), 4);
+    });
+
+    it("returns a strong bonus for a 7-day interval", () => {
+      expect(computeSpacingFactor([t1, t1 + SEVEN_DAYS_SECS])).toBeCloseTo(Math.log1p(8), 4);
+    });
+
+    it("treats same-timestamp cramming as neutral", () => {
+      expect(computeSpacingFactor([t1, t1, t1, t1, t1])).toBe(1.0);
+    });
+
+    it("uses max gap, not mean gap", () => {
+      const ts = [t1, t1 + ONE_DAY_SECS, t1 + 2 * ONE_DAY_SECS, t1 + 3 * ONE_DAY_SECS, t1 + 10 * ONE_DAY_SECS];
+      expect(computeSpacingFactor(ts)).toBeCloseTo(Math.log1p(8), 4);
+    });
+
+    it("rewards growing SM-2 style intervals", () => {
+      const growing = [
+        t1,
+        t1 + ONE_DAY_SECS,
+        t1 + 3 * ONE_DAY_SECS,
+        t1 + 7 * ONE_DAY_SECS,
+        t1 + 15 * ONE_DAY_SECS,
+        t1 + 31 * ONE_DAY_SECS,
+      ];
+      expect(computeSpacingFactor(growing)).toBeCloseTo(Math.log1p(17), 4);
+    });
+
+    it("handles out-of-order timestamps", () => {
+      const skewed = [t1 + ONE_DAY_SECS, t1, t1 + SEVEN_DAYS_SECS];
+      const result = computeSpacingFactor(skewed);
+      expect(Number.isFinite(result)).toBe(true);
+      expect(result).toBeGreaterThanOrEqual(1.0);
+    });
+
+    it("does not mutate input arrays", () => {
+      const arr = [t1, t1 + SEVEN_DAYS_SECS];
+      const original = [...arr];
+      computeSpacingFactor(arr);
+      expect(arr).toEqual(original);
+    });
+
+    it("imputes legacy intervals when recall_count exists", () => {
+      const now = new Date();
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * ONE_DAY_SECS * 1000).toISOString();
+      const factor = computeSpacingFactor([], 3, thirtyDaysAgo, now.toISOString());
+      expect(factor).toBeGreaterThan(1.0);
+    });
+
+    it("returns neutral when recall_count is zero", () => {
+      expect(computeSpacingFactor([], 0, "2025-01-01T00:00:00Z", "2026-01-01T00:00:00Z")).toBe(1.0);
+    });
+
+    it("stays finite for backward/negative-gap timestamp ordering", () => {
+      const backward = [t1 + SEVEN_DAYS_SECS, t1];
+      const result = computeSpacingFactor(backward);
+      expect(Number.isFinite(result)).toBe(true);
+    });
+  });
+
+  describe("scoreEntryWithBreakdown", () => {
+    it("scores spaced recalls higher than crammed recalls", () => {
+      const now = new Date();
+      const crammed = makeEntry({
+        recall_intervals: [t1, t1 + 100, t1 + 200, t1 + 300, t1 + 400],
+      });
+      const spaced = makeEntry({
+        recall_intervals: [t1, t1 + ONE_DAY_SECS, t1 + 3 * ONE_DAY_SECS, t1 + 7 * ONE_DAY_SECS, t1 + 15 * ONE_DAY_SECS],
+      });
+
+      const crammedScore = scoreEntryWithBreakdown(crammed, 0.8, false, now).score;
+      const spacedScore = scoreEntryWithBreakdown(spaced, 0.8, false, now).score;
+      expect(spacedScore).toBeGreaterThan(crammedScore);
+    });
+
+    it("always reports spacing >= 1.0", () => {
+      const entry = makeEntry({ recall_intervals: [t1, t1 + SEVEN_DAYS_SECS] });
+      const { scores } = scoreEntryWithBreakdown(entry, 0.5, false, new Date());
+      expect(scores.spacing).toBeGreaterThanOrEqual(1.0);
+    });
+
+    it("lets high-importance entries benefit from spacing", () => {
+      const now = new Date();
+      const highImpCrammed = makeEntry({ importance: 9, recall_intervals: [t1, t1 + 100] });
+      const highImpSpaced = makeEntry({ importance: 9, recall_intervals: [t1, t1 + 30 * ONE_DAY_SECS] });
+      const crammedScore = scoreEntryWithBreakdown(highImpCrammed, 0.5, false, now).score;
+      const spacedScore = scoreEntryWithBreakdown(highImpSpaced, 0.5, false, now).score;
+      expect(spacedScore).toBeGreaterThan(crammedScore);
+    });
+
+    it("keeps recallStrength behavior unchanged", () => {
+      expect(recallStrength(0, 10, "permanent")).toBe(0);
+      expect(recallStrength(5, 0, "core")).toBe(1.0);
+      expect(recallStrength(5, 7, "permanent")).toBeCloseTo(
+        Math.min(Math.pow(5, 0.7) / 5, 1.0) * recency(7, "permanent"),
+        6,
+      );
+    });
+  });
+
+  describe("updateRecallMetadata", () => {
+    it("appends one interval for all ids in a bulk call", async () => {
+      const client = makeClient();
+      await initDb(client);
+
+      const ids = ["a", "b", "c", "d", "e"];
+      for (const id of ids) {
+        await insertEntry(client, id);
+      }
+
+      const now = new Date("2026-02-19T12:00:00.000Z");
+      await updateRecallMetadata(client, ids, now);
+
+      const rows = await client.execute({
+        sql: "SELECT id, recall_intervals FROM entries WHERE id IN (?, ?, ?, ?, ?)",
+        args: ids,
+      });
+      const intervalsById = new Map<string, number[]>();
+      for (const row of rows.rows) {
+        intervalsById.set(String(row.id), parseIntervals(row.recall_intervals));
+      }
+
+      for (const id of ids) {
+        expect(intervalsById.get(id)).toHaveLength(1);
+      }
+    });
+
+    it("handles partial overlap updates without dropping appends", async () => {
+      const client = makeClient();
+      await initDb(client);
+
+      await insertEntry(client, "A");
+      await insertEntry(client, "B");
+      await insertEntry(client, "C");
+
+      await updateRecallMetadata(client, ["A", "B"], new Date("2026-02-19T12:00:00.000Z"));
+      await updateRecallMetadata(client, ["B", "C"], new Date("2026-02-19T13:00:00.000Z"));
+
+      const rows = await client.execute({
+        sql: "SELECT id, recall_intervals FROM entries WHERE id IN (?, ?, ?)",
+        args: ["A", "B", "C"],
+      });
+      const byId = new Map<string, number[]>();
+      for (const row of rows.rows) {
+        byId.set(String(row.id), parseIntervals(row.recall_intervals));
+      }
+
+      expect(byId.get("A")).toHaveLength(1);
+      expect(byId.get("B")).toHaveLength(2);
+      expect(byId.get("C")).toHaveLength(1);
+    });
+
+    it("preserves append order across repeated calls", async () => {
+      const client = makeClient();
+      await initDb(client);
+      await insertEntry(client, "ordered");
+
+      const first = new Date("2026-02-19T12:00:00.000Z");
+      const second = new Date("2026-02-19T12:10:00.000Z");
+      const third = new Date("2026-02-19T12:20:00.000Z");
+
+      await updateRecallMetadata(client, ["ordered"], first);
+      await updateRecallMetadata(client, ["ordered"], second);
+      await updateRecallMetadata(client, ["ordered"], third);
+
+      const row = await client.execute({
+        sql: "SELECT recall_intervals FROM entries WHERE id = ?",
+        args: ["ordered"],
+      });
+      const intervals = parseIntervals(row.rows[0]?.recall_intervals);
+      expect(intervals).toEqual([
+        Math.floor(first.getTime() / 1000),
+        Math.floor(second.getTime() / 1000),
+        Math.floor(third.getTime() / 1000),
+      ]);
+    });
+
+    it("is safe under concurrent updates to the same id", async () => {
+      const client = makeClient();
+      await initDb(client);
+      await insertEntry(client, "concurrent");
+
+      await Promise.all([
+        updateRecallMetadata(client, ["concurrent"], new Date("2026-02-19T12:00:00.000Z")),
+        updateRecallMetadata(client, ["concurrent"], new Date("2026-02-19T12:00:01.000Z")),
+      ]);
+
+      const row = await client.execute({
+        sql: "SELECT recall_intervals FROM entries WHERE id = ?",
+        args: ["concurrent"],
+      });
+      const intervals = parseIntervals(row.rows[0]?.recall_intervals);
+      expect(intervals).toHaveLength(2);
+    });
+
+    it("stores timestamps in epoch seconds, not milliseconds", async () => {
+      const client = makeClient();
+      await initDb(client);
+      await insertEntry(client, "unit-check");
+
+      const before = Math.floor(Date.now() / 1000);
+      await updateRecallMetadata(client, ["unit-check"], new Date());
+      const after = Math.floor(Date.now() / 1000);
+
+      const row = await client.execute({
+        sql: "SELECT recall_intervals FROM entries WHERE id = ?",
+        args: ["unit-check"],
+      });
+      const intervals = parseIntervals(row.rows[0]?.recall_intervals);
+      expect(intervals[0]).toBeGreaterThanOrEqual(before);
+      expect(intervals[0]).toBeLessThanOrEqual(after + 1);
+    });
+
+    it("does not crash scoring when recall_intervals is NULL for legacy rows", async () => {
+      const client = makeClient();
+      await initDb(client);
+
+      await insertEntry(client, "legacy-null", {
+        recallCount: 3,
+        recallIntervals: null,
+        createdAt: "2025-12-01T00:00:00.000Z",
+        updatedAt: "2025-12-01T00:00:00.000Z",
+        lastRecalledAt: "2026-01-30T00:00:00.000Z",
+      });
+
+      const results = await recall(
+        client,
+        {
+          text: "",
+          context: "session-start",
+          limit: 5,
+          noUpdate: true,
+        },
+        "sk-test",
+        { now: new Date("2026-02-01T00:00:00.000Z") },
+      );
+
+      const legacy = results.find((item) => item.entry.id === "legacy-null");
+      expect(legacy).toBeTruthy();
+      expect(legacy!.score).toBeGreaterThanOrEqual(0);
+    });
+
+    it("falls back to spacing 1.0 for corrupt recall_intervals JSON", async () => {
+      const client = makeClient();
+      await initDb(client);
+
+      await insertEntry(client, "bad-json", {
+        recallCount: 0,
+        recallIntervals: "not-json",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      const row = await client.execute({
+        sql: `
+          SELECT
+            id, type, subject, content, importance, expiry, scope, platform, project,
+            source_file, source_context, created_at, updated_at, last_recalled_at,
+            recall_count, recall_intervals, confirmations, contradictions, superseded_by,
+            retired, retired_at, retired_reason, suppressed_contexts
+          FROM entries
+          WHERE id = ?
+        `,
+        args: ["bad-json"],
+      });
+      const entry = mapRawStoredEntry(row.rows[0] as Record<string, unknown>, { tags: [] });
+      const scored = scoreEntryWithBreakdown(entry, 1, false, new Date("2026-02-01T00:00:00.000Z"));
+
+      expect(scored.score).toBeGreaterThanOrEqual(0);
+      expect(scored.scores.spacing).toBe(1.0);
+    });
+
+    it("uses recall_intervals in session-start candidate scoring", async () => {
+      const client = makeClient();
+      await initDb(client);
+
+      await insertEntry(client, "session-spaced", {
+        recallCount: 0,
+        recallIntervals: JSON.stringify([t1, t1 + SEVEN_DAYS_SECS]),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      const results = await recall(
+        client,
+        {
+          text: "",
+          context: "session-start",
+          limit: 5,
+          noUpdate: true,
+        },
+        "sk-test",
+        { now: new Date("2026-02-01T00:00:00.000Z") },
+      );
+
+      const spaced = results.find((item) => item.entry.id === "session-spaced");
+      expect(spaced).toBeTruthy();
+      expect(spaced!.scores.spacing).toBeGreaterThan(1.0);
+    });
+
+    it("uses recall_intervals in vector candidate scoring", async () => {
+      const client = makeClient();
+      await initDb(client);
+
+      const vector = to1024([1, 0, 0]);
+      await insertEntry(client, "vector-spaced", {
+        recallCount: 0,
+        recallIntervals: JSON.stringify([t1, t1 + SEVEN_DAYS_SECS]),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        embedding: vector,
+      });
+
+      const results = await recall(
+        client,
+        {
+          text: "vector spaced",
+          limit: 5,
+          noUpdate: true,
+        },
+        "sk-test",
+        {
+          now: new Date("2026-02-01T00:00:00.000Z"),
+          embedFn: async () => [vector],
+        },
+      );
+
+      const spaced = results.find((item) => item.entry.id === "vector-spaced");
+      expect(spaced).toBeTruthy();
+      expect(spaced!.scores.spacing).toBeGreaterThan(1.0);
+    });
+  });
+
+  it("runs recall_intervals migration idempotently", async () => {
+    const client = makeClient();
+
+    await initSchema(client);
+    await initSchema(client);
+    await initSchema(client);
+
+    const info = await client.execute("PRAGMA table_info(entries)");
+    const recallIntervalsColumns = info.rows.filter((row) => String(row.name) === "recall_intervals");
+    expect(recallIntervalsColumns).toHaveLength(1);
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -126,6 +126,7 @@ describe("db schema", () => {
     expect(entryColumns.has("retired_at")).toBe(true);
     expect(entryColumns.has("retired_reason")).toBe(true);
     expect(entryColumns.has("suppressed_contexts")).toBe(true);
+    expect(entryColumns.has("recall_intervals")).toBe(true);
     expect(ingestColumns.has("content_hash")).toBe(true);
     expect(ingestColumns.has("entries_superseded")).toBe(true);
     expect(ingestColumns.has("dedup_llm_calls")).toBe(true);

--- a/tests/db/stored-entry.test.ts
+++ b/tests/db/stored-entry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { mapRawStoredEntry } from "../../src/db/stored-entry.js";
+
+function makeRow(recallIntervals: unknown): Record<string, unknown> {
+  return {
+    id: "entry-1",
+    type: "fact",
+    subject: "Subject",
+    content: "Content",
+    importance: 7,
+    expiry: "temporary",
+    scope: "private",
+    source_file: "stored-entry.test",
+    source_context: "test",
+    created_at: "2026-02-01T00:00:00.000Z",
+    updated_at: "2026-02-01T00:00:00.000Z",
+    recall_count: 0,
+    confirmations: 0,
+    contradictions: 0,
+    recall_intervals: recallIntervals,
+  };
+}
+
+describe("mapRawStoredEntry", () => {
+  it("returns undefined recallIntervals for non-array JSON payloads", () => {
+    const nonArrayPayloads = [JSON.stringify({ value: 1 }), "123", JSON.stringify("text")];
+
+    for (const payload of nonArrayPayloads) {
+      const entry = mapRawStoredEntry(makeRow(payload), { tags: [] });
+      expect(entry.recall_intervals).toBeUndefined();
+    }
+  });
+
+  it("filters mixed recallIntervals arrays to numeric values only", () => {
+    const entry = mapRawStoredEntry(
+      makeRow(JSON.stringify([1708300000, "foo", null])),
+      { tags: [] },
+    );
+    expect(entry.recall_intervals).toEqual([1708300000]);
+  });
+
+  it("preserves empty recallIntervals arrays", () => {
+    const entry = mapRawStoredEntry(makeRow(JSON.stringify([])), { tags: [] });
+    expect(entry.recall_intervals).toEqual([]);
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -42,6 +42,7 @@ function makeRecallResult(overrides?: Partial<RecallResult>): RecallResult {
       freshness: 1,
       todoPenalty: 1,
       fts: 0,
+      spacing: 1,
     },
     entry: {
       id: "entry-1",


### PR DESCRIPTION
## Summary

Adds spaced repetition scoring to agenr recall. Entries recalled after long gaps are rewarded with a spacing bonus, making well-spaced memories surface more reliably over crammed or stale ones.

## What Changed

**Core feature:**
- New `recall_intervals` column (TEXT/JSON) on `entries` table via `COLUMN_MIGRATIONS`
- `computeSpacingFactor()` computes a log-scaled bonus from the longest inter-recall gap
- `spacing` field added to `RecallResult.scores`
- Both `fetchVectorCandidates` and `fetchSessionCandidates` now select `recall_intervals`
- Atomic `json_insert` append in `updateRecallMetadata` - no read-modify-write race
- In-memory `recall_intervals` update mirrors DB write for consistency

**Fixes (from swarm code review):**
- Legacy imputation off-by-one: loop now anchors at `created_at` and lands exactly on `last_recalled_at`, including `recall_count=1` entries
- `spacingFactor` now applied to `recallBase` before importance comparison - prevents early saturation for high-importance entries
- Removed unused `getScoreComponents()` refactor artifact
- Timestamps stored as Unix integer seconds (not ISO strings) to avoid x1000 unit error
- VACUUM added to `db reset --full` to reclaim freed pages immediately

**Non-blocking:**
- TODO comment in `updateRecallMetadata` flagging unbounded array growth

## Tests

634 tests passing (up from 625). New coverage:
- `tests/db/recall-spacing.test.ts` - 26 tests: unit math, DB integration, legacy imputation edge cases, round-trip integration, concurrent appends
- `tests/db/stored-entry.test.ts` - new file, 3 tests for `mapRawStoredEntry` parsing edge cases
- In-memory `recall_intervals` update verified in `recall.test.ts`
- `noBoost` path asserts `spacing === 1.0`
- Score cap verified with extreme spacing factor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.6.4

* **New Features**
  * Recall intervals tracking: System now records when entries are recalled for improved spaced repetition scoring
  * Spacing factor rewards: Entries receive higher scores when recalled at optimal intervals

* **Bug Fixes**
  * Database performance optimization after reset operations
  * Improved handling of historical recall data
  * Enhanced recall-based scoring consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->