### PR TITLE
chore: bump to v0.6.10 - compact AGENR.md summary format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.10] - 2026-02-19
+
+### Fixed
+- OpenClaw plugin: AGENR.md now writes a compact summary (subjects only + entry count + recall instructions) instead of full content, preventing double-injection of full context if loaded into Project Context
+- Note: version 0.6.9 was published with a stale build and unpublished; 0.6.10 is the correct release of these changes
+
 ## [0.6.9] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "agenr",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "openclaw": {
-    "extensions": ["dist/openclaw-plugin/index.js"]
+    "extensions": [
+      "dist/openclaw-plugin/index.js"
+    ]
   },
   "description": "AGENt memoRy -- Memory infrastructure for AI agents",
   "type": "module",


### PR DESCRIPTION
v0.6.9 was published with a stale build (pre-summary-format) and had to be unpublished. npm permanently tombstones unpublished versions so 0.6.9 cannot be reused.

This bump to 0.6.10 publishes the correct build that includes all v0.6.9 changes plus the compact AGENR.md summary format (subjects-only, token-efficient for when OpenClaw loads it into Project Context).

Changes: package.json version 0.6.9 → 0.6.10, CHANGELOG.md entry added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenClaw plugin: Fixed double-injection issue in context loading where full context data was being loaded redundantly.

* **Chores**
  * Version bump to 0.6.10.
  * Package configuration formatting update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->