### PR TITLE
fix(openclaw-plugin): session dedup, ctx.sessionKey, path fix, spawn detection, AGENR.md write (v0.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.9] - 2026-02-19
+
+### Fixed
+- OpenClaw plugin: session-seen guard prevents recall firing on every turn (fires once per session)
+- OpenClaw plugin: sessionKey now read from ctx (second handler arg) instead of event
+- OpenClaw plugin: DEFAULT_AGENR_PATH uses correct 2-level relative path to dist/cli.js
+- OpenClaw plugin: spawn strategy detects .js vs executable binary
+
+### Added
+- OpenClaw plugin: writes AGENR.md to ctx.workspaceDir after successful recall (fire-and-forget)
+
 ## [0.6.8] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "openclaw": {
     "extensions": ["dist/openclaw-plugin/index.js"]
   },

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -2,8 +2,14 @@
 // These mirror the shapes in openclaw/dist/plugin-sdk/ without creating a dependency.
 
 export type BeforeAgentStartEvent = {
-  sessionKey?: string;
   prompt?: string;
+  messages?: unknown[];
+  [key: string]: unknown;
+};
+
+export type PluginHookAgentContext = {
+  sessionKey?: string;
+  workspaceDir?: string;
   [key: string]: unknown;
 };
 
@@ -27,7 +33,8 @@ export type PluginApi = {
   on: (
     hook: "before_agent_start",
     handler: (
-      event: BeforeAgentStartEvent
+      event: BeforeAgentStartEvent,
+      ctx: PluginHookAgentContext
     ) => Promise<BeforeAgentStartResult | undefined> | BeforeAgentStartResult | undefined
   ) => void;
 };

