### PR TITLE
feat(signals): AGENR v0.7.0 - Signal Engine (mid-session push delivery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.7.0] - 2026-02-20
+
+### Added
+- feat(signals): mid-session signal delivery via `before_prompt_build` hook - notifies agents of new high-importance entries (imp >= 7) with compact 50-100 token notifications
+- feat(signals): `signal_watermarks` table for per-consumer rowid-based watermark tracking
+- feat(mcp): `since_seq` parameter on `agenr_recall` for watermark-based incremental recall without embedding cost
+- feat(plugin): `signalsEnabled`, `signalMinImportance`, `signalMaxPerSignal`, and `dbPath` plugin config options
+
+### Changed
+- refactor(plugin): plugin now opens a direct DB connection for sub-ms signal queries (vs CLI spawn)
+- refactor(plugin/types): expanded `PluginApi` and `AgenrPluginConfig` types for signal support
+
 ## [0.6.15] - 2026-02-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.7.0] - 2026-02-20
+## [0.7.0] - 2026-02-19
 
 ### Added
 - feat(signals): mid-session signal delivery via `before_prompt_build` hook - notifies agents of new high-importance entries (imp >= 7) with compact 50-100 token notifications

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.6.15",
+  "version": "0.7.0",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -120,6 +120,13 @@ const CREATE_TABLE_AND_TRIGGER_STATEMENTS: readonly string[] = [
     PRIMARY KEY (merged_entry_id, source_entry_id)
   )
   `,
+  `
+  CREATE TABLE IF NOT EXISTS signal_watermarks (
+    consumer_id TEXT PRIMARY KEY,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL
+  )
+  `,
   CREATE_ENTRIES_FTS_TABLE_SQL,
   CREATE_ENTRIES_FTS_TRIGGER_AI_SQL,
   CREATE_ENTRIES_FTS_TRIGGER_AD_SQL,

--- a/src/db/signals.test.ts
+++ b/src/db/signals.test.ts
@@ -1,0 +1,239 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { initDb } from "./client.js";
+import {
+  fetchNewSignalEntries,
+  formatSignal,
+  getWatermark,
+  initializeWatermark,
+  setWatermark,
+} from "./signals.js";
+
+const clients: Client[] = [];
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    return Number(value);
+  }
+  return Number.NaN;
+}
+
+function makeClient(): Client {
+  const client = createClient({ url: ":memory:" });
+  clients.push(client);
+  return client;
+}
+
+async function insertEntry(
+  client: Client,
+  params: {
+    id: string;
+    type?: string;
+    subject: string;
+    content?: string;
+    importance?: number;
+    retired?: number;
+    createdAt?: string;
+  },
+): Promise<number> {
+  const createdAt = params.createdAt ?? new Date().toISOString();
+  await client.execute({
+    sql: `
+      INSERT INTO entries (
+        id, type, subject, content, importance, expiry, scope, source_file, source_context,
+        created_at, updated_at, retired
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    args: [
+      params.id,
+      params.type ?? "fact",
+      params.subject,
+      params.content ?? `${params.subject} content`,
+      params.importance ?? 5,
+      "temporary",
+      "private",
+      "signals.test.jsonl",
+      "unit test",
+      createdAt,
+      createdAt,
+      params.retired ?? 0,
+    ],
+  });
+
+  const row = await client.execute({
+    sql: "SELECT rowid FROM entries WHERE id = ?",
+    args: [params.id],
+  });
+  return toNumber((row.rows[0] as { rowid?: unknown } | undefined)?.rowid);
+}
+
+afterEach(() => {
+  while (clients.length > 0) {
+    clients.pop()?.close();
+  }
+});
+
+describe("db signals", () => {
+  it("fetchNewSignalEntries returns entries above watermark", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, { id: "e1", subject: "S1", importance: 7 });
+    await insertEntry(client, { id: "e2", subject: "S2", importance: 8 });
+    await insertEntry(client, { id: "e3", subject: "S3", importance: 9 });
+
+    const batch = await fetchNewSignalEntries(client, 0, 7, 10);
+    expect(batch.entries).toHaveLength(3);
+    expect(batch.entries.map((entry) => entry.subject)).toEqual(["S1", "S2", "S3"]);
+    expect(batch.entries.map((entry) => entry.rowid)).toEqual(
+      [...batch.entries.map((entry) => entry.rowid)].sort((a, b) => a - b),
+    );
+    expect(batch.maxSeq).toBe(batch.entries[2]?.rowid);
+  });
+
+  it("fetchNewSignalEntries respects importance threshold", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, { id: "e1", subject: "low", importance: 5 });
+    await insertEntry(client, { id: "e2", subject: "mid", importance: 7 });
+    await insertEntry(client, { id: "e3", subject: "high", importance: 9 });
+
+    const batch = await fetchNewSignalEntries(client, 0, 7, 10);
+    expect(batch.entries.map((entry) => entry.subject)).toEqual(["mid", "high"]);
+  });
+
+  it("fetchNewSignalEntries respects limit", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    for (let i = 0; i < 10; i += 1) {
+      await insertEntry(client, { id: `e${i}`, subject: `S${i}`, importance: 9 });
+    }
+
+    const batch = await fetchNewSignalEntries(client, 0, 7, 3);
+    expect(batch.entries).toHaveLength(3);
+  });
+
+  it("fetchNewSignalEntries excludes retired entries", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, { id: "e1", subject: "active", importance: 8, retired: 0 });
+    await insertEntry(client, { id: "e2", subject: "retired", importance: 9, retired: 1 });
+
+    const batch = await fetchNewSignalEntries(client, 0, 7, 10);
+    expect(batch.entries).toHaveLength(1);
+    expect(batch.entries[0]?.subject).toBe("active");
+  });
+
+  it("fetchNewSignalEntries returns empty for no new entries", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    const rowid = await insertEntry(client, { id: "e1", subject: "S1", importance: 8 });
+    const batch = await fetchNewSignalEntries(client, rowid, 7, 10);
+
+    expect(batch.entries).toEqual([]);
+    expect(batch.maxSeq).toBe(rowid);
+  });
+
+  it("formatSignal produces correct format", () => {
+    const formatted = formatSignal([
+      {
+        rowid: 1,
+        id: "a",
+        type: "decision",
+        subject: "Switch to Postgres for prod",
+        importance: 8,
+        created_at: "2026-02-19T00:00:00.000Z",
+      },
+      {
+        rowid: 2,
+        id: "b",
+        type: "fact",
+        subject: "AWS contract signed through 2027",
+        importance: 9,
+        created_at: "2026-02-19T00:00:00.000Z",
+      },
+    ]);
+
+    expect(formatted).toBe(
+      [
+        "AGENR SIGNAL: 2 new high-importance entries",
+        '- [decision, imp:8] "Switch to Postgres for prod"',
+        '- [fact, imp:9] "AWS contract signed through 2027"',
+        '-> Use agenr_recall query="<subject>" for details.',
+      ].join("\n"),
+    );
+  });
+
+  it("formatSignal handles single entry (singular)", () => {
+    const formatted = formatSignal([
+      {
+        rowid: 1,
+        id: "a",
+        type: "fact",
+        subject: "Single item",
+        importance: 7,
+        created_at: "2026-02-19T00:00:00.000Z",
+      },
+    ]);
+    expect(formatted).toContain("AGENR SIGNAL: 1 new high-importance entry");
+  });
+
+  it("formatSignal returns empty string for no entries", () => {
+    expect(formatSignal([])).toBe("");
+  });
+
+  it("getWatermark returns 0 for unknown consumer", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    expect(await getWatermark(client, "consumer-a")).toBe(0);
+  });
+
+  it("setWatermark creates then updates", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await setWatermark(client, "consumer-a", 12);
+    expect(await getWatermark(client, "consumer-a")).toBe(12);
+
+    await setWatermark(client, "consumer-a", 27);
+    expect(await getWatermark(client, "consumer-a")).toBe(27);
+  });
+
+  it("initializeWatermark sets to max rowid on first call", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, { id: "e1", subject: "S1", importance: 8 });
+    const maxRowid = await insertEntry(client, { id: "e2", subject: "S2", importance: 8 });
+
+    const watermark = await initializeWatermark(client, "consumer-init");
+    expect(watermark).toBe(maxRowid);
+    expect(await getWatermark(client, "consumer-init")).toBe(maxRowid);
+  });
+
+  it("initializeWatermark is idempotent", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, { id: "e1", subject: "S1", importance: 8 });
+    const first = await initializeWatermark(client, "consumer-idempotent");
+
+    await insertEntry(client, { id: "e2", subject: "S2", importance: 8 });
+    const second = await initializeWatermark(client, "consumer-idempotent");
+
+    expect(second).toBe(first);
+    expect(await getWatermark(client, "consumer-idempotent")).toBe(first);
+  });
+});

