### PR TITLE
feat(watch): health heartbeat - watcher.health.json with atomic writes (v0.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.12] - 2026-02-19
+
+### Added
+- feat(watch): new `src/watch/health.ts` heartbeat support with `WatcherHealth` schema, atomic `watcher.health.json` writes, resilient reads, and `isHealthy()` stale-heartbeat checks (5 minute threshold)
+- feat(watch): `runWatcher` now writes heartbeat health snapshots on startup and after every cycle, including PID, start time, last heartbeat timestamp, sessions watched, and total entries stored
+- feat(watch): directory-mode session switch events now increment `sessionsWatched` (including initial `null -> first` activation)
+
+### Changed
+- chore(watch): injected `writeHealthFileFn` dependency in watcher and watch command paths to keep heartbeat writes testable and mockable
+- test(watch): added `tests/watch/health.test.ts` (10 tests) and new watcher heartbeat assertion coverage in `tests/watch/watcher.test.ts`
+
 ## [0.6.11] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -19,6 +19,7 @@ import { generateContextFile } from "./context.js";
 import { detectWatchPlatform, getResolver, type WatchPlatform } from "../watch/resolvers/index.js";
 import { deleteWatcherPid, writeWatcherPid } from "../watch/pid.js";
 import { getDefaultPlatformDir } from "../watch/platform-defaults.js";
+import { writeHealthFile } from "../watch/health.js";
 import { getFileState, loadWatchState, saveWatchState } from "../watch/state.js";
 import { readFileFromOffset, runWatcher } from "../watch/watcher.js";
 import { installSignalHandlers, isShutdownRequested, onShutdown, runShutdownHandlers } from "../shutdown.js";