--- a/tests/openclaw-plugin/plugin.test.ts
+++ b/tests/openclaw-plugin/plugin.test.ts
@@ -1,16 +1,66 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BeforeAgentStartEvent, BeforeAgentStartResult } from "../../src/openclaw-plugin/types.js";
+
+type PluginHookAgentContext = {
+  sessionKey?: string;
+  workspaceDir?: string;
+  [key: string]: unknown;
+};
+
+type BeforeAgentStartHandler = (
+  event: BeforeAgentStartEvent,
+  ctx?: PluginHookAgentContext
+) => Promise<BeforeAgentStartResult | undefined>;
+
+const recallModulePath = "../../src/openclaw-plugin/recall.js";
+const indexModulePath = "../../src/openclaw-plugin/index.js";
+
+async function registerPlugin(
+  pluginConfig?: Record<string, unknown>
+): Promise<{
+  handler: BeforeAgentStartHandler;
+  loggerWarn: ReturnType<typeof vi.fn>;
+}> {
+  const mod = await import(indexModulePath);
+  const plugin = mod.default;
+
+  let capturedHandler: BeforeAgentStartHandler | null = null;
+  const loggerWarn = vi.fn();
+  const mockApi = {
+    id: "agenr",
+    name: "agenr",
+    pluginConfig,
+    logger: { warn: loggerWarn, error: vi.fn() },
+    on: (_hook: string, handler: BeforeAgentStartHandler) => {
+      capturedHandler = handler;
+    },
+  };
+
+  plugin.register(mockApi as never);
+  if (!capturedHandler) {
+    throw new Error("Expected before_agent_start handler to be registered");
+  }
+
+  return { handler: capturedHandler, loggerWarn };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock(recallModulePath);
+});
 
 describe("agenr OpenClaw plugin", () => {
   it("exports a default object with id 'agenr' and a register function", async () => {
-    const mod = await import("../../src/openclaw-plugin/index.js");
+    vi.resetModules();
+    const mod = await import(indexModulePath);
     const plugin = mod.default;
     expect(plugin.id).toBe("agenr");
     expect(typeof plugin.register).toBe("function");
   });
 
   it("register calls api.on with 'before_agent_start'", async () => {
-    const mod = await import("../../src/openclaw-plugin/index.js");
+    vi.resetModules();
+    const mod = await import(indexModulePath);
     const plugin = mod.default;
 
     const registeredHooks: string[] = [];
@@ -24,197 +74,183 @@ describe("agenr OpenClaw plugin", () => {
       },
     };
 
-    await plugin.register(mockApi as never);
+    plugin.register(mockApi as never);
     expect(registeredHooks).toContain("before_agent_start");
   });
 
-  it("before_agent_start handler returns prependContext when recall returns valid content", async () => {
+  it("before_agent_start returns prependContext when recall returns valid content", async () => {
     vi.resetModules();
-    vi.doMock("../../src/openclaw-plugin/recall.js", () => ({
+    vi.doMock(recallModulePath, () => ({
       resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
       resolveBudget: vi.fn(() => 2000),
       runRecall: vi.fn(async () => ({
         query: "",
-        results: [
-          {
-            entry: { type: "fact", subject: "subject", content: "content" },
-            score: 0.99,
-          },
-        ],
+        results: [{ entry: { type: "fact", subject: "subject", content: "content" }, score: 0.99 }],
       })),
       formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context\n\n### Facts and Events\n\n- [subject] content"),
+      formatRecallAsSummary: vi.fn(() => "## agenr Memory\n\n1 entries recalled."),
+      writeAgenrMd: vi.fn(async () => {}),
     }));
 
-    const mod = await import("../../src/openclaw-plugin/index.js");
-    const plugin = mod.default;
+    const { handler } = await registerPlugin();
+    const result = await handler(
+      { prompt: "test prompt" },
+      { sessionKey: "agent:main:test-prepend-context", workspaceDir: "/tmp/workspace" }
+    );
 
-    let capturedHandler:
-      | ((event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>)
-      | null = null;
-    const mockApi = {
-      id: "agenr",
-      name: "agenr",
-      pluginConfig: undefined,
-      logger: { warn: vi.fn(), error: vi.fn() },
-      on: (
-        _hook: string,
-        handler: (event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>
-      ) => {
-        capturedHandler = handler;
-      },
-    };
-
-    await plugin.register(mockApi as never);
-    expect(capturedHandler).not.toBeNull();
-    if (!capturedHandler) {
-      throw new Error("Expected before_agent_start handler to be registered");
-    }
-
-    const result = await capturedHandler({
-      sessionKey: "agent:main:interactive",
-      prompt: "test prompt",
-    });
     expect(result?.prependContext).toContain("## agenr Memory Context");
+  });
 
-    vi.doUnmock("../../src/openclaw-plugin/recall.js");
+  it("runs recall only once for repeated calls with the same sessionKey", async () => {
     vi.resetModules();
-  });
-
-  it("before_agent_start handler returns undefined for subagent sessions", async () => {
-    const mod = await import("../../src/openclaw-plugin/index.js");
-    const plugin = mod.default;
-
-    let capturedHandler:
-      | ((event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>)
-      | null = null;
-    const mockApi = {
-      id: "agenr",
-      name: "agenr",
-      pluginConfig: { agenrPath: "/nonexistent/cli.js" },
-      logger: { warn: vi.fn(), error: vi.fn() },
-      on: (
-        _hook: string,
-        handler: (event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>
-      ) => {
-        capturedHandler = handler;
-      },
-    };
-
-    await plugin.register(mockApi as never);
-    expect(capturedHandler).not.toBeNull();
-    if (!capturedHandler) {
-      throw new Error("Expected before_agent_start handler to be registered");
-    }
-
-    const result = await capturedHandler({
-      sessionKey: "agent:main:subagent:abc123",
-    });
-    expect(result).toBeUndefined();
-  });
-
-  it("before_agent_start handler returns undefined for cron sessions", async () => {
-    const mod = await import("../../src/openclaw-plugin/index.js");
-    const plugin = mod.default;
-
-    let capturedHandler:
-      | ((event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>)
-      | null = null;
-    const mockApi = {
-      id: "agenr",
-      name: "agenr",
-      pluginConfig: { agenrPath: "/nonexistent/cli.js" },
-      logger: { warn: vi.fn(), error: vi.fn() },
-      on: (
-        _hook: string,
-        handler: (event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>
-      ) => {
-        capturedHandler = handler;
-      },
-    };
-
-    await plugin.register(mockApi as never);
-    expect(capturedHandler).not.toBeNull();
-    if (!capturedHandler) {
-      throw new Error("Expected before_agent_start handler to be registered");
-    }
-
-    const result = await capturedHandler({
-      sessionKey: "agent:main:cron:heartbeat",
-    });
-
-    expect(result).toBeUndefined();
-  });
-
-  it("before_agent_start handler returns undefined when config.enabled is false", async () => {
-    const mod = await import("../../src/openclaw-plugin/index.js");
-    const plugin = mod.default;
-
-    let capturedHandler:
-      | ((event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>)
-      | null = null;
-    const mockApi = {
-      id: "agenr",
-      name: "agenr",
-      pluginConfig: { enabled: false },
-      logger: { warn: vi.fn(), error: vi.fn() },
-      on: (
-        _hook: string,
-        handler: (event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>
-      ) => {
-        capturedHandler = handler;
-      },
-    };
-
-    await plugin.register(mockApi as never);
-    expect(capturedHandler).not.toBeNull();
-    if (!capturedHandler) {
-      throw new Error("Expected before_agent_start handler to be registered");
-    }
-
-    const result = await capturedHandler({
-      sessionKey: "agent:main",
-    });
-
-    expect(result).toBeUndefined();
-  });
-
-  it("before_agent_start handler resolves without throwing when agenr path does not exist", async () => {
-    vi.resetModules();
-    vi.doMock("../../src/openclaw-plugin/recall.js", () => ({
-      resolveAgenrPath: vi.fn(() => "/nonexistent/path/that/does/not/exist/cli.js"),
+    const runRecall = vi.fn(async () => ({
+      query: "",
+      results: [{ entry: { type: "fact", subject: "subject", content: "content" }, score: 0.99 }],
+    }));
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
       resolveBudget: vi.fn(() => 2000),
-      runRecall: vi.fn(async () => null),
-      formatRecallAsMarkdown: vi.fn(() => ""),
+      runRecall,
+      formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context"),
+      formatRecallAsSummary: vi.fn(() => "## agenr Memory\n\n1 entries recalled."),
+      writeAgenrMd: vi.fn(async () => {}),
     }));
 
-    const mod = await import("../../src/openclaw-plugin/index.js");
-    const plugin = mod.default;
+    const { handler } = await registerPlugin();
+    const first = await handler({}, { sessionKey: "agent:main:test-dedup-same" });
+    const second = await handler({}, { sessionKey: "agent:main:test-dedup-same" });
 
-    let capturedHandler:
-      | ((event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>)
-      | null = null;
-    const mockApi = {
-      id: "agenr",
-      name: "agenr",
-      pluginConfig: { agenrPath: "/nonexistent/path/that/does/not/exist/cli.js" },
-      logger: { warn: vi.fn(), error: vi.fn() },
-      on: (
-        _hook: string,
-        handler: (event: BeforeAgentStartEvent) => Promise<BeforeAgentStartResult | undefined>
-      ) => {
-        capturedHandler = handler;
-      },
-    };
+    expect(first?.prependContext).toContain("## agenr Memory Context");
+    expect(second).toBeUndefined();
+    expect(runRecall).toHaveBeenCalledTimes(1);
+  });
 
-    await plugin.register(mockApi as never);
-    expect(capturedHandler).not.toBeNull();
-    if (!capturedHandler) {
-      throw new Error("Expected before_agent_start handler to be registered");
-    }
-
-    await expect(capturedHandler({ sessionKey: "agent:main" })).resolves.toBeUndefined();
-
-    vi.doUnmock("../../src/openclaw-plugin/recall.js");
+  it("runs recall for each distinct sessionKey", async () => {
     vi.resetModules();
+    const runRecall = vi.fn(async () => ({
+      query: "",
+      results: [{ entry: { type: "fact", subject: "subject", content: "content" }, score: 0.99 }],
+    }));
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall,
+      formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context"),
+      formatRecallAsSummary: vi.fn(() => "## agenr Memory\n\n1 entries recalled."),
+      writeAgenrMd: vi.fn(async () => {}),
+    }));
+
+    const { handler } = await registerPlugin();
+    await handler({}, { sessionKey: "agent:main:test-distinct-1" });
+    await handler({}, { sessionKey: "agent:main:test-distinct-2" });
+
+    expect(runRecall).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads sessionKey from ctx (second arg), not from event", async () => {
+    vi.resetModules();
+    const runRecall = vi.fn(async () => ({
+      query: "",
+      results: [{ entry: { type: "fact", subject: "subject", content: "content" }, score: 0.99 }],
+    }));
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall,
+      formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context"),
+      formatRecallAsSummary: vi.fn(() => "## agenr Memory\n\n1 entries recalled."),
+      writeAgenrMd: vi.fn(async () => {}),
+    }));
+
+    const { handler } = await registerPlugin();
+    const result = await handler(
+      { sessionKey: "agent:main:interactive" },
+      { sessionKey: "agent:main:subagent:abc123" }
+    );
+
+    expect(result).toBeUndefined();
+    expect(runRecall).not.toHaveBeenCalled();
+  });
+
+  it("calls writeAgenrMd with summary content and ctx.workspaceDir when markdown is present", async () => {
+    vi.resetModules();
+    const writeAgenrMd = vi.fn(async () => {});
+    const summaryOutput = [
+      "## agenr Memory -- 2026-02-19 13:51",
+      "",
+      "1 entries recalled. Full context injected into this session automatically.",
+      "To pull specific memories: ask your agent, or run:",
+      '  mcporter call agenr.agenr_recall query="your topic" limit=5',
+      "",
+      "### Facts and Events (1)",
+      "",
+      "- subject",
+    ].join("\n");
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall: vi.fn(async () => ({
+        query: "",
+        results: [{ entry: { type: "fact", subject: "subject", content: "full content body" }, score: 0.99 }],
+      })),
+      formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context\n\n### Facts and Events\n\n- [subject] full content body"),
+      formatRecallAsSummary: vi.fn(() => summaryOutput),
+      writeAgenrMd,
+    }));
+
+    const { handler } = await registerPlugin();
+    await handler({}, { sessionKey: "agent:main:test-write-md", workspaceDir: "/tmp/workspace" });
+
+    expect(writeAgenrMd).toHaveBeenCalledTimes(1);
+    const [content, workspace] = writeAgenrMd.mock.calls[0] as [string, string];
+    expect(workspace).toBe("/tmp/workspace");
+    expect(content).toContain("mcporter call agenr.agenr_recall");
+    expect(content).toContain("## agenr Memory");
+    expect(content).not.toContain("full content body");
+  });
+
+  it("does not reject when writeAgenrMd fails", async () => {
+    vi.resetModules();
+    const writeAgenrMd = vi.fn(async () => {
+      throw new Error("write failed");
+    });
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall: vi.fn(async () => ({
+        query: "",
+        results: [{ entry: { type: "fact", subject: "subject", content: "content" }, score: 0.99 }],
+      })),
+      formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context"),
+      formatRecallAsSummary: vi.fn(() => "## agenr Memory\n\n1 entries recalled."),
+      writeAgenrMd,
+    }));
+
+    const { handler } = await registerPlugin();
+    await expect(
+      handler({}, { sessionKey: "agent:main:test-write-failure", workspaceDir: "/tmp/workspace" })
+    ).resolves.toEqual({ prependContext: "## agenr Memory Context" });
+  });
+
+  it("returns undefined when config.enabled is false", async () => {
+    vi.resetModules();
+    const runRecall = vi.fn(async () => ({
+      query: "",
+      results: [{ entry: { type: "fact", subject: "subject", content: "content" }, score: 0.99 }],
+    }));
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr-cli.js"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall,
+      formatRecallAsMarkdown: vi.fn(() => "## agenr Memory Context"),
+      formatRecallAsSummary: vi.fn(() => "## agenr Memory\n\n1 entries recalled."),
+      writeAgenrMd: vi.fn(async () => {}),
+    }));
+
+    const { handler } = await registerPlugin({ enabled: false });
+    const result = await handler({}, { sessionKey: "agent:main:test-disabled-config" });
+
+    expect(result).toBeUndefined();
+    expect(runRecall).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Five fixes and one new feature for the OpenClaw plugin. All changes in `src/openclaw-plugin/` only.

## Changes

### Bugs Fixed

**1. sessionKey read from wrong object**
`before_agent_start` passes context (sessionKey, workspaceDir) as the second handler argument, not on the event. The plugin was reading `event.sessionKey` which was always `undefined`, so the skip-session guard never worked correctly.

**2. Fires on every turn instead of once per session**
`before_agent_start` fires before every agent run, not just once at session start. This caused agenr recall to run on every user message (~350ms latency per turn) and memory context to be prepended to every message. Fixed with a module-level `seenSessions` Set that deduplicates per session key.

**3. DEFAULT_AGENR_PATH used wrong relative path**
The old fallback path only worked on the developer machine at `~/Code/agenr-local`. Any npm-installed user got silent recall failures. Fixed to compute path relative to the module using `import.meta.url`, resolving correctly from both `src/` (tests) and `dist/` (runtime) layouts.

**4. Spawn strategy always used node for any binary**
`runRecall` always spawned `node <agenrPath>`. If `AGENR_BIN` or `agenrPath` pointed to the npm-installed shell-script binary rather than a .js file, the spawn failed silently. Fixed with `buildSpawnArgs`: detects `.js` extension and uses `process.execPath`, otherwise spawns the binary directly.

### New Feature

**5. Writes AGENR.md to workspace directory after successful recall**
After recall, the plugin writes the memory markdown to `ctx.workspaceDir/AGENR.md` fire-and-forget (does not block session start). The file is for inspection and TUI visibility. It does not auto-load into Project Context (`loadWorkspaceBootstrapFiles` uses a hardcoded list). A separate GitHub issue has been filed with the OpenClaw team requesting `extraWorkspaceFiles` config support.

### Types Updated

- `BeforeAgentStartEvent`: removed `sessionKey` (does not exist on the event object)
- `PluginHookAgentContext` added (sessionKey, workspaceDir from second handler arg)
- `PluginApi.on` updated to declare 2-arg handler signature

## Tests

25 tests, all passing. Covers session dedup, ctx.sessionKey sourcing, buildSpawnArgs for both .js and binary paths, writeAgenrMd success and silent error handling, and all existing recall/format behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session tracking now prevents duplicate recall runs per session; session key is read from the runtime context.
  * Fixed CLI path resolution and improved detection of JS vs native executables when launching recall.

* **New Features**
  * Automatically writes AGENR.md into the workspace after a successful recall (fire-and-forget).
  * Recall output gains a concise summary format for easier review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->