### PR TITLE
feat(openclaw-plugin): add OpenClaw plugin for automatic memory injection (v0.6.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.6.6] - 2026-02-19
+
+### Added
+- feat(openclaw-plugin): OpenClaw plugin that injects agenr memory into agent sessions
+  - New src/openclaw-plugin/index.ts: plugin entry point, registers agent:bootstrap hook
+  - New src/openclaw-plugin/recall.ts: runs agenr CLI recall, formats JSON as markdown
+  - New src/openclaw-plugin/types.ts: local type aliases for OpenClaw SDK compatibility
+  - Memory injected as synthetic AGENR.md file into # Project Context in system prompt
+  - Grouped markdown output: Active Todos / Preferences and Decisions / Facts and Events
+  - Skips subagent and cron sessions automatically (sessionKey pattern check)
+  - Configurable: agenrPath, budget, enabled via openclaw.json plugins.entries.agenr.config
+  - 5 second timeout on recall; all errors swallowed silently to never block session start
+  - package.json "openclaw" key declares dist/openclaw-plugin/index.js as plugin extension
+
 ## [0.6.5] - 2026-02-19
 
 ### Added

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "agenr",
+  "name": "agenr Memory",
+  "description": "Local memory layer - injects agenr context at session start",
+  "version": "0.6.6",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "agenrPath": {
+        "type": "string",
+        "description": "Path to agenr CLI entry point (dist/cli.js)."
+      },
+      "budget": {
+        "type": "number",
+        "description": "Token budget for session-start recall. Default: 2000."
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Set false to disable memory injection without uninstalling."
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "agenr",
-  "version": "0.6.5",
+  "version": "0.6.6",
+  "openclaw": {
+    "extensions": ["dist/openclaw-plugin/index.js"]
+  },
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",
   "bin": {
     "agenr": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsup src/cli.ts src/cli-main.ts --format esm --dts",
+    "build": "tsup src/cli.ts src/cli-main.ts src/openclaw-plugin/index.ts --format esm --dts",
     "dev": "tsup src/cli.ts src/cli-main.ts --format esm --watch",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -49,6 +52,7 @@
   ],
   "files": [
     "dist",
+    "openclaw.plugin.json",
     "CHANGELOG.md",
     "LICENSE",
     "README.md"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -1,0 +1,78 @@
+import os from "node:os";
+import path from "node:path";
+import { formatRecallAsMarkdown, resolveAgenrPath, resolveBudget, runRecall } from "./recall.js";
+import type {
+  AgenrPluginConfig,
+  BootstrapFile,
+  BootstrapHookContext,
+  HookEvent,
+  PluginApi,
+} from "./types.js";
+
+// Path used as the ## header in Project Context for the injected memory block.
+const AGENR_CONTEXT_PATH = path.join(os.homedir(), ".agenr", "AGENR.md");
+
+// Session key substrings that indicate non-interactive sessions to skip.
+const SKIP_SESSION_PATTERNS = [":subagent:", ":cron:"];
+
+function shouldSkipSession(sessionKey: string): boolean {
+  return SKIP_SESSION_PATTERNS.some((pattern) => sessionKey.includes(pattern));
+}
+
+const plugin = {
+  id: "agenr",
+  name: "agenr memory context",
+  description: "Injects agenr long-term memory into every agent session via agent:bootstrap",
+
+  register(api: PluginApi): void {
+    api.registerHook("agent:bootstrap", async (event: HookEvent): Promise<void> => {
+      try {
+        const ctx = event.context as BootstrapHookContext;
+        if (!Array.isArray(ctx.bootstrapFiles)) {
+          return;
+        }
+
+        // Check session key from both event root and context.
+        const sessionKey = ctx.sessionKey ?? event.sessionKey ?? "";
+
+        // Skip non-interactive sessions.
+        if (shouldSkipSession(sessionKey)) {
+          return;
+        }
+
+        const config = api.pluginConfig as AgenrPluginConfig | undefined;
+        if (config?.enabled === false) {
+          return;
+        }
+
+        const agenrPath = resolveAgenrPath(config);
+        const budget = resolveBudget(config);
+
+        const result = await runRecall(agenrPath, budget);
+        if (!result) {
+          return;
+        }
+
+        const markdown = formatRecallAsMarkdown(result);
+        if (!markdown.trim()) {
+          return;
+        }
+
+        // Push synthetic bootstrap file - cast name to any since "AGENR.md" is not
+        // in the WorkspaceBootstrapFileName union but runtime does not validate it.
+        const file: BootstrapFile = {
+          name: "AGENR.md" as unknown as never,
+          path: AGENR_CONTEXT_PATH,
+          content: markdown,
+          missing: false,
+        };
+
+        ctx.bootstrapFiles.push(file);
+      } catch {
+        // Never block session start - swallow all errors silently.
+      }
+    });
+  },
+};
+
+export default plugin;

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -58,10 +58,9 @@ const plugin = {
           return;
         }
 
-        // Push synthetic bootstrap file - cast name to any since "AGENR.md" is not
-        // in the WorkspaceBootstrapFileName union but runtime does not validate it.
+        // Push synthetic bootstrap file containing recalled memory context.
         const file: BootstrapFile = {
-          name: "AGENR.md" as unknown as never,
+          name: "AGENR.md",
           path: AGENR_CONTEXT_PATH,
           content: markdown,
           missing: false,

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -1,11 +1,19 @@
 import { spawn } from "node:child_process";
-import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AgenrPluginConfig } from "./types.js";
 
 const RECALL_TIMEOUT_MS = 5000;
 const DEFAULT_BUDGET = 2000;
-const DEFAULT_AGENR_PATH = path.join(os.homedir(), "Code", "agenr-local", "dist", "cli.js");
+// Resolve bundled CLI path from this module location for both src/ and dist/ runtime layouts.
+const DEFAULT_AGENR_PATH = path.resolve(
+  fileURLToPath(import.meta.url),
+  "..",
+  "..",
+  "..",
+  "dist",
+  "cli.js"
+);
 
 export type RecallEntry = {
   type: string;

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -1,0 +1,153 @@
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import type { AgenrPluginConfig } from "./types.js";
+
+const RECALL_TIMEOUT_MS = 5000;
+const DEFAULT_BUDGET = 2000;
+const DEFAULT_AGENR_PATH = path.join(os.homedir(), "Code", "agenr-local", "dist", "cli.js");
+
+export type RecallEntry = {
+  type: string;
+  subject: string;
+  content: string;
+  importance?: number;
+};
+
+export type RecallResult = {
+  query: string;
+  results: Array<{
+    entry: RecallEntry & Record<string, unknown>;
+    score: number;
+    category?: string;
+  }>;
+};
+
+export function resolveAgenrPath(config?: AgenrPluginConfig): string {
+  return config?.agenrPath?.trim() || process.env["AGENR_BIN"]?.trim() || DEFAULT_AGENR_PATH;
+}
+
+export function resolveBudget(config?: AgenrPluginConfig): number {
+  return config?.budget ?? DEFAULT_BUDGET;
+}
+
+export async function runRecall(agenrPath: string, budget: number): Promise<RecallResult | null> {
+  return await new Promise((resolve) => {
+    let stdout = "";
+    let settled = false;
+
+    function finish(value: RecallResult | null): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(value);
+    }
+
+    const child = spawn(
+      process.execPath,
+      [agenrPath, "recall", "--context", "session-start", "--budget", String(budget), "--json"],
+      { stdio: ["ignore", "pipe", "ignore"] }
+    );
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(null);
+    }, RECALL_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    child.on("close", () => {
+      clearTimeout(timer);
+      try {
+        const parsed: unknown = JSON.parse(stdout);
+        finish(isRecallResult(parsed) ? parsed : null);
+      } catch {
+        finish(null);
+      }
+    });
+
+    child.on("error", () => {
+      clearTimeout(timer);
+      finish(null);
+    });
+  });
+}
+
+function isRecallResult(value: unknown): value is RecallResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "results" in value &&
+    Array.isArray((value as RecallResult).results)
+  );
+}
+
+// Entry types mapped to display groups.
+const TODO_TYPES = new Set(["todo"]);
+const PREFERENCE_TYPES = new Set(["preference", "decision"]);
+// All other types fall into facts/events group.
+
+export function formatRecallAsMarkdown(result: RecallResult): string {
+  if (!result.results || result.results.length === 0) {
+    return "";
+  }
+
+  const todos: RecallEntry[] = [];
+  const preferences: RecallEntry[] = [];
+  const facts: RecallEntry[] = [];
+
+  for (const item of result.results) {
+    const entry = item.entry;
+    if (
+      !entry ||
+      typeof entry.type !== "string" ||
+      typeof entry.subject !== "string" ||
+      typeof entry.content !== "string"
+    ) {
+      continue;
+    }
+
+    if (TODO_TYPES.has(entry.type)) {
+      todos.push(entry);
+    } else if (PREFERENCE_TYPES.has(entry.type)) {
+      preferences.push(entry);
+    } else {
+      facts.push(entry);
+    }
+  }
+
+  if (todos.length === 0 && preferences.length === 0 && facts.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = ["## agenr Memory Context", ""];
+
+  if (todos.length > 0) {
+    lines.push("### Active Todos", "");
+    for (const entry of todos) {
+      lines.push(`- [${entry.subject}] ${entry.content}`);
+    }
+    lines.push("");
+  }
+
+  if (preferences.length > 0) {
+    lines.push("### Preferences and Decisions", "");
+    for (const entry of preferences) {
+      lines.push(`- [${entry.subject}] ${entry.content}`);
+    }
+    lines.push("");
+  }
+
+  if (facts.length > 0) {
+    lines.push("### Facts and Events", "");
+    for (const entry of facts) {
+      lines.push(`- [${entry.subject}] ${entry.content}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -45,7 +45,7 @@ export type PluginApi = {
 };
 
 export type AgenrPluginConfig = {
-  /** Path to agenr CLI entry point (dist/cli.js). Defaults to AGENR_BIN env or ~/Code/agenr-local/dist/cli.js */
+  /** Path to agenr CLI entry point (dist/cli.js). Defaults to AGENR_BIN env or bundled dist/cli.js */
   agenrPath?: string;
   /** Token budget for recall (default: 2000) */
   budget?: number;

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -1,0 +1,54 @@
+// Local type aliases for OpenClaw plugin SDK types.
+// These mirror the shapes in openclaw/dist/plugin-sdk/ without creating a dependency.
+
+export type BootstrapFile = {
+  name: string;
+  path: string;
+  content?: string;
+  missing: boolean;
+};
+
+export type BootstrapHookContext = {
+  bootstrapFiles: BootstrapFile[];
+  sessionKey?: string;
+  workspaceDir?: string;
+  sessionId?: string;
+  agentId?: string;
+};
+
+export type HookEvent = {
+  type: string;
+  action: string;
+  sessionKey: string;
+  context: Record<string, unknown>;
+  timestamp: Date;
+  messages: string[];
+};
+
+export type PluginLogger = {
+  debug?: (message: string) => void;
+  info?: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+};
+
+export type PluginApi = {
+  id: string;
+  name: string;
+  version?: string;
+  pluginConfig?: Record<string, unknown>;
+  logger: PluginLogger;
+  registerHook: (
+    events: string | string[],
+    handler: (event: HookEvent) => Promise<void> | void
+  ) => void;
+};
+
+export type AgenrPluginConfig = {
+  /** Path to agenr CLI entry point (dist/cli.js). Defaults to AGENR_BIN env or ~/Code/agenr-local/dist/cli.js */
+  agenrPath?: string;
+  /** Token budget for recall (default: 2000) */
+  budget?: number;
+  /** Set to false to disable memory injection without removing the plugin */
+  enabled?: boolean;
+};

--- a/tests/openclaw-plugin/plugin.test.ts
+++ b/tests/openclaw-plugin/plugin.test.ts
@@ -1,0 +1,213 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+describe("agenr OpenClaw plugin", () => {
+  it("exports a default object with id 'agenr' and a register function", async () => {
+    const mod = await import("../../src/openclaw-plugin/index.js");
+    const plugin = mod.default;
+    expect(plugin.id).toBe("agenr");
+    expect(typeof plugin.register).toBe("function");
+  });
+
+  it("register calls api.registerHook with 'agent:bootstrap'", async () => {
+    const mod = await import("../../src/openclaw-plugin/index.js");
+    const plugin = mod.default;
+
+    const registeredEvents: string[] = [];
+    const mockApi = {
+      id: "agenr",
+      name: "agenr",
+      pluginConfig: undefined,
+      logger: { warn: vi.fn(), error: vi.fn() },
+      registerHook: (events: string | string[], _handler: unknown) => {
+        const list = Array.isArray(events) ? events : [events];
+        registeredEvents.push(...list);
+      },
+    };
+
+    await plugin.register(mockApi as never);
+    expect(registeredEvents).toContain("agent:bootstrap");
+  });
+
+  it("bootstrap handler pushes exactly one file when recall returns valid content", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/openclaw-plugin/recall.js", () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall: vi.fn(async () => ({
+        query: "",
+        results: [
+          {
+            entry: { type: "fact", subject: "subject", content: "content" },
+            score: 0.99,
+          },
+        ],
+      })),
+      formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context\n\n### Facts and Events\n\n- [subject] content"),
+    }));
+
+    const mod = await import("../../src/openclaw-plugin/index.js");
+    const plugin = mod.default;
+
+    let capturedHandler: ((event: unknown) => Promise<void>) | null = null;
+    const mockApi = {
+      id: "agenr",
+      name: "agenr",
+      pluginConfig: undefined,
+      logger: { warn: vi.fn(), error: vi.fn() },
+      registerHook: (_events: unknown, handler: (event: unknown) => Promise<void>) => {
+        capturedHandler = handler;
+      },
+    };
+
+    await plugin.register(mockApi as never);
+
+    const bootstrapFiles: Array<{ path?: string; name?: string; content?: string }> = [];
+    await capturedHandler?.({
+      type: "agent",
+      action: "bootstrap",
+      sessionKey: "agent:main:interactive",
+      context: { bootstrapFiles, sessionKey: "agent:main:interactive" },
+      timestamp: new Date(),
+      messages: [],
+    });
+
+    expect(bootstrapFiles).toHaveLength(1);
+    expect(bootstrapFiles[0]?.name).toBe("AGENR.md");
+    expect(bootstrapFiles[0]?.path).toBe(path.join(os.homedir(), ".agenr", "AGENR.md"));
+    expect(bootstrapFiles[0]?.content).toContain("## agenr Memory Context");
+
+    vi.doUnmock("../../src/openclaw-plugin/recall.js");
+    vi.resetModules();
+  });
+
+  it("bootstrap handler does not push to bootstrapFiles for subagent sessions", async () => {
+    const mod = await import("../../src/openclaw-plugin/index.js");
+    const plugin = mod.default;
+
+    let capturedHandler: ((event: unknown) => Promise<void>) | null = null;
+    const mockApi = {
+      id: "agenr",
+      name: "agenr",
+      pluginConfig: { agenrPath: "/nonexistent/cli.js" },
+      logger: { warn: vi.fn(), error: vi.fn() },
+      registerHook: (_events: unknown, handler: (event: unknown) => Promise<void>) => {
+        capturedHandler = handler;
+      },
+    };
+
+    await plugin.register(mockApi as never);
+    expect(capturedHandler).not.toBeNull();
+
+    const bootstrapFiles: unknown[] = [];
+    await capturedHandler?.({
+      type: "agent",
+      action: "bootstrap",
+      sessionKey: "agent:main:subagent:abc123",
+      context: {
+        bootstrapFiles,
+        sessionKey: "agent:main:subagent:abc123",
+      },
+      timestamp: new Date(),
+      messages: [],
+    });
+
+    expect(bootstrapFiles).toHaveLength(0);
+  });
+
+  it("bootstrap handler does not push to bootstrapFiles for cron sessions", async () => {
+    const mod = await import("../../src/openclaw-plugin/index.js");
+    const plugin = mod.default;
+
+    let capturedHandler: ((event: unknown) => Promise<void>) | null = null;
+    const mockApi = {
+      id: "agenr",
+      name: "agenr",
+      pluginConfig: { agenrPath: "/nonexistent/cli.js" },
+      logger: { warn: vi.fn(), error: vi.fn() },
+      registerHook: (_events: unknown, handler: (event: unknown) => Promise<void>) => {
+        capturedHandler = handler;
+      },
+    };
+
+    await plugin.register(mockApi as never);
+
+    const bootstrapFiles: unknown[] = [];
+    await capturedHandler?.({
+      type: "agent",
+      action: "bootstrap",
+      sessionKey: "agent:main:cron:heartbeat",
+      context: {
+        bootstrapFiles,
+        sessionKey: "agent:main:cron:heartbeat",
+      },
+      timestamp: new Date(),
+      messages: [],
+    });
+
+    expect(bootstrapFiles).toHaveLength(0);
+  });
+
+  it("bootstrap handler does not push when config.enabled is false", async () => {
+    const mod = await import("../../src/openclaw-plugin/index.js");
+    const plugin = mod.default;
+
+    let capturedHandler: ((event: unknown) => Promise<void>) | null = null;
+    const mockApi = {
+      id: "agenr",
+      name: "agenr",
+      pluginConfig: { enabled: false },
+      logger: { warn: vi.fn(), error: vi.fn() },
+      registerHook: (_events: unknown, handler: (event: unknown) => Promise<void>) => {
+        capturedHandler = handler;
+      },
+    };
+
+    await plugin.register(mockApi as never);
+
+    const bootstrapFiles: unknown[] = [];
+    await capturedHandler?.({
+      type: "agent",
+      action: "bootstrap",
+      sessionKey: "agent:main",
+      context: { bootstrapFiles, sessionKey: "agent:main" },
+      timestamp: new Date(),
+      messages: [],
+    });
+
+    expect(bootstrapFiles).toHaveLength(0);
+  });
+
+  it("bootstrap handler resolves without throwing when agenr path does not exist", async () => {
+    const mod = await import("../../src/openclaw-plugin/index.js");
+    const plugin = mod.default;
+
+    let capturedHandler: ((event: unknown) => Promise<void>) | null = null;
+    const mockApi = {
+      id: "agenr",
+      name: "agenr",
+      pluginConfig: { agenrPath: "/nonexistent/path/that/does/not/exist/cli.js" },
+      logger: { warn: vi.fn(), error: vi.fn() },
+      registerHook: (_events: unknown, handler: (event: unknown) => Promise<void>) => {
+        capturedHandler = handler;
+      },
+    };
+
+    await plugin.register(mockApi as never);
+
+    const bootstrapFiles: unknown[] = [];
+    await expect(
+      capturedHandler?.({
+        type: "agent",
+        action: "bootstrap",
+        sessionKey: "agent:main",
+        context: { bootstrapFiles, sessionKey: "agent:main" },
+        timestamp: new Date(),
+        messages: [],
+      })
+    ).resolves.toBeUndefined();
+
+    expect(bootstrapFiles).toHaveLength(0);
+  });
+});

--- a/tests/openclaw-plugin/recall.test.ts
+++ b/tests/openclaw-plugin/recall.test.ts
@@ -122,8 +122,10 @@ describe("resolveAgenrPath", () => {
     delete process.env["AGENR_BIN"];
     try {
       const resolved = resolveAgenrPath(undefined);
-      expect(resolved).toContain("agenr-local");
+      expect(resolved).toContain("dist");
       expect(resolved).toContain("cli.js");
+      expect(resolved).toMatch(/[\\/]dist[\\/]cli\.js$/);
+      expect(resolved).not.toContain("agenr-local");
     } finally {
       if (original !== undefined) {
         process.env["AGENR_BIN"] = original;

--- a/tests/openclaw-plugin/recall.test.ts
+++ b/tests/openclaw-plugin/recall.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { formatRecallAsMarkdown, resolveAgenrPath } from "../../src/openclaw-plugin/recall.js";
+import type { RecallResult } from "../../src/openclaw-plugin/recall.js";
+
+function makeResult(entries: Array<{ type: string; subject: string; content: string }>): RecallResult {
+  return {
+    query: "",
+    results: entries.map((entry) => ({
+      entry: { ...entry, importance: 6 },
+      score: 0.9,
+    })),
+  };
+}
+
+describe("formatRecallAsMarkdown", () => {
+  it("returns empty string when results array is empty", () => {
+    const result = formatRecallAsMarkdown({ query: "", results: [] });
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when all entries are invalid (missing required fields)", () => {
+    const result = formatRecallAsMarkdown({
+      query: "",
+      results: [{ entry: { type: "fact" } as never, score: 0.9 }],
+    });
+    expect(result).toBe("");
+  });
+
+  it("groups todo entries under Active Todos section", () => {
+    const result = formatRecallAsMarkdown(
+      makeResult([{ type: "todo", subject: "fix bug", content: "Fix the null crash" }])
+    );
+    expect(result).toContain("### Active Todos");
+    expect(result).toContain("[fix bug] Fix the null crash");
+  });
+
+  it("groups decision entries under Preferences and Decisions section", () => {
+    const result = formatRecallAsMarkdown(
+      makeResult([{ type: "decision", subject: "use vitest", content: "Use vitest for all tests" }])
+    );
+    expect(result).toContain("### Preferences and Decisions");
+    expect(result).toContain("[use vitest] Use vitest for all tests");
+  });
+
+  it("groups preference entries under Preferences and Decisions section", () => {
+    const result = formatRecallAsMarkdown(
+      makeResult([{ type: "preference", subject: "dark mode", content: "Prefers dark mode in all UIs" }])
+    );
+    expect(result).toContain("### Preferences and Decisions");
+    expect(result).toContain("[dark mode] Prefers dark mode in all UIs");
+  });
+
+  it("groups fact and event entries under Facts and Events section", () => {
+    const result = formatRecallAsMarkdown(
+      makeResult([
+        { type: "fact", subject: "home dir", content: "Home directory is /Users/jmartin" },
+        { type: "event", subject: "launch", content: "Launched agenr v0.6.4" },
+      ])
+    );
+    expect(result).toContain("### Facts and Events");
+    expect(result).toContain("[home dir] Home directory is /Users/jmartin");
+    expect(result).toContain("[launch] Launched agenr v0.6.4");
+  });
+
+  it("renders all three sections when mixed types are present", () => {
+    const result = formatRecallAsMarkdown(
+      makeResult([
+        { type: "todo", subject: "a", content: "do a" },
+        { type: "decision", subject: "b", content: "chose b" },
+        { type: "fact", subject: "c", content: "fact c" },
+      ])
+    );
+    expect(result).toContain("### Active Todos");
+    expect(result).toContain("### Preferences and Decisions");
+    expect(result).toContain("### Facts and Events");
+  });
+
+  it("includes the top-level agenr Memory Context header", () => {
+    const result = formatRecallAsMarkdown(makeResult([{ type: "fact", subject: "x", content: "y" }]));
+    expect(result).toContain("## agenr Memory Context");
+  });
+
+  it("gracefully skips entries with missing required fields", () => {
+    const result = formatRecallAsMarkdown({
+      query: "",
+      results: [
+        { entry: { type: "fact", subject: "good", content: "valid entry" }, score: 1 },
+        { entry: { type: "fact" } as never, score: 0.5 },
+        { entry: { subject: "no type" } as never, score: 0.3 },
+        { entry: null as never, score: 0.1 },
+      ],
+    });
+    expect(result).toContain("[good] valid entry");
+    const lines = result.split("\n").filter((line) => line.startsWith("- "));
+    expect(lines).toHaveLength(1);
+  });
+});
+
+describe("resolveAgenrPath", () => {
+  it("returns config.agenrPath when provided", () => {
+    const resolved = resolveAgenrPath({ agenrPath: "/custom/path/cli.js" });
+    expect(resolved).toBe("/custom/path/cli.js");
+  });
+
+  it("falls back to AGENR_BIN env var when config is empty", () => {
+    const original = process.env["AGENR_BIN"];
+    process.env["AGENR_BIN"] = "/env/agenr/cli.js";
+    try {
+      const resolved = resolveAgenrPath({});
+      expect(resolved).toBe("/env/agenr/cli.js");
+    } finally {
+      if (original === undefined) {
+        delete process.env["AGENR_BIN"];
+      } else {
+        process.env["AGENR_BIN"] = original;
+      }
+    }
+  });
+
+  it("falls back to default path when nothing is configured", () => {
+    const original = process.env["AGENR_BIN"];
+    delete process.env["AGENR_BIN"];
+    try {
+      const resolved = resolveAgenrPath(undefined);
+      expect(resolved).toContain("agenr-local");
+      expect(resolved).toContain("cli.js");
+    } finally {
+      if (original !== undefined) {
+        process.env["AGENR_BIN"] = original;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds an OpenClaw plugin that injects agenr memory context automatically at every session start - no tool calls, no rituals, no agent awareness required. Memory just appears in `# Project Context` alongside SOUL.md and MEMORY.md.

## What Changed

**New files:**
- `src/openclaw-plugin/index.ts` - plugin entry point, registers `agent:bootstrap` hook
- `src/openclaw-plugin/recall.ts` - runs agenr CLI recall, formats JSON as grouped markdown
- `src/openclaw-plugin/types.ts` - local OpenClaw SDK type aliases (no hard peer dependency)
- `openclaw.plugin.json` - manifest at repo root (required for OpenClaw plugin discovery)

**Modified:**
- `package.json` - `"openclaw": { "extensions": ["dist/openclaw-plugin/index.js"] }`, tsup build entry, version 0.6.6
- `CHANGELOG.md` - v0.6.6 section

**Key implementation details:**
- Uses `agent:bootstrap` hook - fires before system prompt is assembled, same mechanism as SOUL.md/MEMORY.md injection
- Skips subagent and cron sessions automatically (`:subagent:`, `:cron:` pattern check)
- Never blocks session start - entire handler wrapped in try/catch, all recall errors return null
- 5s timeout on recall subprocess
- agenr binary path: `config.agenrPath` -> `AGENR_BIN` env -> `import.meta.url` relative (works for any npm install)
- Output grouped as: Active Todos / Preferences and Decisions / Facts and Events

## End-User Install

```bash
openclaw plugins install agenr
agenr watch
```

That's it. No config editing required.

## Tests

668 tests passing. New coverage in `tests/openclaw-plugin/`:
- Plugin registration and hook firing
- Subagent + cron session filtering
- Binary-not-found error resilience
- Exactly one file pushed to bootstrapFiles on success
- Full formatter coverage: todos, preferences+decisions, facts+events, empty results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced agenr Memory plugin that automatically injects memory context into agent sessions, organizing information into Active Todos, Preferences & Decisions, and Facts & Events sections.

* **Chores**
  * Version bumped to 0.6.6.
  * Plugin is configurable via openclaw.json with path and budget settings.
  * Automatically skips memory injection for subagent and cron sessions.
  * Added comprehensive test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->