### PR TITLE
feat: v0.7.5 signal noise reduction and dedup threshold improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.7.5] - 2026-02-20
+
+### Changed
+- fix(plugin): raise default signalMinImportance from 7 to 8 - default-importance stores (importance 7) no longer trigger mid-session signal interrupts
+- fix(plugin): lower default maxPerSignal from 5 to 3 - smaller batches
+- fix(dedup): lower DEFAULT_DEDUP_THRESHOLD from 0.80 to 0.72 - entries with cosine similarity 0.72-0.80 now reach LLM review instead of being stored as duplicates
+- fix(extractor): increase MAX_PREFETCH_RESULTS from 3 to 5 and lower PREFETCH_SIMILARITY_THRESHOLD from 0.78 to 0.72
+
+### Added
+- feat(plugin): signalCooldownMs config - minimum ms between signal batches per session (default: 30000)
+- feat(plugin): signalMaxPerSession config - max total signal batches per session lifetime (default: 10)
+- feat(plugin): signalMaxAgeSec config - only surface entries created within last N seconds (default: 300)
+- feat(dedup): dedup.aggressive config in ~/.agenr/config.json - lower thresholds and more candidate lookups for high-noise environments
+- feat(dedup): dedup.threshold config - manual override for LLM dedup similarity threshold
+
 ## [0.7.4] - 2026-02-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - fix(plugin): lower default maxPerSignal from 5 to 3 - smaller batches
 - fix(dedup): lower DEFAULT_DEDUP_THRESHOLD from 0.80 to 0.72 - entries with cosine similarity 0.72-0.80 now reach LLM review instead of being stored as duplicates
 - fix(extractor): increase MAX_PREFETCH_RESULTS from 3 to 5 and lower PREFETCH_SIMILARITY_THRESHOLD from 0.78 to 0.72
