### PR TITLE
feat(plugin): bundled skill + openclaw init cleanup (v0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
-## [0.7.2] - 2026-02-20
+## [0.7.3] - 2026-02-20
 
-### Fixed
-- fix(store): within-batch deduplication - entries with the same subject+type+source file in a single storeEntries() call are now deduplicated before processing, preventing same-batch signal duplicates (entries from different source files with the same subject are kept as distinct)
-- fix(store): re-extraction guard - entries with the same subject+type+source_file extracted within 24 hours now increment confirmations instead of adding a new entry
-- fix(mcp): append-only MCP access log at ~/.agenr/mcp-access.log for observability of agenr_recall and agenr_store tool calls
+### Added
+- feat(plugin): bundled OpenClaw skill (skills/SKILL.md) - teaches agents when to call agenr_store and agenr_recall as MCP tools; automatically available when plugin is installed
+- feat(plugin): complete configSchema in openclaw.plugin.json (signalMinImportance, signalMaxPerSignal, signalsEnabled, dbPath)
+
+### Changed
+- fix(init): removed AGENTS.md auto-detection heuristic for openclaw platform - openclaw must be specified explicitly via --platform openclaw (AGENTS.md is also used by Codex; the heuristic was unreliable)
+- fix(init): agenr init --platform openclaw no longer writes to AGENTS.md - the OpenClaw plugin handles memory injection via prependContext; AGENTS.md write was redundant
+
+### Internal
+- chore(plugin): bump openclaw.plugin.json version to 0.7.3
 
 ## [0.7.1] - 2026-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
 ### Internal
 - chore(plugin): bump openclaw.plugin.json version to 0.7.3
 
+## [0.7.2] - 2026-02-20
+
+### Fixed
+- fix(store): within-batch deduplication - entries with the same subject+type+source file in a single storeEntries() call are now deduplicated before processing, preventing same-batch signal duplicates (entries from different source files with the same subject are kept as distinct)
+- fix(store): re-extraction guard - entries with the same subject+type+source_file extracted within 24 hours now increment confirmations instead of adding a new entry
+- fix(mcp): append-only MCP access log at ~/.agenr/mcp-access.log for observability of agenr_recall and agenr_store tool calls
+
 ## [0.7.1] - 2026-02-20
 
 ### Added

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,10 @@
   "id": "agenr",
   "name": "agenr Memory",
   "description": "Local memory layer - injects agenr context at session start",
-  "version": "0.6.6",
+  "version": "0.7.3",
+  "skills": [
+    "skills"
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -18,6 +21,22 @@
       "enabled": {
         "type": "boolean",
         "description": "Set false to disable memory injection without uninstalling."
+      },
+      "signalMinImportance": {
+        "type": "number",
+        "description": "Minimum importance for mid-session signals (1-10, default: 7). Raise to reduce noise."
+      },
+      "signalMaxPerSignal": {
+        "type": "number",
+        "description": "Max entries per signal notification (default: 5)."
+      },
+      "signalsEnabled": {
+        "type": "boolean",
+        "description": "Set false to disable mid-session signals without uninstalling."
+      },
+      "dbPath": {
+        "type": "string",
+        "description": "Path to agenr DB. Defaults to AGENR_DB_PATH env or ~/.agenr/knowledge.db."
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"
@@ -54,6 +54,7 @@
   ],
   "files": [
     "dist",
+    "skills",
     "openclaw.plugin.json",
     "CHANGELOG.md",
     "LICENSE",

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: agenr
+description: Use when storing new knowledge (decisions, preferences, lessons, todos) or recalling context mid-session. The agenr plugin auto-injects memory at session start - this skill covers proactive store and on-demand recall.
+---
+
+Use `agenr_store` proactively. Call it immediately after any decision, user preference, lesson learned, important event, or fact worth remembering. Do not ask first.
+
+Required fields: `type`, `content`, `importance`.
+Types: `fact | decision | preference | todo | lesson | event`.
+Importance: `1-10` (default `7`), use `9` for critical items, use `10` sparingly.
+
+Do not store secrets/credentials, temporary state, or verbatim conversation.
+
+Use `agenr_recall` mid-session when you need context you do not already have. Use a specific query so results stay relevant.
+
+Session-start recall is already handled automatically by the OpenClaw plugin. Do not call `agenr_recall` at turn 1 unless you need extra context beyond the injected summary.


### PR DESCRIPTION
## What

Two related improvements to the OpenClaw plugin experience.

## 1. Bundled SKILL.md

Adds `skills/SKILL.md` to the plugin package. When installed, OpenClaw automatically loads this skill, teaching the agent when and how to use `agenr_store` and `agenr_recall` as MCP tools.

- `agenr_store`: call immediately after decisions, preferences, lessons, events. No asking first.
- `agenr_recall`: call mid-session when you need context you don't have. Not at turn 1 — the plugin's auto-injection handles session-start recall.

Registered via `"skills": ["skills"]` in `openclaw.plugin.json`. Also completes the plugin's `configSchema` with the 4 fields that were wired in code since v0.7.0 but missing from the manifest: `signalMinImportance`, `signalMaxPerSignal`, `signalsEnabled`, `dbPath`.

## 2. openclaw init cleanup

`agenr init` no longer writes to `AGENTS.md` for the openclaw platform:

- **Removed**: `AGENTS.md` presence as auto-detection heuristic for openclaw (unreliable — Codex also uses `AGENTS.md`)
- **Changed**: `--platform openclaw` now returns `null` for `instructionsPath` and skips `upsertPromptBlock` entirely
- **Kept**: `writeMcpConfig` still runs — agents need the MCP server for `agenr_store`/`agenr_recall` tool calls

The OpenClaw plugin's `prependContext` injection makes the AGENTS.md write redundant. The bundled skill covers what AGENTS.md was doing.

## Changes

- `skills/SKILL.md` — new bundled skill
- `openclaw.plugin.json` — version 0.7.3, 4 config fields added, skills dir registered
- `src/commands/init.ts` — openclaw platform: null instructionsPath, skip AGENTS.md write
- `src/commands/init.test.ts` — 2 new tests replace old AGENTS.md auto-detect test
- `CHANGELOG.md`, `package.json` — v0.7.3

## Testing

`pnpm test` — 771/771 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "agenr" skill for storing and recalling knowledge during sessions.
  * Added signal configuration options: importance threshold, max entries per notification, and enable/disable toggle.
  * Added configurable database path for knowledge storage.

* **Changed**
  * Updated memory injection handling for improved platform compatibility.
  * Modified platform detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->