### PR TITLE
fix(store): within-batch dedup + re-extraction guard + MCP access log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.2] - 2026-02-20
+
+### Fixed
+- fix(store): within-batch deduplication - entries with the same subject+type in a single storeEntries() call are now deduplicated before processing, preventing same-batch signal duplicates
+- fix(store): re-extraction guard - entries with the same subject+type+source_file extracted within 24 hours now increment confirmations instead of adding a new entry
+- fix(mcp): append-only MCP access log at ~/.agenr/mcp-access.log for observability of agenr_recall and agenr_store tool calls
+
 ## [0.7.1] - 2026-02-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.7.2] - 2026-02-20
 
 ### Fixed
-- fix(store): within-batch deduplication - entries with the same subject+type in a single storeEntries() call are now deduplicated before processing, preventing same-batch signal duplicates
+- fix(store): within-batch deduplication - entries with the same subject+type+source file in a single storeEntries() call are now deduplicated before processing, preventing same-batch signal duplicates (entries from different source files with the same subject are kept as distinct)
 - fix(store): re-extraction guard - entries with the same subject+type+source_file extracted within 24 hours now increment confirmations instead of adding a new entry
 - fix(mcp): append-only MCP access log at ~/.agenr/mcp-access.log for observability of agenr_recall and agenr_store tool calls
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/db/store.test.ts
+++ b/src/db/store.test.ts
@@ -2,7 +2,7 @@ import { createClient, type Client } from "@libsql/client";
 import { afterEach, describe, expect, it } from "vitest";
 import type { KnowledgeEntry } from "../types.js";
 import { initDb } from "./client.js";
-import { storeEntries } from "./store.js";
+import { findRecentEntryBySubjectTypeAndSourceFile, storeEntries } from "./store.js";
 
 const clients: Client[] = [];
 