--- a/src/db/signals.test.ts
+++ b/src/db/signals.test.ts
@@ -223,6 +223,16 @@ describe("db signals", () => {
     expect(await getWatermark(client, "consumer-init")).toBe(maxRowid);
   });
 
+  it("initializeWatermark returns 0 on empty DB", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    // MAX(rowid) returns NULL on empty table - must fall back to 0.
+    const watermark = await initializeWatermark(client, "consumer-empty");
+    expect(watermark).toBe(0);
+    expect(await getWatermark(client, "consumer-empty")).toBe(0);
+  });
+
   it("initializeWatermark is idempotent", async () => {
     const client = makeClient();
     await initDb(client);

--- a/src/db/signals.ts
+++ b/src/db/signals.ts
@@ -1,0 +1,121 @@
+import type { Client } from "@libsql/client";
+
+export interface SignalEntry {
+  rowid: number;
+  id: string;
+  type: string;
+  subject: string;
+  importance: number;
+  created_at: string;
+}
+
+export interface SignalBatch {
+  entries: SignalEntry[];
+  maxSeq: number;
+}
+
+/**
+ * Fetch new high-importance entries since a given watermark.
+ * Returns entries with rowid > sinceSeq, importance >= minImportance, retired = 0.
+ * Ordered by rowid ASC. Limit caps max entries per signal.
+ */
+export async function fetchNewSignalEntries(
+  db: Client,
+  sinceSeq: number,
+  minImportance: number,
+  limit: number,
+): Promise<SignalBatch> {
+  const result = await db.execute({
+    sql: `SELECT rowid, id, type, subject, importance, created_at
+          FROM entries
+          WHERE importance >= ? AND rowid > ? AND retired = 0
+          ORDER BY rowid ASC
+          LIMIT ?`,
+    args: [minImportance, sinceSeq, limit],
+  });
+
+  const entries: SignalEntry[] = result.rows.map((row) => ({
+    rowid: Number(row.rowid),
+    id: String(row.id),
+    type: String(row.type),
+    subject: String(row.subject),
+    importance: Number(row.importance),
+    created_at: String(row.created_at),
+  }));
+
+  const maxSeq =
+    entries.length > 0
+      ? Math.max(...entries.map((entry) => entry.rowid))
+      : sinceSeq;
+
+  return { entries, maxSeq };
+}
+
+/**
+ * Format signal entries into a compact notification string (50-100 tokens).
+ */
+export function formatSignal(entries: SignalEntry[]): string {
+  if (entries.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [
+    `AGENR SIGNAL: ${entries.length} new high-importance ${entries.length === 1 ? "entry" : "entries"}`,
+  ];
+
+  for (const entry of entries) {
+    lines.push(`- [${entry.type}, imp:${entry.importance}] "${entry.subject}"`);
+  }
+
+  lines.push('-> Use agenr_recall query="<subject>" for details.');
+  return lines.join("\n");
+}
+
+/**
+ * Read the current watermark for a consumer.
+ * Returns 0 if no watermark exists (first signal check).
+ */
+export async function getWatermark(db: Client, consumerId: string): Promise<number> {
+  const result = await db.execute({
+    sql: "SELECT last_received_seq FROM signal_watermarks WHERE consumer_id = ?",
+    args: [consumerId],
+  });
+
+  if (result.rows.length === 0) {
+    return 0;
+  }
+  return Number(result.rows[0]?.last_received_seq);
+}
+
+/**
+ * Advance the watermark for a consumer. Upsert.
+ */
+export async function setWatermark(db: Client, consumerId: string, seq: number): Promise<void> {
+  await db.execute({
+    sql: `INSERT INTO signal_watermarks (consumer_id, last_received_seq, updated_at)
+          VALUES (?, ?, datetime('now'))
+          ON CONFLICT(consumer_id)
+          DO UPDATE SET last_received_seq = excluded.last_received_seq,
+                        updated_at = excluded.updated_at`,
+    args: [consumerId, seq],
+  });
+}
+
+/**
+ * Initialize first-seen consumers to the current maximum rowid so pre-existing
+ * high-importance entries are not replayed as mid-session signals.
+ */
+export async function initializeWatermark(db: Client, consumerId: string): Promise<number> {
+  const existing = await db.execute({
+    sql: "SELECT last_received_seq FROM signal_watermarks WHERE consumer_id = ?",
+    args: [consumerId],
+  });
+  if (existing.rows.length > 0) {
+    return Number(existing.rows[0]?.last_received_seq);
+  }
+
+  const maxResult = await db.execute("SELECT MAX(rowid) AS max_rowid FROM entries");
+  const maxRowid = Number((maxResult.rows[0] as { max_rowid?: unknown } | undefined)?.max_rowid ?? 0);
+  await setWatermark(db, consumerId, maxRowid);
+  return maxRowid;
+}

--- a/src/db/signals.ts
+++ b/src/db/signals.ts
@@ -43,10 +43,7 @@ export async function fetchNewSignalEntries(
     created_at: String(row.created_at),
   }));
 
-  const maxSeq =
-    entries.length > 0
-      ? Math.max(...entries.map((entry) => entry.rowid))
-      : sinceSeq;
+  const maxSeq = entries.length > 0 ? (entries.at(-1)?.rowid ?? sinceSeq) : sinceSeq;
 
   return { entries, maxSeq };
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -124,7 +124,7 @@ const TOOL_DEFINITIONS: McpToolDefinition[] = [
         since_seq: {
           type: "integer",
           description:
-            "Only return entries with rowid > this value (watermark for incremental recall). Overrides semantic search and returns entries chronologically.",
+            "Only return entries with rowid > this value (watermark for incremental recall). Overrides semantic search - returns all entries (any importance) ordered by rowid ASC.",
           minimum: 0,
         },
         threshold: {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -124,7 +124,7 @@ const TOOL_DEFINITIONS: McpToolDefinition[] = [
         since_seq: {
           type: "integer",
           description:
-            "Only return entries with rowid > this value (watermark for incremental recall). Overrides semantic search - returns all entries (any importance) ordered by rowid ASC.",
+            "Only return entries with rowid > this value (watermark for incremental recall). When set, overrides all other filters (query, context, types, since, threshold, platform, project) and returns all non-retired entries ordered by rowid ASC.",
           minimum: 0,
         },
         threshold: {

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -183,7 +183,7 @@ const plugin = {
           }
 
           const db = await ensurePluginDb(config);
-          const signalConfig = resolveSignalConfig(api.pluginConfig);
+          const signalConfig = resolveSignalConfig(config);
           const signal = await checkSignals(db, sessionKey, signalConfig);
           if (!signal) {
             return;

--- a/src/openclaw-plugin/signals.test.ts
+++ b/src/openclaw-plugin/signals.test.ts
@@ -1,0 +1,116 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { initDb } from "../db/client.js";
+import { getWatermark } from "../db/signals.js";
+import { checkSignals, resolveSignalConfig } from "./signals.js";
+
+const clients: Client[] = [];
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    return Number(value);
+  }
+  return Number.NaN;
+}
+
+function makeClient(): Client {
+  const client = createClient({ url: ":memory:" });
+  clients.push(client);
+  return client;
+}
+
+async function insertEntry(
+  client: Client,
+  params: { id: string; subject: string; importance: number; createdAt?: string },
+): Promise<number> {
+  const createdAt = params.createdAt ?? new Date().toISOString();
+  await client.execute({
+    sql: `
+      INSERT INTO entries (
+        id, type, subject, content, importance, expiry, scope, source_file, source_context,
+        created_at, updated_at, retired
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+    `,
+    args: [
+      params.id,
+      "fact",
+      params.subject,
+      `${params.subject} content`,
+      params.importance,
+      "temporary",
+      "private",
+      "signals.test.jsonl",
+      "unit test",
+      createdAt,
+      createdAt,
+    ],
+  });
+  const row = await client.execute({ sql: "SELECT rowid FROM entries WHERE id = ?", args: [params.id] });
+  return toNumber((row.rows[0] as { rowid?: unknown } | undefined)?.rowid);
+}
+
+afterEach(() => {
+  while (clients.length > 0) {
+    clients.pop()?.close();
+  }
+});
+
+describe("openclaw plugin signals adapter", () => {
+  it("checkSignals returns null when no new entries", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, { id: "e1", subject: "Existing", importance: 8 });
+    const first = await checkSignals(client, "consumer-no-new");
+    expect(first).toBeNull();
+
+    const second = await checkSignals(client, "consumer-no-new");
+    expect(second).toBeNull();
+  });
+
+  it("checkSignals returns formatted signal and advances watermark", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, { id: "seed", subject: "Seed", importance: 8 });
+    await checkSignals(client, "consumer-new");
+
+    await insertEntry(client, { id: "e1", subject: "New A", importance: 7 });
+    const newestRowid = await insertEntry(client, { id: "e2", subject: "New B", importance: 9 });
+
+    const signal = await checkSignals(client, "consumer-new");
+    expect(signal).toContain("AGENR SIGNAL: 2 new high-importance entries");
+    expect(signal).toContain('- [fact, imp:7] "New A"');
+    expect(signal).toContain('- [fact, imp:9] "New B"');
+    expect(await getWatermark(client, "consumer-new")).toBe(newestRowid);
+  });
+
+  it("checkSignals initializes watermark on first call", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    const maxRowid = await insertEntry(client, { id: "e1", subject: "Existing", importance: 9 });
+
+    const signal = await checkSignals(client, "consumer-init");
+    expect(signal).toBeNull();
+    expect(await getWatermark(client, "consumer-init")).toBe(maxRowid);
+  });
+
+  it("resolveSignalConfig uses defaults", () => {
+    expect(resolveSignalConfig()).toEqual({ minImportance: 7, maxPerSignal: 5 });
+  });
+
+  it("resolveSignalConfig respects overrides", () => {
+    expect(resolveSignalConfig({ signalMinImportance: 9, signalMaxPerSignal: 2 })).toEqual({
+      minImportance: 9,
+      maxPerSignal: 2,
+    });
+  });
+});