@@ -240,6 +241,7 @@ export interface WatchCommandDeps {
   storeEntriesFn: typeof storeEntries;
   loadWatchStateFn: typeof loadWatchState;
   saveWatchStateFn: typeof saveWatchState;
+  writeHealthFileFn: typeof writeHealthFile;
   statFileFn: typeof fs.stat;
   readFileFn: (path: string, offset: number) => Promise<Buffer>;
   generateContextFileFn: typeof generateContextFile;
@@ -387,6 +389,7 @@ export async function runWatchCommand(
     storeEntriesFn: deps?.storeEntriesFn ?? storeEntries,
     loadWatchStateFn: deps?.loadWatchStateFn ?? loadWatchState,
     saveWatchStateFn: deps?.saveWatchStateFn ?? saveWatchState,
+    writeHealthFileFn: deps?.writeHealthFileFn ?? writeHealthFile,
     statFileFn: deps?.statFileFn ?? fs.stat,
     readFileFn: deps?.readFileFn ?? readFileFromOffset,
     generateContextFileFn: deps?.generateContextFileFn ?? generateContextFile,
@@ -585,6 +588,7 @@ export async function runWatchCommand(
         storeEntriesFn: resolvedDeps.storeEntriesFn,
         loadWatchStateFn: resolvedDeps.loadWatchStateFn,
         saveWatchStateFn: resolvedDeps.saveWatchStateFn,
+        writeHealthFileFn: resolvedDeps.writeHealthFileFn,
         statFileFn: resolvedDeps.statFileFn,
         readFileFn: resolvedDeps.readFileFn,
         nowFn: resolvedDeps.nowFn,

--- a/src/watch/health.ts
+++ b/src/watch/health.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveConfigDir } from "./state.js";
+
+export interface WatcherHealth {
+  pid: number;
+  startedAt: string;
+  lastHeartbeat: string;
+  sessionsWatched: number;
+  entriesStored: number;
+}
+
+const HEALTH_FILE = "watcher.health.json";
+const HEALTH_STALE_MS = 5 * 60 * 1000;
+
+export function resolveHealthPath(configDir?: string): string {
+  return path.join(resolveConfigDir(configDir), HEALTH_FILE);
+}
+
+export async function writeHealthFile(health: WatcherHealth, configDir?: string): Promise<void> {
+  const healthPath = resolveHealthPath(configDir);
+  await fs.mkdir(path.dirname(healthPath), { recursive: true });
+  const tmpPath = `${healthPath}.${process.pid}.${Date.now()}.tmp`;
+  let handle: fs.FileHandle | null = null;
+  try {
+    handle = await fs.open(tmpPath, "w");
+    await handle.writeFile(JSON.stringify(health, null, 2), "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await fs.rename(tmpPath, healthPath);
+  } catch (error: unknown) {
+    if (handle) {
+      await handle.close().catch(() => undefined);
+    }
+    await fs.unlink(tmpPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+function isWatcherHealth(value: unknown): value is WatcherHealth {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.pid === "number" &&
+    typeof record.startedAt === "string" &&
+    typeof record.lastHeartbeat === "string" &&
+    typeof record.sessionsWatched === "number" &&
+    typeof record.entriesStored === "number"
+  );
+}
+
+export async function readHealthFile(configDir?: string): Promise<WatcherHealth | null> {
+  try {
+    const raw = await fs.readFile(resolveHealthPath(configDir), "utf8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (!isWatcherHealth(parsed)) {
+      return null;
+    }
+    return parsed;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export function isHealthy(health: WatcherHealth, now = new Date()): boolean {
+  const heartbeatTs = Date.parse(health.lastHeartbeat);
+  if (Number.isNaN(heartbeatTs)) {
+    return false;
+  }
+  return now.getTime() - heartbeatTs < HEALTH_STALE_MS;
+}

--- a/tests/watch/health.test.ts
+++ b/tests/watch/health.test.ts
@@ -1,0 +1,261 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetShutdownForTests } from "../../src/shutdown.js";
+import { isHealthy, readHealthFile, resolveHealthPath, writeHealthFile, type WatcherHealth } from "../../src/watch/health.js";
+import { runWatcher, type WatcherDeps } from "../../src/watch/watcher.js";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const tempDirs: string[] = [];
+
+function makeHealth(overrides?: Partial<WatcherHealth>): WatcherHealth {
+  return {
+    pid: 1234,
+    startedAt: "2026-02-19T12:00:00.000Z",
+    lastHeartbeat: "2026-02-19T12:00:00.000Z",
+    sessionsWatched: 2,
+    entriesStored: 9,
+    ...overrides,
+  };
+}
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agenr-watch-health-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function useTempHome(dir: string): void {
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+}
+
+function makeWatcherDeps(overrides?: Partial<WatcherDeps>): Partial<WatcherDeps> {
+  return {
+    readConfigFn: vi.fn(() => ({ db: { path: ":memory:" } })),
+    resolveEmbeddingApiKeyFn: vi.fn(() => "sk-test"),
+    parseTranscriptFileFn: vi.fn(async () => ({
+      file: "/tmp/delta.txt",
+      messages: [],
+      chunks: [],
+      warnings: [],
+    })),
+    createLlmClientFn: vi.fn(() => ({ resolvedModel: { modelId: "test" }, credentials: { apiKey: "x" } })),
+    extractKnowledgeFromChunksFn: vi.fn(async () => ({
+      entries: [],
+      successfulChunks: 0,
+      failedChunks: 0,
+      warnings: [],
+    })),
+    deduplicateEntriesFn: vi.fn((entries) => entries),
+    getDbFn: vi.fn(() => ({} as unknown as ReturnType<WatcherDeps["getDbFn"]>)),
+    initDbFn: vi.fn(async () => undefined),
+    closeDbFn: vi.fn(() => undefined),
+    walCheckpointFn: vi.fn(async () => undefined),
+    storeEntriesFn: vi.fn(async () => ({
+      added: 0,
+      updated: 0,
+      skipped: 0,
+      superseded: 0,
+      llm_dedup_calls: 0,
+      relations_created: 0,
+      total_entries: 0,
+      duration_ms: 1,
+    })),
+    loadWatchStateFn: vi.fn(async () => ({ version: 1 as const, files: {} })),
+    saveWatchStateFn: vi.fn(async () => undefined),
+    writeHealthFileFn: vi.fn(async () => undefined),
+    statFileFn: vi.fn(async () => ({ size: 0, isFile: () => true })),
+    readFileFn: vi.fn(async () => Buffer.alloc(0)),
+    readFileHeadFn: vi.fn(async () => Buffer.alloc(0)),
+    detectProjectFn: vi.fn(() => null),
+    mkdtempFn: vi.fn(async () => "/tmp/agenr-watch-health"),
+    writeFileFn: vi.fn(async () => undefined),
+    rmFn: vi.fn(async () => undefined),
+    watchFn: vi.fn(
+      () =>
+        ({
+          close: () => undefined,
+        }) as unknown as ReturnType<WatcherDeps["watchFn"]>,
+    ),
+    nowFn: vi.fn(() => new Date("2026-02-19T12:00:00.000Z")),
+    sleepFn: vi.fn(async () => undefined),
+    shouldShutdownFn: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  process.env.HOME = originalHome;
+  process.env.USERPROFILE = originalUserProfile;
+  resetShutdownForTests();
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe("watch health", () => {
+  it("writes and reads health data round-trip", async () => {
+    useTempHome(await makeTempDir());
+    const health = makeHealth();
+
+    await writeHealthFile(health);
+
+    const loaded = await readHealthFile();
+    expect(loaded).toEqual(health);
+  });
+
+  it("writes health atomically and leaves no tmp files", async () => {
+    useTempHome(await makeTempDir());
+    const health = makeHealth();
+
+    await writeHealthFile(health);
+
+    const loaded = await readHealthFile();
+    expect(loaded).toEqual(health);
+
+    const dirEntries = await fs.readdir(path.dirname(resolveHealthPath()));
+    const hasTmp = dirEntries.some((name) => name.endsWith(".tmp"));
+    expect(hasTmp).toBe(false);
+  });
+
+  it("returns null when health file is missing", async () => {
+    useTempHome(await makeTempDir());
+    await expect(readHealthFile()).resolves.toBeNull();
+  });
+
+  it("returns null when health file contains invalid JSON", async () => {
+    useTempHome(await makeTempDir());
+    const healthPath = resolveHealthPath();
+    await fs.mkdir(path.dirname(healthPath), { recursive: true });
+    await fs.writeFile(healthPath, "not-json", "utf8");
+
+    await expect(readHealthFile()).resolves.toBeNull();
+  });
+
+  it("returns null when required health field is missing", async () => {
+    useTempHome(await makeTempDir());
+    const healthPath = resolveHealthPath();
+    await fs.mkdir(path.dirname(healthPath), { recursive: true });
+    await fs.writeFile(
+      healthPath,
+      JSON.stringify(
+        {
+          startedAt: "2026-02-19T12:00:00.000Z",
+          lastHeartbeat: "2026-02-19T12:01:00.000Z",
+          sessionsWatched: 1,
+          entriesStored: 2,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    await expect(readHealthFile()).resolves.toBeNull();
+  });
+
+  it("returns null when health field has wrong type", async () => {
+    useTempHome(await makeTempDir());
+    const healthPath = resolveHealthPath();
+    await fs.mkdir(path.dirname(healthPath), { recursive: true });
+    await fs.writeFile(
+      healthPath,
+      JSON.stringify(
+        {
+          pid: "not-a-number",
+          startedAt: "2026-02-19T12:00:00.000Z",
+          lastHeartbeat: "2026-02-19T12:01:00.000Z",
+          sessionsWatched: 1,
+          entriesStored: 2,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    await expect(readHealthFile()).resolves.toBeNull();
+  });
+
+  it("isHealthy returns true for recent heartbeat", () => {
+    const now = new Date("2026-02-19T12:00:00.000Z");
+    const health = makeHealth({
+      lastHeartbeat: new Date(now.getTime() - 60 * 1000).toISOString(),
+    });
+
+    expect(isHealthy(health, now)).toBe(true);
+  });
+
+  it("isHealthy returns false for stale heartbeat", () => {
+    const now = new Date("2026-02-19T12:00:00.000Z");
+    const health = makeHealth({
+      lastHeartbeat: new Date(now.getTime() - 6 * 60 * 1000).toISOString(),
+    });
+
+    expect(isHealthy(health, now)).toBe(false);
+  });
+
+  it("isHealthy returns false for invalid heartbeat dates", () => {
+    const health = makeHealth({ lastHeartbeat: "not-a-date" });
+
+    expect(isHealthy(health, new Date("2026-02-19T12:00:00.000Z"))).toBe(false);
+  });
+
+  it("increments sessionsWatched when watcher switches sessions", async () => {
+    const fileA = "/tmp/agenr-health-a.jsonl";
+    const fileB = "/tmp/agenr-health-b.jsonl";
+    const sessionsDir = await makeTempDir();
+    const writes: WatcherHealth[] = [];
+    let resolveCalls = 0;
+    let shutdown = false;
+    let cycles = 0;
+
+    const resolver = {
+      filePattern: "*.jsonl",
+      resolveActiveSession: vi.fn(async () => {
+        resolveCalls += 1;
+        if (resolveCalls === 1) {
+          return fileA;
+        }
+        return fileB;
+      }),
+    };
+
+    const writeHealthFileFn = vi.fn(async (health: WatcherHealth) => {
+      writes.push(health);
+    });
+
+    await runWatcher(
+      {
+        intervalMs: 1,
+        minChunkChars: 5,
+        dryRun: true,
+        verbose: false,
+        raw: false,
+        once: false,
+        directoryMode: true,
+        sessionsDir,
+        resolver,
+        onCycle: () => {
+          cycles += 1;
+          if (cycles >= 2) {
+            shutdown = true;
+          }
+        },
+      },
+      makeWatcherDeps({
+        shouldShutdownFn: vi.fn(() => shutdown),
+        sleepFn: vi.fn(async () => undefined),
+        writeHealthFileFn,
+      }),
+    );
+
+    const hasSwitchCount = writes.some((health) => health.sessionsWatched >= 1);
+    expect(hasSwitchCount).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Creates `src/watch/health.ts` from scratch and wires heartbeat writes into the watcher loop.

### What's new

**`src/watch/health.ts`**
- `WatcherHealth` schema: pid, startedAt, lastHeartbeat, sessionsWatched, entriesStored
- `writeHealthFile`: atomic write (open tmp -> writeFile -> sync -> close -> rename); cleans up tmp on failure
- `readHealthFile`: returns null on ENOENT, null on bad JSON, null on wrong shape, rethrows other errors
- `isHealthy`: stale threshold = 5 minutes; returns false for NaN timestamps
- `resolveHealthPath`: resolves to `~/.agenr/watcher.health.json` by default

**`src/watch/watcher.ts`**
- `writeHeartbeat()` fires on startup and after every cycle (fire-and-forget; failures surface via `onWarn`)
- `handleSwitch()` wraps `options.onSwitch` and increments `sessionsWatched` for both initial activation (null -> first) and subsequent directory-mode switches
- `writeHealthFileFn` injected as a dep for testability

## Tests
- 64/64 passing (10 new in health.test.ts, 1 new watcher integration test)
- Covers: round-trip, atomic write leaves no tmp files, ENOENT returns null, invalid JSON, wrong shape, wrong type, isHealthy fresh/stale/invalid, sessionsWatched increment

## Checklist
- [x] Version bumped to 0.6.12
- [x] CHANGELOG updated
- [x] All tests pass
- [x] No new TS errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added watcher health monitoring with automatic heartbeat tracking for operational status visibility
  * Session activity and storage metrics now recorded during watch cycles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->