+- fix(extractor): increase PREFETCH_CANDIDATE_LIMIT from 10 to 15 for broader elaborative encoding candidates
+- fix(extractor): tighten extractor prompt to suppress near-variant entries already captured in DB
 
 ### Added
 - feat(plugin): signalCooldownMs config - minimum ms between signal batches per session (default: 30000)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -42,6 +42,27 @@ Stores:
 }
 ```
 
+### dedup
+
+Controls deduplication behavior when storing entries.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `aggressive` | boolean | `false` | Enable aggressive dedup: uses a lower similarity threshold (0.62) and checks more candidates (10). Useful in high-noise environments. |
+| `threshold` | number (0.0-1.0) | `0.72` | Override the LLM dedup similarity threshold. Entries above this threshold trigger LLM review. Lower values mean more entries reach the LLM reviewer. |
+
+Example in `~/.agenr/config.json`:
+```json
+{
+  "dedup": {
+    "aggressive": true,
+    "threshold": 0.65
+  }
+}
+```
+
+Note: `dedup.aggressive` in `~/.agenr/config.json` applies to all store paths (CLI, MCP, and the OpenClaw native plugin tool). The `dedup.threshold` field similarly applies globally.
+
 ## Database
 
 Default path: `~/.agenr/knowledge.db`

--- a/docs/OPENCLAW.md
+++ b/docs/OPENCLAW.md
@@ -117,6 +117,31 @@ fact, decision, preference, todo, relationship, event, lesson
 
 The key insight: **tell the agent what's worth remembering and what isn't.** Without guidance, agents either store everything (noisy) or nothing (defeats the purpose).
 
+### Tuning Signal Noise
+
+Three config fields control how often mid-session signal notifications fire:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `signalCooldownMs` | `30000` | Minimum ms between signal batches per session. Set `0` to disable. |
+| `signalMaxPerSession` | `10` | Max total signal batches per session lifetime. Set `0` to disable. |
+| `signalMaxAgeSec` | `300` | Only surface entries created in the last N seconds. Set `0` to disable age filter. |
+
+Example in `openclaw.json`:
+```json
+"plugins": {
+  "entries": {
+    "agenr": {
+      "config": {
+        "signalCooldownMs": 60000,
+        "signalMaxPerSession": 5,
+        "signalMaxAgeSec": 120
+      }
+    }
+  }
+}
+```
+
 ## Consolidation
 
 Over time, your knowledge base accumulates duplicates and near-duplicates. The same fact gets stored slightly differently across sessions. Consolidation merges these into clean canonical entries.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,11 +24,23 @@
       },
       "signalMinImportance": {
         "type": "number",
-        "description": "Minimum importance for mid-session signals (1-10, default: 7). Raise to reduce noise."
+        "description": "Minimum importance for mid-session signals (1-10, default: 8). Raise to reduce noise."
       },
       "signalMaxPerSignal": {
         "type": "number",
-        "description": "Max entries per signal notification (default: 5)."
+        "description": "Max entries per signal notification (default: 3)."
+      },
+      "signalCooldownMs": {
+        "type": "number",
+        "description": "Minimum ms between signal batches per session (default: 30000). Set 0 to disable cooldown."
+      },
+      "signalMaxPerSession": {
+        "type": "number",
+        "description": "Max total signal batches delivered per session lifetime (default: 10). Set 0 to disable."
+      },
+      "signalMaxAgeSec": {
+        "type": "number",
+        "description": "Only surface entries created within last N seconds (default: 300). Set 0 to disable age filter."
       },
       "signalsEnabled": {
         "type": "boolean",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "agenr",
   "name": "agenr Memory",
   "description": "Local memory layer - injects agenr context at session start",
-  "version": "0.7.3",
+  "version": "0.7.5",
   "skills": [
     "skills"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "agenr",
-  "version": "0.7.4",
+  "version": "0.7.5",
+
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -8,6 +8,10 @@ Use `agenr_store` proactively. Call it immediately after any decision, user pref
 Required fields: `type`, `content`, `importance`.
 Types: `fact | decision | preference | todo | lesson | event`.
 Importance: `1-10` (default `7`), use `9` for critical items, use `10` sparingly.
+Importance calibration: entries at importance 7 (the default) are saved to
+memory but will NOT trigger mid-session signals to active sessions. Use
+importance 8+ only for updates that other active sessions need to know about
+NOW. Routine facts should stay at 7.
 
 Do not store secrets/credentials, temporary state, or verbatim conversation.
 

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -23,6 +23,7 @@ export interface StoreCommandOptions {
   platform?: string;
   project?: string | string[];
   onlineDedup?: boolean;
+  aggressive?: boolean;
   dedupThreshold?: number | string;
 }
 
@@ -295,7 +296,7 @@ export async function runStoreCommand(
   );
 
   const config = resolvedDeps.readConfigFn(process.env);
-  const aggressiveDedup = config?.dedup?.aggressive === true;
+  const aggressiveDedup = options.aggressive === true ? true : config?.dedup?.aggressive === true;
   const configDedupThreshold = typeof config?.dedup?.threshold === "number"
     ? config.dedup.threshold
     : undefined;

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -295,6 +295,10 @@ export async function runStoreCommand(
   );
 
   const config = resolvedDeps.readConfigFn(process.env);
+  const aggressiveDedup = config?.dedup?.aggressive === true;
+  const configDedupThreshold = typeof config?.dedup?.threshold === "number"
+    ? config.dedup.threshold
+    : undefined;
   const platformRaw = options.platform?.trim();
   const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
   if (platformRaw && !platform) {
@@ -369,7 +373,8 @@ export async function runStoreCommand(
         force: options.force,
         verbose: options.verbose,
         onlineDedup,
-        dedupThreshold,
+        aggressiveDedup,
+        dedupThreshold: dedupThreshold ?? configDedupThreshold,
         llmClient,
         dbPath,
         sourceFile: input.sourceFile,

--- a/src/config.ts
+++ b/src/config.ts
@@ -227,6 +227,25 @@ function normalizeForgettingConfig(input: unknown): NonNullable<AgenrConfig["for
   return normalized;
 }
 
+function normalizeDedupConfig(input: unknown): AgenrConfig["dedup"] | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+
+  const record = input as Record<string, unknown>;
+  const normalized: NonNullable<AgenrConfig["dedup"]> = {};
+
+  if (typeof record.aggressive === "boolean") {
+    normalized.aggressive = record.aggressive;
+  }
+
+  if (typeof record.threshold === "number" && Number.isFinite(record.threshold) && record.threshold >= 0 && record.threshold <= 1) {
+    normalized.threshold = record.threshold;
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
 function normalizeLabelProjectMap(input: unknown): Record<string, string> | undefined {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     return undefined;
@@ -285,6 +304,11 @@ export function normalizeConfig(input: unknown): AgenrConfig {
   const labelProjectMap = normalizeLabelProjectMap(record.labelProjectMap);
   if (labelProjectMap) {
     normalized.labelProjectMap = labelProjectMap;
+  }
+
+  const dedup = normalizeDedupConfig(record.dedup);
+  if (dedup) {
+    normalized.dedup = dedup;
   }
 
   return normalized;
@@ -377,6 +401,13 @@ export function mergeConfigPatch(current: AgenrConfig | null, patch: AgenrConfig
     merged.forgetting = {
       ...(current?.forgetting ?? {}),
       ...(patch.forgetting ?? {}),
+    };
+  }
+
+  if (current?.dedup || patch.dedup) {
+    merged.dedup = {
+      ...(current?.dedup ?? {}),
+      ...(patch.dedup ?? {}),
     };
   }
 

--- a/src/db/signals.test.ts
+++ b/src/db/signals.test.ts
@@ -145,6 +145,27 @@ describe("db signals", () => {
     expect(batch.maxSeq).toBe(rowid);
   });
 
+  it("fetchNewSignalEntries respects maxAgeSec filter", async () => {
+    const client = makeClient();
+    await initDb(client);
+
+    await insertEntry(client, {
+      id: "old",
+      subject: "old",
+      importance: 9,
+      createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    });
+    await insertEntry(client, {
+      id: "new",
+      subject: "new",
+      importance: 9,
+      createdAt: new Date(Date.now() - 30 * 1000).toISOString(),
+    });
+
+    const batch = await fetchNewSignalEntries(client, 0, 8, 10, 300);
+    expect(batch.entries.map((entry) => entry.subject)).toEqual(["new"]);
+  });
+
   it("formatSignal produces correct format", () => {
     const formatted = formatSignal([
       {

--- a/src/db/signals.test.ts
+++ b/src/db/signals.test.ts
@@ -163,6 +163,7 @@ describe("db signals", () => {
     });
 
     const batch = await fetchNewSignalEntries(client, 0, 8, 10, 300);
+    expect(batch.entries).toHaveLength(1);
     expect(batch.entries.map((entry) => entry.subject)).toEqual(["new"]);
   });
 

--- a/src/db/signals.ts
+++ b/src/db/signals.ts
@@ -24,6 +24,7 @@ export async function fetchNewSignalEntries(
   sinceSeq: number,
   minImportance: number,
   limit: number,
+  // maxAgeSec: age filter window in seconds. Pass 0 (default) to disable age filtering.
   maxAgeSec: number = 0,
 ): Promise<SignalBatch> {
   const ageArgs: (string | number)[] = maxAgeSec > 0

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1319,11 +1319,14 @@ export async function storeEntries(
 ): Promise<StoreResult> {
   warnIfLocked();
 
+  const explicitThreshold = options.dedupThreshold !== undefined;
   const dedupThreshold = validateThreshold(
     options.dedupThreshold ??
       (options.aggressiveDedup === true ? AGGRESSIVE_DEDUP_THRESHOLD : DEFAULT_DEDUP_THRESHOLD),
   );
-  const similarLimit = options.aggressiveDedup === true ? AGGRESSIVE_SIMILAR_LIMIT : DEFAULT_SIMILAR_LIMIT;
+  // Only use aggressive candidate limit when aggressiveDedup is fully active (no explicit threshold override).
+  const similarLimit =
+    options.aggressiveDedup === true && !explicitThreshold ? AGGRESSIVE_SIMILAR_LIMIT : DEFAULT_SIMILAR_LIMIT;
   const onlineDedup = options.onlineDedup === true && options.force !== true;
   const llmDedupEnabled = onlineDedup && options.skipLlmDedup !== true;
   if (llmDedupEnabled && entries.length > 0 && !options.llmClient) {

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -252,10 +252,10 @@ const MAX_ATTEMPTS = 5;
 const DEFAULT_INTER_CHUNK_DELAY_MS = 150;
 const DEDUP_BATCH_SIZE = 50;
 const DEDUP_BATCH_TRIGGER = 100;
-export const PREFETCH_SIMILARITY_THRESHOLD = 0.78;
+export const PREFETCH_SIMILARITY_THRESHOLD = 0.72;
 const PREFETCH_SIMILARITY_EPSILON = 1e-6;
-export const PREFETCH_CANDIDATE_LIMIT = 10;
-export const MAX_PREFETCH_RESULTS = 3;
+export const PREFETCH_CANDIDATE_LIMIT = 15;
+export const MAX_PREFETCH_RESULTS = 5;
 export const PREFETCH_MIN_DB_ENTRIES = 20;
 export const PREFETCH_TIMEOUT_MS = 5000;
 
@@ -401,7 +401,7 @@ export function buildUserPrompt(chunk: TranscriptChunk, related?: StoredEntry[])
     "Existing related memories (reference only -- your SKIP/emit threshold is unchanged):",
     memoryBlock,
     "",
-    "Do not emit entries that express the same fact as any memory listed above, even in different words.",
+    "Do not emit entries that express the same fact, topic, or concept as any memory listed above, even if worded differently or from a different angle. If an existing memory already captures the core idea, do not emit a near-variant as a separate entry. When uncertain, omit rather than emit.",
     "If this chunk clearly contradicts a memory listed above, emit a fact entry stating the contradiction directly in the content field. Do not use inline citation markers like [1] or [2] in any field -- these become dead references.",
     "Only emit a cross-reference entry when this chunk extends, contradicts, or updates a specific fact. Do not cross-reference just because entries share the same project or general domain.",
     "Your SKIP/emit threshold is unchanged. The memories above are reference only.",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -963,12 +963,18 @@ export function createMcpServer(
         : parsed;
     const db = await ensureDb();
     const config = resolvedDeps.readConfigFn(env);
+    const aggressiveDedup = config?.dedup?.aggressive === true;
+    const configDedupThreshold = typeof config?.dedup?.threshold === "number"
+      ? config.dedup.threshold
+      : undefined;
     const dedupClient = resolvedDeps.createLlmClientFn({ config, env });
     const apiKey = resolvedDeps.resolveEmbeddingApiKeyFn(config, env);
     const result = await resolvedDeps.storeEntriesFn(db, entries, apiKey, {
       sourceFile: "mcp:agenr_store",
       onlineDedup: true,
       llmClient: dedupClient,
+      aggressiveDedup,
+      dedupThreshold: configDedupThreshold,
       dbPath: options.dbPath,
     });
 

--- a/src/openclaw-plugin/signals.ts
+++ b/src/openclaw-plugin/signals.ts
@@ -9,11 +9,17 @@ import {
 export interface SignalConfig {
   minImportance: number;
   maxPerSignal: number;
+  cooldownMs: number;
+  maxPerSession: number;
+  maxAgeSec: number;
 }
 
 const DEFAULT_SIGNAL_CONFIG: SignalConfig = {
-  minImportance: 7,
-  maxPerSignal: 5,
+  minImportance: 8,
+  maxPerSignal: 3,
+  cooldownMs: 30000,
+  maxPerSession: 10,
+  maxAgeSec: 300,
 };
 
 /**
@@ -32,7 +38,13 @@ export async function checkSignals(
   config: SignalConfig = DEFAULT_SIGNAL_CONFIG,
 ): Promise<string | null> {
   const watermark = await initializeWatermark(db, consumerId);
-  const batch = await fetchNewSignalEntries(db, watermark, config.minImportance, config.maxPerSignal);
+  const batch = await fetchNewSignalEntries(
+    db,
+    watermark,
+    config.minImportance,
+    config.maxPerSignal,
+    config.maxAgeSec,
+  );
 
   if (batch.entries.length === 0) {
     return null;
@@ -58,5 +70,8 @@ export function resolveSignalConfig(pluginConfig?: Record<string, unknown>): Sig
   return {
     minImportance: readNonNegativeInt(pluginConfig?.signalMinImportance, DEFAULT_SIGNAL_CONFIG.minImportance),
     maxPerSignal: readNonNegativeInt(pluginConfig?.signalMaxPerSignal, DEFAULT_SIGNAL_CONFIG.maxPerSignal),
+    cooldownMs: readNonNegativeInt(pluginConfig?.signalCooldownMs, DEFAULT_SIGNAL_CONFIG.cooldownMs),
+    maxPerSession: readNonNegativeInt(pluginConfig?.signalMaxPerSession, DEFAULT_SIGNAL_CONFIG.maxPerSession),
+    maxAgeSec: readNonNegativeInt(pluginConfig?.signalMaxAgeSec, DEFAULT_SIGNAL_CONFIG.maxAgeSec),
   };
 }

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -90,8 +90,14 @@ export type AgenrPluginConfig = {
   dbPath?: string;
   /** Set to false to disable mid-session signals (default: true) */
   signalsEnabled?: boolean;
-  /** Minimum importance for signal entries (default: 7) */
+  /** Minimum importance for signal entries (default: 8) */
   signalMinImportance?: number;
-  /** Max entries per signal notification (default: 5) */
+  /** Max entries per signal notification (default: 3) */
   signalMaxPerSignal?: number;
+  /** Minimum ms between signal batches per session (default: 30000). Set 0 to disable cooldown. */
+  signalCooldownMs?: number;
+  /** Max total signal batches delivered per session lifetime (default: 10). Set 0 to disable. */
+  signalMaxPerSession?: number;
+  /** Only surface entries created within last N seconds (default: 300). Set 0 to disable age filter. */
+  signalMaxAgeSec?: number;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,12 @@ export interface AgenrConfig {
   db?: {
     path?: string;
   };
+  dedup?: {
+    /** Enable aggressive dedup mode: lower thresholds, more candidates. */
+    aggressive?: boolean;
+    /** Override the LLM dedup similarity threshold (0.0-1.0). */
+    threshold?: number;
+  };
 }
 
 export interface KnowledgeEntry {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -192,4 +192,23 @@ describe("config", () => {
   it("drops empty labelProjectMap objects", () => {
     expect(normalizeConfig({ labelProjectMap: {} }).labelProjectMap).toBeUndefined();
   });
+
+  it("preserves dedup config through normalizeConfig", () => {
+    const normalized = normalizeConfig({
+      dedup: {
+        aggressive: true,
+        threshold: 0.72,
+      },
+    });
+
+    expect(normalized.dedup).toEqual({
+      aggressive: true,
+      threshold: 0.72,
+    });
+  });
+
+  it("drops invalid dedup config values", () => {
+    expect(normalizeConfig({ dedup: "yes" }).dedup).toBeUndefined();
+    expect(normalizeConfig({ dedup: { aggressive: "yes", threshold: 2 } }).dedup).toBeUndefined();
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -210,6 +210,17 @@ describe("config", () => {
   it("drops invalid dedup config values", () => {
     expect(normalizeConfig({ dedup: "yes" }).dedup).toBeUndefined();
     expect(normalizeConfig({ dedup: { aggressive: "yes", threshold: 2 } }).dedup).toBeUndefined();
+    // Partial invalidity: valid aggressive preserved, only out-of-range threshold dropped
+    expect(normalizeConfig({ dedup: { aggressive: true, threshold: 1.5 } }).dedup).toEqual({ aggressive: true });
+  });
+
+  it("preserves dedup config with only aggressive set", () => {
+    expect(normalizeConfig({ dedup: { aggressive: false } }).dedup).toEqual({ aggressive: false });
+    expect(normalizeConfig({ dedup: { aggressive: true } }).dedup).toEqual({ aggressive: true });
+  });
+
+  it("preserves dedup config with only threshold set", () => {
+    expect(normalizeConfig({ dedup: { threshold: 0.65 } }).dedup).toEqual({ threshold: 0.65 });
   });
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -212,3 +212,36 @@ describe("config", () => {
     expect(normalizeConfig({ dedup: { aggressive: "yes", threshold: 2 } }).dedup).toBeUndefined();
   });
 });
+
+describe("normalizeConfig dedup", () => {
+  it("normalizeConfig ignores missing dedup key", () => {
+    const config = normalizeConfig({ signalMinImportance: 8 });
+    expect(config.dedup).toBeUndefined();
+  });
+
+  it("normalizeConfig accepts aggressive: true with no threshold", () => {
+    const config = normalizeConfig({ dedup: { aggressive: true } });
+    expect(config.dedup).toEqual({ aggressive: true });
+    expect(config.dedup?.threshold).toBeUndefined();
+  });
+
+  it("normalizeConfig accepts threshold in range 0-1", () => {
+    const config = normalizeConfig({ dedup: { threshold: 0.65 } });
+    expect(config.dedup?.threshold).toBe(0.65);
+  });
+
+  it("normalizeConfig rejects threshold out of range", () => {
+    const config = normalizeConfig({ dedup: { threshold: 1.5 } });
+    expect(config.dedup?.threshold).toBeUndefined();
+  });
+
+  it("normalizeConfig rejects non-boolean aggressive", () => {
+    const config = normalizeConfig({ dedup: { aggressive: "yes" } });
+    expect(config.dedup?.aggressive).toBeUndefined();
+  });
+
+  it("normalizeConfig returns undefined dedup for empty object", () => {
+    const config = normalizeConfig({ dedup: {} });
+    expect(config.dedup).toBeUndefined();
+  });
+});

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -259,13 +259,13 @@ describe("pre-fetch", () => {
     const db = await makeDb();
     await seedEntries(db, 15, 0.1);
     await insertEntryWithEmbedding(db, "sim-080", 0.8, { subject: "sim-080", content: "sim-080" });
-    await insertEntryWithEmbedding(db, "sim-07801", 0.7801, { subject: "sim-07801", content: "sim-07801" });
-    await insertEntryWithEmbedding(db, "sim-07800", 0.78, { subject: "sim-07800", content: "sim-07800" });
-    await insertEntryWithEmbedding(db, "sim-07799", 0.7799, { subject: "sim-07799", content: "sim-07799" });
+    await insertEntryWithEmbedding(db, "sim-07201", 0.7201, { subject: "sim-07201", content: "sim-07201" });
+    await insertEntryWithEmbedding(db, "sim-07200", 0.72, { subject: "sim-07200", content: "sim-07200" });
+    await insertEntryWithEmbedding(db, "sim-07199", 0.7199, { subject: "sim-07199", content: "sim-07199" });
     await insertEntryWithEmbedding(db, "sim-070", 0.7, { subject: "sim-070", content: "sim-070" });
 
     const related = await preFetchRelated("chunk", db, "sk-test", async () => [unitVector(1)]);
-    expect(related.map((entry) => entry.subject)).toEqual(["sim-080", "sim-07801", "sim-07800"]);
+    expect(related.map((entry) => entry.subject)).toEqual(["sim-080", "sim-07201", "sim-07200"]);
   });
 
   it("caps related results at MAX_PREFETCH_RESULTS", async () => {


### PR DESCRIPTION
## Summary

Reduces mid-session signal spam and closes the dedup dead zone where semantically equivalent entries were bypassing LLM review.

## Changes

### Signal noise reduction
- Raise default `signalMinImportance` 7 -> 8 - default-importance stores no longer trigger mid-session interrupts
- Lower default `maxPerSignal` 5 -> 3 - smaller, less noisy batches
- New `signalCooldownMs` config - minimum ms between signal batches per session (default: 30000)
- New `signalMaxPerSession` config - max total signal batches per session lifetime (default: 10)
- New `signalMaxAgeSec` config - only surface entries created within last N seconds (default: 300)

### Dedup threshold fix
- Lower `DEFAULT_DEDUP_THRESHOLD` 0.80 -> 0.72 - entries at 0.72-0.80 cosine similarity now reach LLM review instead of being stored as duplicates
- New `dedup.aggressive` config in `~/.agenr/config.json` - lower thresholds and more candidate lookups for high-noise environments
- New `dedup.threshold` config - manual override for LLM dedup similarity threshold

### Extractor tuning
- Increase `MAX_PREFETCH_RESULTS` 3 -> 5
- Lower `PREFETCH_SIMILARITY_THRESHOLD` 0.78 -> 0.72

## Testing

`pnpm test` passes. `pnpm build` compiles clean.

## Notes

Built on top of v0.7.4 (native OpenClaw tool registration). Signal cooldown state is in-memory and resets on gateway restart - this is acceptable and acknowledged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signal management controls including cooldown periods, per-session limits, and age-based filtering
  * Introduced configurable dedup options with aggressive mode and custom similarity thresholds
  * Enhanced prefetch behavior with expanded similarity detection and increased result capacity

* **Documentation**
  * Added guidance on signal importance calibration for optimal session behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->