### PR TITLE
fix(openclaw-plugin): use api.on(before_agent_start) instead of registerHook (v0.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [0.6.8] - 2026-02-19
 
 ### Fixed
@@ -7,8 +9,6 @@
 
 ### Fixed
 - fix(openclaw-plugin): add name and description to registerHook opts to resolve OpenClaw hook registration warning
-
-# Changelog
 
 ## [0.6.6] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.8] - 2026-02-19
+
+### Fixed
+- fix(openclaw-plugin): OpenClaw plugin now uses api.on("before_agent_start") instead of api.registerHook("agent:bootstrap"). The previous approach registered the handler in the gateway bundle's internal handlers map, which is a different module instance from the embedded agent runner. The typed hook system (api.on) uses the shared global plugin registry and works correctly across both bundles.
+
 ## [0.6.7] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "openclaw": {
     "extensions": ["dist/openclaw-plugin/index.js"]
   },

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -47,8 +47,11 @@ const plugin = {
           }
 
           return { prependContext: markdown };
-        } catch {
-          // Never block session start - swallow all errors silently.
+        } catch (err) {
+          // Never block session start - log and swallow.
+          api.logger.warn(
+            `agenr plugin before_agent_start recall failed: ${err instanceof Error ? err.message : String(err)}`
+          );
           return;
         }
       }

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -1,28 +1,14 @@
 // Local type aliases for OpenClaw plugin SDK types.
 // These mirror the shapes in openclaw/dist/plugin-sdk/ without creating a dependency.
 