--- a/src/openclaw-plugin/signals.test.ts
+++ b/src/openclaw-plugin/signals.test.ts
@@ -142,4 +142,11 @@ describe("openclaw plugin signals adapter", () => {
       maxPerSignal: 0,
     });
   });
+
+  it("resolveSignalConfig treats null values as unset (uses defaults)", () => {
+    expect(resolveSignalConfig({ signalMinImportance: null, signalMaxPerSignal: null })).toEqual({
+      minImportance: 7,
+      maxPerSignal: 5,
+    });
+  });
 });

--- a/src/openclaw-plugin/signals.ts
+++ b/src/openclaw-plugin/signals.ts
@@ -44,6 +44,9 @@ export async function checkSignals(
 }
 
 function readNonNegativeInt(value: unknown, fallback: number): number {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) {
     return fallback;

--- a/src/openclaw-plugin/signals.ts
+++ b/src/openclaw-plugin/signals.ts
@@ -1,0 +1,54 @@
+import type { Client } from "@libsql/client";
+import {
+  fetchNewSignalEntries,
+  formatSignal,
+  initializeWatermark,
+  setWatermark,
+} from "../db/signals.js";
+
+export interface SignalConfig {
+  minImportance: number;
+  maxPerSignal: number;
+}
+
+const DEFAULT_SIGNAL_CONFIG: SignalConfig = {
+  minImportance: 7,
+  maxPerSignal: 5,
+};
+
+/**
+ * Check for and format new signals for a consumer session.
+ * Returns prependContext string or null if nothing new.
+ */
+export async function checkSignals(
+  db: Client,
+  consumerId: string,
+  config: SignalConfig = DEFAULT_SIGNAL_CONFIG,
+): Promise<string | null> {
+  const watermark = await initializeWatermark(db, consumerId);
+  const batch = await fetchNewSignalEntries(db, watermark, config.minImportance, config.maxPerSignal);
+
+  if (batch.entries.length === 0) {
+    return null;
+  }
+
+  // Advance watermark BEFORE returning (fire-once guarantee).
+  await setWatermark(db, consumerId, batch.maxSeq);
+  return formatSignal(batch.entries);
+}
+
+function readPositiveInt(value: unknown, fallback: number): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+export function resolveSignalConfig(pluginConfig?: Record<string, unknown>): SignalConfig {
+  const raw = pluginConfig as { signalMinImportance?: unknown; signalMaxPerSignal?: unknown } | undefined;
+  return {
+    minImportance: readPositiveInt(raw?.signalMinImportance, DEFAULT_SIGNAL_CONFIG.minImportance),
+    maxPerSignal: readPositiveInt(raw?.signalMaxPerSignal, DEFAULT_SIGNAL_CONFIG.maxPerSignal),
+  };
+}

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -17,6 +17,17 @@ export type BeforeAgentStartResult = {
   prependContext?: string;
 };
 
+export type BeforePromptBuildEvent = {
+  prompt?: string;
+  messages?: unknown[];
+  [key: string]: unknown;
+};
+
+export type BeforePromptBuildResult = {
+  systemPrompt?: string;
+  prependContext?: string;
+};
+
 export type PluginLogger = {
   debug?: (message: string) => void;
   info?: (message: string) => void;
@@ -30,13 +41,22 @@ export type PluginApi = {
   version?: string;
   pluginConfig?: Record<string, unknown>;
   logger: PluginLogger;
-  on: (
-    hook: "before_agent_start",
-    handler: (
-      event: BeforeAgentStartEvent,
-      ctx: PluginHookAgentContext
-    ) => Promise<BeforeAgentStartResult | undefined> | BeforeAgentStartResult | undefined
-  ) => void;
+  on: {
+    (
+      hook: "before_agent_start",
+      handler: (
+        event: BeforeAgentStartEvent,
+        ctx: PluginHookAgentContext
+      ) => Promise<BeforeAgentStartResult | undefined> | BeforeAgentStartResult | undefined,
+    ): void;
+    (
+      hook: "before_prompt_build",
+      handler: (
+        event: BeforePromptBuildEvent,
+        ctx: PluginHookAgentContext
+      ) => Promise<BeforePromptBuildResult | undefined> | BeforePromptBuildResult | undefined,
+    ): void;
+  };
 };
 
 export type AgenrPluginConfig = {
@@ -46,4 +66,12 @@ export type AgenrPluginConfig = {
   budget?: number;
   /** Set to false to disable memory injection without removing the plugin */
   enabled?: boolean;
+  /** Path to agenr DB. Defaults to AGENR_DB_PATH env or ~/.agenr/knowledge.db */
+  dbPath?: string;
+  /** Set to false to disable mid-session signals (default: true) */
+  signalsEnabled?: boolean;
+  /** Minimum importance for signal entries (default: 7) */
+  signalMinImportance?: number;
+  /** Max entries per signal notification (default: 5) */
+  signalMaxPerSignal?: number;
 };

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -28,6 +28,7 @@ describe("db schema", () => {
       "relations",
       "ingest_log",
       "entry_sources",
+      "signal_watermarks",
       "entries_fts",
       "idx_entries_embedding",
       "idx_entries_type",
@@ -80,6 +81,7 @@ describe("db schema", () => {
         'relations',
         'ingest_log',
         'entry_sources',
+        'signal_watermarks',
         'entries_fts',
         'idx_entries_embedding',
         'idx_entries_type',
@@ -100,7 +102,7 @@ describe("db schema", () => {
       )
       GROUP BY name
     `);
-    expect(namesResult.rows).toHaveLength(22);
+    expect(namesResult.rows).toHaveLength(23);
     for (const row of namesResult.rows as Array<{ count?: unknown }>) {
       expect(Number(row.count)).toBe(1);
     }

--- a/tests/integration/signals-since-seq.test.ts
+++ b/tests/integration/signals-since-seq.test.ts
@@ -1,0 +1,135 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { initDb } from "../../src/db/client.js";
+import { createMcpServer } from "../../src/mcp/server.js";
+
+const clients: Client[] = [];
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return Number(value);
+  }
+  return Number.NaN;
+}
+
+function makeClient(): Client {
+  const client = createClient({ url: ":memory:" });
+  clients.push(client);
+  return client;
+}
+
+async function insertEntry(client: Client, id: string, importance: number, content: string): Promise<number> {
+  const createdAt = new Date().toISOString();
+  await client.execute({
+    sql: `
+      INSERT INTO entries (
+        id, type, subject, content, importance, expiry, scope, source_file, source_context,
+        created_at, updated_at, retired
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+    `,
+    args: [
+      id,
+      "fact",
+      id,
+      content,
+      importance,
+      "temporary",
+      "private",
+      "signals-since-seq.test.jsonl",
+      "integration test",
+      createdAt,
+      createdAt,
+    ],
+  });
+  const row = await client.execute({
+    sql: "SELECT rowid FROM entries WHERE id = ?",
+    args: [id],
+  });
+  return toNumber((row.rows[0] as { rowid?: unknown } | undefined)?.rowid);
+}
+
+function getToolText(response: unknown): string {
+  const payload = response as {
+    result?: { content?: Array<{ type?: string; text?: string }> };
+  };
+  return payload.result?.content?.[0]?.text ?? "";
+}
+
+afterEach(() => {
+  while (clients.length > 0) {
+    clients.pop()?.close();
+  }
+});
+
+describe("integration: since_seq incremental recall", () => {
+  it("returns all entries by rowid and supports high-watermark empty responses", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    const rowid1 = await insertEntry(client, "entry-1", 5, "importance 5");
+    const rowid2 = await insertEntry(client, "entry-2", 8, "importance 8");
+    const rowid3 = await insertEntry(client, "entry-3", 9, "importance 9");
+
+    const server = createMcpServer(
+      {},
+      {
+        readConfigFn: () => ({ db: { path: ":memory:" } }),
+        resolveEmbeddingApiKeyFn: () => "sk-test",
+        getDbFn: () => client,
+        initDbFn: async () => undefined,
+        closeDbFn: () => undefined,
+      },
+    );
+
+    const first = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "agenr_recall",
+        arguments: {
+          since_seq: 0,
+          limit: 10,
+        },
+      },
+    });
+
+    const firstText = getToolText(first);
+    expect(firstText).toContain("3 entries since seq 0:");
+    expect(firstText).toContain(`[rowid=${rowid1}] [id=entry-1]`);
+    expect(firstText).toContain(`[rowid=${rowid2}] [id=entry-2]`);
+    expect(firstText).toContain(`[rowid=${rowid3}] [id=entry-3]`);
+    const pos1 = firstText.indexOf(`[rowid=${rowid1}] [id=entry-1]`);
+    const pos2 = firstText.indexOf(`[rowid=${rowid2}] [id=entry-2]`);
+    const pos3 = firstText.indexOf(`[rowid=${rowid3}] [id=entry-3]`);
+    expect(pos1).toBeGreaterThan(-1);
+    expect(pos2).toBeGreaterThan(pos1);
+    expect(pos3).toBeGreaterThan(pos2);
+
+    const highWatermark = Math.max(rowid1, rowid2, rowid3) + 100;
+    const second = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "agenr_recall",
+        arguments: {
+          since_seq: highWatermark,
+          limit: 10,
+        },
+      },
+    });
+
+    const secondText = getToolText(second);
+    expect(secondText).toBe(`No new entries since seq ${highWatermark}.`);
+
+    await server.stop();
+  });
+});

--- a/tests/openclaw-plugin/plugin.test.ts
+++ b/tests/openclaw-plugin/plugin.test.ts
@@ -347,6 +347,44 @@ describe("agenr OpenClaw plugin", () => {
     expect(checkSignals).not.toHaveBeenCalled();
   });
 
+  it("before_prompt_build skips when enabled=false (global disable)", async () => {
+    vi.resetModules();
+    vi.doMock(dbClientModulePath, () => ({
+      getDb: vi.fn(() => ({ execute: vi.fn(), close: vi.fn() })),
+      initDb: vi.fn(async () => undefined),
+      closeDb: vi.fn(() => undefined),
+    }));
+    const checkSignals = vi.fn(async () => "AGENR SIGNAL: ...");
+    vi.doMock(signalsModulePath, () => ({
+      checkSignals,
+      resolveSignalConfig: vi.fn(() => ({ minImportance: 7, maxPerSignal: 5 })),
+    }));
+
+    const { beforePromptBuildHandler } = await registerPlugin({ enabled: false });
+    const result = await beforePromptBuildHandler({}, { sessionKey: "agent:main:test-global-disable" });
+    expect(result).toBeUndefined();
+    expect(checkSignals).not.toHaveBeenCalled();
+  });
+
+  it("before_prompt_build skips when sessionKey is empty string", async () => {
+    vi.resetModules();
+    const checkSignals = vi.fn(async () => "AGENR SIGNAL: ...");
+    vi.doMock(dbClientModulePath, () => ({
+      getDb: vi.fn(),
+      initDb: vi.fn(),
+      closeDb: vi.fn(),
+    }));
+    vi.doMock(signalsModulePath, () => ({
+      checkSignals,
+      resolveSignalConfig: vi.fn(() => ({ minImportance: 7, maxPerSignal: 5 })),
+    }));
+
+    const { beforePromptBuildHandler } = await registerPlugin();
+    const result = await beforePromptBuildHandler({}, { sessionKey: "" });
+    expect(result).toBeUndefined();
+    expect(checkSignals).not.toHaveBeenCalled();
+  });
+
   it("before_prompt_build returns prependContext with signal", async () => {
     vi.resetModules();
     const fakeDb = { execute: vi.fn(), close: vi.fn() };


### PR DESCRIPTION
## Summary

Implements the v0.7.0 Signal Engine - mid-session push delivery of high-importance memory entries via the OpenClaw `before_prompt_build` hook.

## What ships

- **Mid-session signals:** When new entries with importance >= 7 are stored while a session is active, the next agent turn receives a compact 50-100 token notification instead of a context dump
- **`signal_watermarks` table:** Per-consumer rowid-based watermark tracking (monotonic, zero clock skew)
- **`since_seq` on `agenr_recall`:** Optional MCP param for watermark-based incremental recall without embedding cost
- **Signal config:** `signalsEnabled`, `signalMinImportance`, `signalMaxPerSignal`, `dbPath` plugin config options

## Signal format

```
AGENR SIGNAL: 2 new high-importance entries
- [decision, imp:9] "Switch to Postgres for prod"
- [todo, imp:8] "Follow up with client re: contract"
-> Use agenr_recall query="<subject>" for details.
```

## Architecture

- Core signal logic in `src/db/signals.ts` (platform-agnostic)
- OpenClaw adapter in `src/openclaw-plugin/signals.ts` (~54 lines)
- `before_prompt_build` hook fires every turn, sub-ms SQLite query, errors swallowed and logged (never blocks prompt)
- `initializeWatermark` bootstraps new consumers to MAX(rowid) so pre-existing entries are not replayed
- Delivery semantics: at-least-once (documented)

## Tests

744 tests passing across 78 test files. Includes:
- Unit tests for all signal functions
- Integration test against real libsql `:memory:` DB (no mocks)
- Plugin hook behavior tests (skip patterns, error swallowing, config flags)
- MCP `since_seq` path tests

Closes #55 (partial - per-project brain dirs deferred to v0.7.1+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signals notification system, incremental recall (since_seq) for recall tool, and before_prompt_build hook to prepend signal context.
  * Plugin-configurable signal settings and DB-backed signal tracking (migration adds signal watermarks).

* **Documentation**
  * Published changelog entry for v0.7.0.

* **Tests**
  * Added extensive unit and integration tests covering signals, recall behavior, and plugin hook scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->