### PR TITLE
fix(openclaw-plugin): add name to registerHook opts (v0.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.7] - 2026-02-19
+
+### Fixed
+- fix(openclaw-plugin): add name and description to registerHook opts to resolve OpenClaw hook registration warning
+
 # Changelog
 
 ## [0.6.6] - 2026-02-19

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "openclaw": {
     "extensions": ["dist/openclaw-plugin/index.js"]
   },

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -70,7 +70,7 @@ const plugin = {
       } catch {
         // Never block session start - swallow all errors silently.
       }
-    });
+    }, { name: "agenr-memory", description: "Inject agenr memory context at session start" });
   },
 };
 

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -40,7 +40,8 @@ export type PluginApi = {
   logger: PluginLogger;
   registerHook: (
     events: string | string[],
-    handler: (event: HookEvent) => Promise<void> | void
+    handler: (event: HookEvent) => Promise<void> | void,
+    opts?: { name?: string; description?: string; priority?: number }
   ) => void;
 };
 


### PR DESCRIPTION
Hotfix for v0.6.6 OpenClaw plugin. OpenClaw's `registerHook` requires a `name` field in the opts argument - without it the doctor command shows a warning and the hook may not register correctly. Adds `{ name: 'agenr-memory', description: '...' }` as the third argument. Also updates the local `PluginApi` type alias in `types.ts` to include the optional `opts` parameter. 667 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a hook registration warning by adding metadata support to plugin registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->