### PR TITLE
fix(init): use result.platform in memory injection summary line

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -311,7 +311,7 @@ export function formatInitSummary(result: InitCommandResult): string[] {
   if (result.instructionsPath !== null) {
     lines.splice(2, 0, `- Wrote system prompt block to ${path.basename(result.instructionsPath)}`);
   } else {
-    lines.splice(2, 0, "- Memory injection: handled automatically by OpenClaw plugin (no AGENTS.md needed)");
+    lines.splice(2, 0, `- Memory injection: handled automatically by ${result.platform} plugin (no instructions file needed)`);
   }
   if (result.gitignoreUpdated) {
     lines.push("- Added .agenr/knowledge.db to .gitignore");


### PR DESCRIPTION
CRabbit nit from PR #80.

Changes hardcoded `"OpenClaw plugin"` string to `${result.platform}` in `formatInitSummary` so the summary line correctly reflects whatever platform was used, not just openclaw.

Also updates the trailing copy from `(no AGENTS.md needed)` to `(no instructions file needed)` for platform-agnostic wording.