-export type BootstrapFile = {
-  name: string;
-  path: string;
-  content?: string;
-  missing: boolean;
-};
-
-export type BootstrapHookContext = {
-  bootstrapFiles: BootstrapFile[];
+export type BeforeAgentStartEvent = {
   sessionKey?: string;
-  workspaceDir?: string;
-  sessionId?: string;
-  agentId?: string;
+  prompt?: string;
+  [key: string]: unknown;
 };
 
-export type HookEvent = {
-  type: string;
-  action: string;
-  sessionKey: string;
-  context: Record<string, unknown>;
-  timestamp: Date;
-  messages: string[];
+export type BeforeAgentStartResult = {
+  prependContext?: string;
 };
 
 export type PluginLogger = {
@@ -38,10 +24,11 @@ export type PluginApi = {
   version?: string;
   pluginConfig?: Record<string, unknown>;
   logger: PluginLogger;
-  registerHook: (
-    events: string | string[],
-    handler: (event: HookEvent) => Promise<void> | void,
-    opts?: { name?: string; description?: string; priority?: number }
+  on: (
+    hook: "before_agent_start",
+    handler: (
+      event: BeforeAgentStartEvent
+    ) => Promise<BeforeAgentStartResult | undefined> | BeforeAgentStartResult | undefined
   ) => void;
 };
 

--- a/tests/openclaw-plugin/plugin.test.ts
+++ b/tests/openclaw-plugin/plugin.test.ts
@@ -66,8 +66,11 @@ describe("agenr OpenClaw plugin", () => {
 
     await plugin.register(mockApi as never);
     expect(capturedHandler).not.toBeNull();
+    if (!capturedHandler) {
+      throw new Error("Expected before_agent_start handler to be registered");
+    }
 
-    const result = await capturedHandler?.({
+    const result = await capturedHandler({
       sessionKey: "agent:main:interactive",
       prompt: "test prompt",
     });
@@ -99,8 +102,11 @@ describe("agenr OpenClaw plugin", () => {
 
     await plugin.register(mockApi as never);
     expect(capturedHandler).not.toBeNull();
+    if (!capturedHandler) {
+      throw new Error("Expected before_agent_start handler to be registered");
+    }
 
-    const result = await capturedHandler?.({
+    const result = await capturedHandler({
       sessionKey: "agent:main:subagent:abc123",
     });
     expect(result).toBeUndefined();
@@ -127,8 +133,12 @@ describe("agenr OpenClaw plugin", () => {
     };
 
     await plugin.register(mockApi as never);
+    expect(capturedHandler).not.toBeNull();
+    if (!capturedHandler) {
+      throw new Error("Expected before_agent_start handler to be registered");
+    }
 
-    const result = await capturedHandler?.({
+    const result = await capturedHandler({
       sessionKey: "agent:main:cron:heartbeat",
     });
 
@@ -156,8 +166,12 @@ describe("agenr OpenClaw plugin", () => {
     };
 
     await plugin.register(mockApi as never);
+    expect(capturedHandler).not.toBeNull();
+    if (!capturedHandler) {
+      throw new Error("Expected before_agent_start handler to be registered");
+    }
 
-    const result = await capturedHandler?.({
+    const result = await capturedHandler({
       sessionKey: "agent:main",
     });
 
@@ -165,6 +179,14 @@ describe("agenr OpenClaw plugin", () => {
   });
 
   it("before_agent_start handler resolves without throwing when agenr path does not exist", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/openclaw-plugin/recall.js", () => ({
+      resolveAgenrPath: vi.fn(() => "/nonexistent/path/that/does/not/exist/cli.js"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall: vi.fn(async () => null),
+      formatRecallAsMarkdown: vi.fn(() => ""),
+    }));
+
     const mod = await import("../../src/openclaw-plugin/index.js");
     const plugin = mod.default;
 
@@ -185,7 +207,14 @@ describe("agenr OpenClaw plugin", () => {
     };
 
     await plugin.register(mockApi as never);
+    expect(capturedHandler).not.toBeNull();
+    if (!capturedHandler) {
+      throw new Error("Expected before_agent_start handler to be registered");
+    }
 
-    await expect(capturedHandler?.({ sessionKey: "agent:main" })).resolves.toBeUndefined();
+    await expect(capturedHandler({ sessionKey: "agent:main" })).resolves.toBeUndefined();
+
+    vi.doUnmock("../../src/openclaw-plugin/recall.js");
+    vi.resetModules();
   });
 });


### PR DESCRIPTION
## Problem

The OpenClaw plugin registered the memory injection handler via `api.registerHook("agent:bootstrap", ...)` but the hook never fired.

**Root cause:** `api.registerHook` adds the handler to the internal `handlers` map inside the gateway bundle (`entry.js`, inlined code). When a new session starts, `applyBootstrapHookOverrides` fires `triggerInternalHook` from the embedded agent runner (`pi-embedded-BxoxxVJz.js`), which imports its registry from the external `registry-B3v_dMjW.js` module. These are two separate `handlers` map instances. The handler was never in the embedded agent's map. `allHandlers.length === 0` and the event returned without calling anything.

## Fix

Switch to `api.on("before_agent_start", handler)`, which uses the typed hook system stored in the global plugin registry (`Symbol.for("openclaw.pluginRegistryState")`). This IS shared across both bundles. Return `{ prependContext: markdown }` to inject content.

This is the same pattern used by the stock `memory-lancedb` plugin.

## Changes

- `src/openclaw-plugin/index.ts`: swap `registerHook` -> `api.on`, return `{ prependContext }` instead of mutating `bootstrapFiles`
- `src/openclaw-plugin/types.ts`: remove bootstrap event types, add `BeforeAgentStartEvent` / `BeforeAgentStartResult`
- `tests/openclaw-plugin/plugin.test.ts`: updated tests for new hook signature
- `package.json`: version bump to 0.6.8
- `CHANGELOG.md`: v0.6.8 entry

## Testing

- Unit tests updated and passing
- Verified against memory-lancedb reference implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed openclaw-plugin handler registration so long-term memory injection initializes reliably across sessions and bundles.
* **Release**
  * Bumped package to version 0.6.8 and added corresponding changelog entry.
* **Tests**
  * Updated lifecycle tests to validate the new initialization flow and expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->