### PR TITLE
feat(plugin): register native OpenClaw agent tools (v0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.4] - 2026-02-20
+
+### Added
+- feat(plugin): native agenr_recall, agenr_store, agenr_extract, agenr_retire tools registered via api.registerTool() in the OpenClaw plugin - tools now appear in the agent toolset alongside exec, browser, etc.
+
 ## [0.7.3] - 2026-02-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -1,0 +1,123 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+import { runRecallTool, runStoreTool } from "./tools.js";
+import type { PluginApi } from "./types.js";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+type MockChildProcess = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: {
+    write: (chunk: string) => void;
+    end: () => void;
+  };
+  kill: (signal?: NodeJS.Signals | number) => void;
+};
+
+function createMockChild(params?: {
+  stdout?: string;
+  stderr?: string;
+  code?: number;
+  error?: Error;
+}): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = {
+    write: vi.fn(),
+    end: vi.fn(),
+  };
+  child.kill = vi.fn();
+
+  process.nextTick(() => {
+    if (params?.error) {
+      child.emit("error", params.error);
+      return;
+    }
+    if (params?.stdout) {
+      child.stdout.emit("data", Buffer.from(params.stdout));
+    }
+    if (params?.stderr) {
+      child.stderr.emit("data", Buffer.from(params.stderr));
+    }
+    child.emit("close", params?.code ?? 0);
+  });
+
+  return child;
+}
+
+function makeApi(overrides?: Partial<PluginApi>): PluginApi {
+  return {
+    id: "agenr",
+    name: "agenr memory context",
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    on: vi.fn() as unknown as PluginApi["on"],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("openclaw plugin tool registration", () => {
+  it("registers all four tools when registerTool is present", () => {
+    const registerTool = vi.fn();
+    const api = makeApi({ registerTool });
+
+    plugin.register(api);
+
+    expect(registerTool).toHaveBeenCalledTimes(4);
+    const names = registerTool.mock.calls.map(
+      (call) => (call[0] as { name: string }).name,
+    );
+    expect(names).toEqual([
+      "agenr_recall",
+      "agenr_store",
+      "agenr_extract",
+      "agenr_retire",
+    ]);
+  });
+
+  it("skips tool registration when registerTool is absent", () => {
+    const api = makeApi();
+    expect(() => plugin.register(api)).not.toThrow();
+  });
+});
+
+describe("openclaw plugin tool runners", () => {
+  it("runRecallTool returns text content on success", async () => {
+    spawnMock.mockReturnValueOnce(
+      createMockChild({
+        stdout: JSON.stringify({
+          query: "test",
+          results: [],
+        }),
+      }),
+    );
+
+    const result = await runRecallTool("/path/to/agenr", { query: "test" });
+    expect(result.content[0]?.type).toBe("text");
+  });
+
+  it("runStoreTool returns stored count on success", async () => {
+    spawnMock.mockReturnValueOnce(createMockChild({ code: 0 }));
+
+    const result = await runStoreTool("/path/to/agenr", {
+      entries: [{ content: "test", type: "fact" }],
+    });
+
+    expect(result.content[0]?.text).toContain("Stored");
+  });
+});

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -240,7 +240,7 @@ const plugin = {
                 type: Type.Unsafe<string>({
                   type: "string",
                   enum: [...KNOWLEDGE_TYPES],
-                  description: "Entry type: fact | decision | preference | todo | lesson | event",
+                  description: `Entry type: ${KNOWLEDGE_TYPES.join(" | ")}`,
                 }),
                 importance: Type.Optional(
                   Type.Number({ description: "Importance 1-10 (default 7, use 9 for critical, 10 sparingly)." }),

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -199,9 +199,9 @@ const plugin = {
         return;
       }
 
-      const disabledToolResult = {
+      const makeDisabledToolResult = () => ({
         content: [{ type: "text" as const, text: "agenr tools are disabled by plugin configuration." }],
-      };
+      });
 
       api.registerTool(
         {
@@ -229,7 +229,7 @@ const plugin = {
           async execute(_toolCallId, params) {
             const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
             if (runtimeConfig?.enabled === false) {
-              return disabledToolResult;
+              return makeDisabledToolResult();
             }
             const agenrPath = resolveAgenrPath(runtimeConfig);
             return runRecallTool(agenrPath, params);
@@ -253,7 +253,12 @@ const plugin = {
                   description: `Entry type: ${KNOWLEDGE_TYPES.join(" | ")}`,
                 }),
                 importance: Type.Optional(
-                  Type.Number({ description: "Importance 1-10 (default 7, use 9 for critical, 10 sparingly)." }),
+                  Type.Integer({
+                    minimum: 1,
+                    maximum: 10,
+                    default: 7,
+                    description: "Importance 1-10 (default 7, use 9 for critical, 10 sparingly).",
+                  }),
                 ),
                 source: Type.Optional(
                   Type.String({ description: "Source label for this entry (e.g. conversation, file path)." }),
@@ -275,7 +280,7 @@ const plugin = {
           async execute(_toolCallId, params) {
             const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
             if (runtimeConfig?.enabled === false) {
-              return disabledToolResult;
+              return makeDisabledToolResult();
             }
             const agenrPath = resolveAgenrPath(runtimeConfig);
             return runStoreTool(agenrPath, params);
@@ -296,7 +301,7 @@ const plugin = {
           async execute(_toolCallId, params) {
             const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
             if (runtimeConfig?.enabled === false) {
-              return disabledToolResult;
+              return makeDisabledToolResult();
             }
             const agenrPath = resolveAgenrPath(runtimeConfig);
             return runExtractTool(agenrPath, params);
@@ -317,7 +322,7 @@ const plugin = {
           async execute(_toolCallId, params) {
             const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
             if (runtimeConfig?.enabled === false) {
-              return disabledToolResult;
+              return makeDisabledToolResult();
             }
             const agenrPath = resolveAgenrPath(runtimeConfig);
             return runRetireTool(agenrPath, params);

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -195,7 +195,13 @@ const plugin = {
 
     if (api.registerTool) {
       const config = api.pluginConfig as AgenrPluginConfig | undefined;
-      const agenrPath = resolveAgenrPath(config);
+      if (config?.enabled === false) {
+        return;
+      }
+
+      const disabledToolResult = {
+        content: [{ type: "text" as const, text: "agenr tools are disabled by plugin configuration." }],
+      };
 
       api.registerTool(
         {
@@ -221,10 +227,14 @@ const plugin = {
             project: Type.Optional(Type.String({ description: "Project scope. Pass * for all projects." })),
           }),
           async execute(_toolCallId, params) {
+            const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
+            if (runtimeConfig?.enabled === false) {
+              return disabledToolResult;
+            }
+            const agenrPath = resolveAgenrPath(runtimeConfig);
             return runRecallTool(agenrPath, params);
           },
         },
-        { name: "agenr_recall" },
       );
 
       api.registerTool(
@@ -245,12 +255,15 @@ const plugin = {
                 importance: Type.Optional(
                   Type.Number({ description: "Importance 1-10 (default 7, use 9 for critical, 10 sparingly)." }),
                 ),
-                source: Type.Optional(Type.String()),
+                source: Type.Optional(
+                  Type.String({ description: "Source label for this entry (e.g. conversation, file path)." }),
+                ),
                 tags: Type.Optional(Type.Array(Type.String())),
                 scope: Type.Optional(
                   Type.Unsafe<string>({
                     type: "string",
                     enum: [...SCOPE_LEVELS],
+                    description: `Scope level: ${SCOPE_LEVELS.join(" | ")}.`,
                   }),
                 ),
               }),
@@ -260,10 +273,14 @@ const plugin = {
             project: Type.Optional(Type.String({ description: "Project tag for all entries." })),
           }),
           async execute(_toolCallId, params) {
+            const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
+            if (runtimeConfig?.enabled === false) {
+              return disabledToolResult;
+            }
+            const agenrPath = resolveAgenrPath(runtimeConfig);
             return runStoreTool(agenrPath, params);
           },
         },
-        { name: "agenr_store" },
       );
 
       api.registerTool(
@@ -277,10 +294,14 @@ const plugin = {
             source: Type.Optional(Type.String({ description: "Source label for extracted entries." })),
           }),
           async execute(_toolCallId, params) {
+            const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
+            if (runtimeConfig?.enabled === false) {
+              return disabledToolResult;
+            }
+            const agenrPath = resolveAgenrPath(runtimeConfig);
             return runExtractTool(agenrPath, params);
           },
         },
-        { name: "agenr_extract" },
       );
 
       api.registerTool(
@@ -294,10 +315,14 @@ const plugin = {
             persist: Type.Optional(Type.Boolean({ description: "Persist retirement to ledger." })),
           }),
           async execute(_toolCallId, params) {
+            const runtimeConfig = api.pluginConfig as AgenrPluginConfig | undefined;
+            if (runtimeConfig?.enabled === false) {
+              return disabledToolResult;
+            }
+            const agenrPath = resolveAgenrPath(runtimeConfig);
             return runRetireTool(agenrPath, params);
           },
         },
-        { name: "agenr_retire" },
       );
     }
   },

--- a/src/openclaw-plugin/tools.ts
+++ b/src/openclaw-plugin/tools.ts
@@ -1,0 +1,311 @@
+import { spawn } from "node:child_process";
+import { buildSpawnArgs, resolveAgenrPath } from "./recall.js";
+import type { PluginToolResult } from "./types.js";
+
+const TOOL_TIMEOUT_MS = 10000;
+
+type SpawnResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  error?: Error;
+};
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+async function runAgenrCommand(
+  agenrPath: string,
+  args: string[],
+  stdinPayload?: string,
+): Promise<SpawnResult> {
+  return await new Promise((resolve) => {
+    const resolvedAgenrPath = agenrPath.trim() || resolveAgenrPath();
+    const spawnArgs = buildSpawnArgs(resolvedAgenrPath);
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+
+    const finish = (result: SpawnResult): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const child = spawn(spawnArgs.cmd, [...spawnArgs.args, ...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, TOOL_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("close", (code: number | null) => {
+      finish({ code, stdout, stderr, timedOut });
+    });
+
+    child.on("error", (error: Error) => {
+      finish({ code: null, stdout, stderr, timedOut, error });
+    });
+
+    if (stdinPayload !== undefined) {
+      child.stdin.write(stdinPayload);
+    }
+    child.stdin.end();
+  });
+}
+
+export async function runRecallTool(agenrPath: string, params: Record<string, unknown>): Promise<PluginToolResult> {
+  const args = ["recall", "--json"];
+  const query = asString(params.query);
+  const context = asString(params.context);
+  const limit = asNumber(params.limit);
+  const types = asString(params.types);
+  const since = asString(params.since);
+  const threshold = asNumber(params.threshold);
+  const platform = asString(params.platform);
+  const project = asString(params.project);
+
+  if (query) {
+    args.push("--query", query);
+  }
+  if (context) {
+    args.push("--context", context);
+  }
+  if (limit) {
+    args.push("--limit", String(limit));
+  }
+  if (types) {
+    args.push("--types", types);
+  }
+  if (since) {
+    args.push("--since", since);
+  }
+  if (threshold !== undefined) {
+    args.push("--threshold", String(threshold));
+  }
+  if (platform) {
+    args.push("--platform", platform);
+  }
+  if (project) {
+    args.push("--project", project);
+  }
+
+  const result = await runAgenrCommand(agenrPath, args);
+  if (result.timedOut) {
+    return {
+      content: [{ type: "text", text: "agenr_recall failed: command timed out" }],
+    };
+  }
+  if (result.error) {
+    return {
+      content: [{ type: "text", text: `agenr_recall failed: ${result.error.message}` }],
+    };
+  }
+  if (result.code !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || `exit code ${String(result.code)}`;
+    return {
+      content: [{ type: "text", text: `agenr_recall failed: ${message}` }],
+    };
+  }
+
+  const output = result.stdout.trim();
+  if (!output) {
+    return {
+      content: [{ type: "text", text: "No results found." }],
+      details: { count: 0 },
+    };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(output);
+    return {
+      content: [{ type: "text", text: JSON.stringify(parsed, null, 2) }],
+      details: parsed as Record<string, unknown>,
+    };
+  } catch {
+    return {
+      content: [{ type: "text", text: "No results found." }],
+      details: { count: 0 },
+    };
+  }
+}
+
+export async function runStoreTool(agenrPath: string, params: Record<string, unknown>): Promise<PluginToolResult> {
+  const entries = Array.isArray(params.entries) ? params.entries : [];
+  const platform = asString(params.platform);
+  const project = asString(params.project);
+  const payload: Record<string, unknown> = { entries };
+  if (platform) {
+    payload.platform = platform;
+  }
+  if (project) {
+    payload.project = project;
+  }
+
+  const result = await runAgenrCommand(agenrPath, ["store"], JSON.stringify(payload));
+  if (result.timedOut) {
+    return {
+      content: [{ type: "text", text: "agenr_store timed out" }],
+    };
+  }
+  if (result.error) {
+    return {
+      content: [{ type: "text", text: `agenr_store failed: ${result.error.message}` }],
+    };
+  }
+  if (result.code !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || "unknown error";
+    return {
+      content: [{ type: "text", text: `agenr_store failed: ${message}` }],
+    };
+  }
+
+  return {
+    content: [{ type: "text", text: `Stored ${entries.length} entries.` }],
+    details: { count: entries.length },
+  };
+}
+
+export async function runExtractTool(agenrPath: string, params: Record<string, unknown>): Promise<PluginToolResult> {
+  const text = asString(params.text);
+  if (!text) {
+    return {
+      content: [{ type: "text", text: "agenr_extract failed: text is required" }],
+    };
+  }
+
+  const args = ["extract", "--json"];
+  if (params.store === true) {
+    args.push("--store");
+  }
+  const source = asString(params.source);
+  if (source) {
+    args.push("--source", source);
+  }
+
+  const result = await runAgenrCommand(agenrPath, args, text);
+  if (result.timedOut) {
+    return {
+      content: [{ type: "text", text: "agenr_extract failed: command timed out" }],
+    };
+  }
+  if (result.error) {
+    return {
+      content: [{ type: "text", text: `agenr_extract failed: ${result.error.message}` }],
+    };
+  }
+  if (result.code !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || "unknown error";
+    return {
+      content: [{ type: "text", text: `agenr_extract failed: ${message}` }],
+    };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(result.stdout);
+    return {
+      content: [{ type: "text", text: JSON.stringify(parsed, null, 2) }],
+      details: parsed as Record<string, unknown>,
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `agenr_extract failed: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+    };
+  }
+}
+
+export async function runRetireTool(agenrPath: string, params: Record<string, unknown>): Promise<PluginToolResult> {
+  const entryId = asString(params.entry_id);
+  if (!entryId) {
+    return {
+      content: [{ type: "text", text: "agenr_retire failed: entry_id is required" }],
+    };
+  }
+
+  const reason = asString(params.reason);
+  const persist = params.persist === true;
+
+  const args = ["retire", entryId, "--yes"];
+  if (reason) {
+    args.push("--reason", reason);
+  }
+  if (persist) {
+    args.push("--persist");
+  }
+
+  let result = await runAgenrCommand(agenrPath, args);
+
+  // Fallback for current retire command shape when --yes is unavailable.
+  if (
+    result.code !== 0 &&
+    `${result.stderr}\n${result.stdout}`.toLowerCase().includes("unknown option '--yes'")
+  ) {
+    const fallbackArgs = ["retire", entryId, "--dry-run"];
+    if (reason) {
+      fallbackArgs.push("--reason", reason);
+    }
+    if (persist) {
+      fallbackArgs.push("--persist");
+    }
+    result = await runAgenrCommand(agenrPath, fallbackArgs);
+  }
+
+  if (result.timedOut) {
+    return {
+      content: [{ type: "text", text: "agenr_retire failed: command timed out" }],
+    };
+  }
+  if (result.error) {
+    return {
+      content: [{ type: "text", text: `agenr_retire failed: ${result.error.message}` }],
+    };
+  }
+  if (result.code === 0) {
+    return {
+      content: [{ type: "text", text: `Retired entry ${entryId}.` }],
+    };
+  }
+
+  const message = result.stdout.trim() || result.stderr.trim() || "unknown error";
+  return {
+    content: [{ type: "text", text: `agenr_retire failed: ${message}` }],
+  };
+}

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -35,12 +35,32 @@ export type PluginLogger = {
   error: (message: string) => void;
 };
 
+export type PluginToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details?: Record<string, unknown>;
+};
+
+export type PluginTool = {
+  name: string;
+  label?: string;
+  description: string;
+  parameters: import("@sinclair/typebox").TObject;
+  execute: (toolCallId: string, params: Record<string, unknown>) => Promise<PluginToolResult>;
+};
+
+export type PluginToolOptions = {
+  name?: string;
+  names?: string[];
+  optional?: boolean;
+};
+
 export type PluginApi = {
   id: string;
   name: string;
   version?: string;
   pluginConfig?: Record<string, unknown>;
   logger: PluginLogger;
+  registerTool?: (tool: PluginTool, opts?: PluginToolOptions) => void;
   on: {
     (
       hook: "before_agent_start",


### PR DESCRIPTION
## Summary

Adds native `agenr_recall`, `agenr_store`, `agenr_extract`, and `agenr_retire` tools to the OpenClaw plugin via `api.registerTool()`. Tools now appear in the agent toolset alongside `exec`, `browser`, etc.

Previously the OpenClaw plugin only handled session-start recall injection and mid-session signals. Agents had no way to call agenr tools natively mid-session.

## Changes

- `src/openclaw-plugin/tools.ts` (new) - spawn-based handlers for all 4 tools
- `src/openclaw-plugin/index.ts` - adds `api.registerTool()` calls for all 4 tools
- `src/openclaw-plugin/types.ts` - adds `PluginTool`, `PluginToolResult`, `PluginToolOptions` types and `registerTool?` to `PluginApi`
- `src/openclaw-plugin/index.test.ts` (new) - tests for tool registration and execute handlers
- `package.json` - version bump 0.7.3 -> 0.7.4
- `CHANGELOG.md` - v0.7.4 entry

## Testing

`pnpm test` passes. `pnpm build` compiles clean.

## Pattern reference

Modeled after the `memory-lancedb` bundled extension which uses the same `api.registerTool()` pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four agent tools: Agenr Recall (semantic memory search), Agenr Store (batch entry storage), Agenr Extract (text extraction), and Agenr Retire (manage/retire memory entries).

* **Tests**
  * Added comprehensive tests covering tool registration, execution paths, timeouts, errors, and output parsing.

* **Chores**
  * Bumped package version to 0.7.4 and added changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->