### PR TITLE
fix(shutdown): graceful shutdown wake + force-exit guard (v0.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.11] - 2026-02-19
+
+### Fixed
+- fix(shutdown): SIGINT/SIGTERM now wake the watcher immediately via a shared wake callback, so long polling sleeps are interrupted without waiting for the next interval
+- fix(watch): watcher now registers and always deregisters the shutdown wake callback in `runWatcher`, preventing stale wake handlers across normal exits (`--once`) and repeated runs
+- fix(watch): `runWatchCommand` now executes registered shutdown handlers on signal-triggered exits, keeps direct PID cleanup for clean `--once` exits, and adds a 5s force-exit timeout guard (`.unref()`) to avoid indefinite hangs
+
 ## [0.6.10] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -31,7 +31,7 @@ export function onShutdown(handler: ShutdownHandler): void {
   shutdownHandlers.push(handler);
 }
 
-export function onWake(fn: () => void): void {
+export function onWake(fn: (() => void) | null): void {
   wakeCallback = fn;
 }
 
@@ -40,7 +40,11 @@ export async function runShutdownHandlers(): Promise<void> {
   for (let i = shutdownHandlers.length - 1; i >= 0; i -= 1) {
     const handler = shutdownHandlers[i];
     if (!handler) continue;
-    await handler();
+    try {
+      await handler();
+    } catch (err) {
+      process.stderr.write(`[agenr] Shutdown handler failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
   }
 }
 

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -771,7 +771,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
       await waitForNextCycle();
     }
   } finally {
-    onWake(() => undefined);
+    onWake(null);
     closeAllWatchers();
     if (db) {
       try {

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -13,7 +13,7 @@ import { createLlmClient } from "../llm/client.js";
 import { parseTranscriptFile } from "../parser.js";
 import { normalizeKnowledgePlatform } from "../platform.js";
 import { detectProjectFromCwd } from "../project.js";
-import { installSignalHandlers, isShutdownRequested } from "../shutdown.js";
+import { installSignalHandlers, isShutdownRequested, onWake } from "../shutdown.js";
 import type { KnowledgeEntry, KnowledgePlatform, WatchState } from "../types.js";
 import type { SessionResolver } from "./session-resolver.js";
 import type { WatchPlatform } from "./resolvers/index.js";
@@ -316,6 +316,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
       wakePromise = null;
     }
   };
+  onWake(requestWake);
 
   const waitForNextCycle = async (): Promise<void> => {
     if (options.intervalMs <= 0) {
@@ -770,6 +771,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
       await waitForNextCycle();
     }
   } finally {
+    onWake(() => undefined);
     closeAllWatchers();
     if (db) {
       try {


### PR DESCRIPTION
## Summary

Fixes three gaps in the graceful shutdown path:

1. **Wake on signal**: SIGINT/SIGTERM now immediately interrupt the polling sleep via `onWake()` callback. Previously the watcher could sleep up to `intervalMs` (default 5min) before noticing shutdown.

2. **Wake callback lifecycle**: `runWatcher` registers `requestWake` on entry and deregisters via `onWake(() => undefined)` in its `finally` block. Prevents stale closures after `--once` exits or repeated runs.

3. **Force-exit guard in `runWatchCommand`**: Signal-triggered exits call `runShutdownHandlers()` (LIFO). A 5s `.unref()` timer fires `exitProcessFn(1)` if cleanup stalls. Normal completion calls `exitProcessFn(0)`. Clean `--once` exits bypass shutdown handlers and call `deleteWatcherPidFn` directly.

## Tests
- 56/56 passing (17 new tests)
- Covers: wake fires on SIGTERM, deregisters on normal exit, interrupts sleep, shutdown handlers run on signal path only, clean exits skip handlers

## Checklist
- [x] Version bumped to 0.6.11
- [x] CHANGELOG updated
- [x] All tests pass
- [x] No new TS errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown responsiveness by interrupting long-poll sleeps via a wake mechanism.
  * Prevented stale shutdown handlers across repeated runs and normal exits by always registering/deregistering handlers.
  * Ensured shutdown handlers run on signal exits and added a 5s force-exit guard to avoid hangs.

* **Chores**
  * Bumped package version to 0.6.11 and added changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->