### PR TITLE
perf(db): WAL checkpoint rate-limiting + busy_timeout (v0.6.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.15] - 2026-02-19
+
+### Changed
+- perf(db): file-backed DB clients now set `PRAGMA busy_timeout=3000` during WAL initialization, reducing immediate `SQLITE_BUSY` failures under write contention
+- perf(db): `initDb()` now explicitly sets `PRAGMA wal_autocheckpoint=1000` for WAL-enabled clients to make checkpoint behavior explicit and testable
+- perf(watch): watcher now supports `walCheckpointIntervalMs` (default `30000`) to rate-limit per-cycle WAL checkpoints while keeping shutdown checkpoint behavior unchanged
+
+### Fixed
+- test(watch): updated per-cycle checkpoint tests to pass `walCheckpointIntervalMs: 0` when asserting legacy always-checkpoint behavior
+- test(db): added coverage for file-backed `busy_timeout`, explicit `wal_autocheckpoint`, and `:memory:` busy-timeout exclusion
+- test(watch): added interval-gating, shutdown-checkpoint, and sentinel-bypass coverage for WAL checkpoint scheduling
+
 ## [0.6.14] - 2026-02-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -22,6 +22,8 @@ import { createEmptyWatchState, getFileState, loadWatchState, saveWatchState, up
 import type { WatcherHealth } from "./health.js";
 import { writeHealthFile } from "./health.js";
 
+const DEFAULT_WAL_CHECKPOINT_INTERVAL_MS = 30_000;
+
 interface WatchTarget {
   dir: string;
   platform: WatchPlatform;
@@ -791,7 +793,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
       writeHeartbeat();
 
       const nowAt = resolvedDeps.nowFn();
-      const intervalMs = options.walCheckpointIntervalMs ?? 30000;
+      const intervalMs = options.walCheckpointIntervalMs ?? DEFAULT_WAL_CHECKPOINT_INTERVAL_MS;
       const shouldCheckpoint =
         intervalMs <= 0 || (nowAt.getTime() - lastCheckpointAt.getTime()) >= intervalMs;
 


### PR DESCRIPTION
## Summary

Reduces DB contention in the watcher by rate-limiting WAL checkpoints and adding a busy_timeout pragma.

### Changes

- **busy_timeout 3s**: Set on DB open for all file-backed databases before any queries run. Prevents SQLITE_BUSY on concurrent reads. Skipped for :memory: databases.
- **WAL checkpoint interval**: Checkpoints rate-limited to once per 30s by default (walCheckpointIntervalMs option). Uses new Date(0) initial value so first cycle always fires. Zero interval bypasses throttle (used in tests).
- **wal_autocheckpoint=1000**: Explicit SQLite autocheckpoint threshold set during DB init.
- **Named constant**: DEFAULT_WAL_CHECKPOINT_INTERVAL_MS = 30_000 extracted from inline magic number.
- **Re-elapse test**: Third cycle added to interval test verifying checkpoint re-fires after threshold is crossed again.

### Tests
712/712 tests pass. Two existing watcher tests patched with walCheckpointIntervalMs: 0 to prevent throttle suppressing checkpoint calls on fast test cycles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.6.15

* **Changed**
  * Database performance optimizations: added timeout handling and automatic checkpoint tuning for file-backed databases to improve responsiveness.
  * New configurable WAL checkpoint interval rate-limiting option for the watcher to control synchronization frequency.

* **Tests**
  * Expanded test suite to validate database configuration settings and WAL checkpoint interval gating behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->