@@ -132,6 +132,15 @@ describe("db store", () => {
 
     expect(result.updated).toBe(1);
     expect(result.added).toBe(0);
+    const persisted = await findRecentEntryBySubjectTypeAndSourceFile(
+      client,
+      "bar",
+      "fact",
+      "/tmp/session.jsonl",
+      48,
+    );
+    expect(persisted).not.toBeNull();
+    expect(persisted!.confirmations).toBeGreaterThan(0);
   });
 
   it("source-file recency guard: same subject+type but different source_file adds new entry", async () => {

--- a/src/db/store.test.ts
+++ b/src/db/store.test.ts
@@ -1,0 +1,172 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import type { KnowledgeEntry } from "../types.js";
+import { initDb } from "./client.js";
+import { storeEntries } from "./store.js";
+
+const clients: Client[] = [];
+
+function makeClient(): Client {
+  const client = createClient({ url: ":memory:" });
+  clients.push(client);
+  return client;
+}
+
+function makeEntry(params: {
+  subject: string;
+  type: KnowledgeEntry["type"];
+  content: string;
+  sourceFile: string;
+}): KnowledgeEntry {
+  return {
+    subject: params.subject,
+    type: params.type,
+    content: params.content,
+    importance: 7,
+    expiry: "temporary",
+    tags: [],
+    source: {
+      file: params.sourceFile,
+      context: "store-test",
+    },
+  };
+}
+
+const embedStub = async (texts: string[], _apiKey: string): Promise<number[][]> =>
+  texts.map(() => new Array(1024).fill(0));
+
+afterEach(() => {
+  while (clients.length > 0) {
+    clients.pop()?.close();
+  }
+});
+
+describe("db store", () => {
+  it("within-batch dedup: two entries with same subject+type yield 1 added + 1 skipped", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    const result = await storeEntries(
+      client,
+      [
+        makeEntry({
+          subject: "version 0.7.1 release",
+          type: "event",
+          content: "Initial release summary",
+          sourceFile: "/tmp/session.jsonl",
+        }),
+        makeEntry({
+          subject: "version 0.7.1 release",
+          type: "event",
+          content: "Refined release summary",
+          sourceFile: "/tmp/session.jsonl",
+        }),
+      ],
+      "test-api-key",
+      { embedFn: embedStub },
+    );
+
+    expect(result.added).toBe(1);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("within-batch dedup: same subject but different type are both kept", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    const result = await storeEntries(
+      client,
+      [
+        makeEntry({
+          subject: "foo",
+          type: "fact",
+          content: "Foo is true",
+          sourceFile: "/tmp/session-a.jsonl",
+        }),
+        makeEntry({
+          subject: "foo",
+          type: "decision",
+          content: "Decided foo policy",
+          sourceFile: "/tmp/session-a.jsonl",
+        }),
+      ],
+      "test-api-key",
+      { embedFn: embedStub },
+    );
+
+    expect(result.added).toBe(2);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("source-file recency guard: same subject+type+source within 24h increments confirmations", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await storeEntries(
+      client,
+      [
+        makeEntry({
+          subject: "bar",
+          type: "fact",
+          content: "Initial bar content",
+          sourceFile: "/tmp/session.jsonl",
+        }),
+      ],
+      "test-api-key",
+      { embedFn: embedStub },
+    );
+
+    const result = await storeEntries(
+      client,
+      [
+        makeEntry({
+          subject: "bar",
+          type: "fact",
+          content: "Updated bar content with different wording",
+          sourceFile: "/tmp/session.jsonl",
+        }),
+      ],
+      "test-api-key",
+      { embedFn: embedStub },
+    );
+
+    expect(result.updated).toBe(1);
+    expect(result.added).toBe(0);
+  });
+
+  it("source-file recency guard: same subject+type but different source_file adds new entry", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await storeEntries(
+      client,
+      [
+        makeEntry({
+          subject: "bar",
+          type: "fact",
+          content: "Initial bar content",
+          sourceFile: "/tmp/session-a.jsonl",
+        }),
+      ],
+      "test-api-key",
+      { embedFn: embedStub },
+    );
+
+    const result = await storeEntries(
+      client,
+      [
+        makeEntry({
+          subject: "bar",
+          type: "fact",
+          content: "Updated bar content with different wording",
+          sourceFile: "/tmp/session-b.jsonl",
+        }),
+      ],
+      "test-api-key",
+      { embedFn: embedStub },
+    );
+
+    expect(result.added).toBe(1);
+    expect(result.updated).toBe(0);
+  });
+});

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1349,13 +1349,13 @@ export async function storeEntries(
         options.onDecision?.({
           entry: entries[i],
           action: "skipped",
-          reason: "within-batch duplicate (same subject+type)",
+          reason: "within-batch duplicate (same subject+type+source.file)",
         });
       }
     }
 
-    entries = entries.filter((_, i) => {
-      const key = `${entries[i].subject.trim().toLowerCase()}:${entries[i].type}:${entries[i].source.file}`;
+    entries = entries.filter((entry, i) => {
+      const key = `${entry.subject.trim().toLowerCase()}:${entry.type}:${entry.source.file}`;
       return seen.get(key) === i;
     });
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1091,12 +1091,11 @@ export function createMcpServer(
     try {
       if (params.name === "agenr_recall") {
         const result = await callRecallTool(params.args);
-        const args = params.args as Record<string, unknown> | undefined;
         await appendMcpLog({
           tool: "agenr_recall",
-          query: typeof args?.query === "string" ? args.query.slice(0, 120) : undefined,
-          context: typeof args?.context === "string" ? args.context : undefined,
-          project: typeof args?.project === "string" ? args.project : undefined,
+          query: typeof params.args.query === "string" ? (params.args.query as string).slice(0, 120) : undefined,
+          context: typeof params.args.context === "string" ? (params.args.context as string) : undefined,
+          project: typeof params.args.project === "string" ? (params.args.project as string) : undefined,
         });
         return {
           content: [{ type: "text", text: result }],
@@ -1105,16 +1104,15 @@ export function createMcpServer(
 
       if (params.name === "agenr_store") {
         const result = await callStoreTool(params.args);
-        const storeArgs = params.args as Record<string, unknown> | undefined;
-        const storeEntries = Array.isArray(storeArgs?.entries) ? storeArgs.entries : [];
-        const firstEntry = storeEntries[0] as Record<string, unknown> | undefined;
+        const storeArgsEntries = Array.isArray(params.args.entries) ? params.args.entries : [];
+        const firstEntry = storeArgsEntries[0] as Record<string, unknown> | undefined;
         await appendMcpLog({
           tool: "agenr_store",
-          count: storeEntries.length,
+          count: storeArgsEntries.length,
           firstType: typeof firstEntry?.type === "string" ? firstEntry.type : undefined,
           firstSubject: typeof firstEntry?.subject === "string" ? firstEntry.subject.slice(0, 80) : undefined,
           firstImportance: typeof firstEntry?.importance === "number" ? firstEntry.importance : undefined,
-          project: typeof storeArgs?.project === "string" ? storeArgs.project : undefined,
+          project: typeof params.args.project === "string" ? (params.args.project as string) : undefined,
         });
         return {
           content: [{ type: "text", text: result }],

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1105,13 +1105,16 @@ export function createMcpServer(
 
       if (params.name === "agenr_store") {
         const result = await callStoreTool(params.args);
-        const args = params.args as Record<string, unknown> | undefined;
+        const storeArgs = params.args as Record<string, unknown> | undefined;
+        const storeEntries = Array.isArray(storeArgs?.entries) ? storeArgs.entries : [];
+        const firstEntry = storeEntries[0] as Record<string, unknown> | undefined;
         await appendMcpLog({
           tool: "agenr_store",
-          type: typeof args?.type === "string" ? args.type : undefined,
-          subject: typeof args?.subject === "string" ? args.subject.slice(0, 80) : undefined,
-          importance: typeof args?.importance === "number" ? args.importance : undefined,
-          project: typeof args?.project === "string" ? args.project : undefined,
+          count: storeEntries.length,
+          firstType: typeof firstEntry?.type === "string" ? firstEntry.type : undefined,
+          firstSubject: typeof firstEntry?.subject === "string" ? firstEntry.subject.slice(0, 80) : undefined,
+          firstImportance: typeof firstEntry?.importance === "number" ? firstEntry.importance : undefined,
+          project: typeof storeArgs?.project === "string" ? storeArgs.project : undefined,
         });
         return {
           content: [{ type: "text", text: result }],


### PR DESCRIPTION
## Summary

Fixes 3 signal reliability bugs and adds MCP access logging.

### Fixes
- **Within-batch dedup** - When storing multiple entries in one call, identical entries (same subject+type+source_file within recency window) were all written. Now guards against duplicates within the same batch.
- **Re-extraction guard** - Growing session transcripts were re-extracted each run, causing duplicate signals from previously-processed content. Recency guard prevents re-insertion of entries seen within the dedup window.
- **MCP access log** - `agenr_recall` and `agenr_store` calls were not logged to the access log. Now logs with correct field extraction from the MCP args shape.

### Tests
- 770/770 passing

### Changelog
See CHANGELOG.md for v0.7.2 entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved duplicate entries created when storing items with identical subject, type, and source file in a single operation
  * Implemented 24-hour time-window guard to prevent re-processing of identical content during extraction
  * Added MCP access logging at ~/.agenr/mcp-access.log for improved tool call observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->