### PR TITLE
docs: README overhaul for v0.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ export OPENAI_API_KEY=sk-...  # for embeddings + extraction
 
 ```bash
 npm install -g agenr
-# or: pnpm add -g agenr
-pnpm add -g agenr
 
 agenr setup        # configure LLM provider + auth
 agenr ingest ~/.openclaw/agents/main/sessions/  # bootstrap from existing sessions
@@ -207,6 +205,8 @@ MCP settings.
 | `agenr retire <subject>` | Retire a stale entry (hidden, not deleted) |
 | `agenr watch [file]` | Live-watch files/directories, auto-extract knowledge |
 | `agenr daemon install` | Install background watch daemon (macOS launchd) |
+| `agenr daemon status` | Show daemon status (running/stopped, pid, watched file, recent logs) |
+| `agenr daemon logs [--lines <n>] [--follow]` | Stream or show recent daemon logs for troubleshooting |
 | `agenr consolidate` | Clean up and merge near-duplicates |
 | `agenr context` | Generate context file for AI tool integration |
 | `agenr health` | Show database health and forgetting candidates |


### PR DESCRIPTION
## Summary

Rewrites the README to reflect the current state of agenr through v0.7.5.

## Changes

- **Setup section** - full 3-step rewrite: install/ingest, daemon, platform wiring
- **OpenClaw section** - updated to reflect native tool registration (v0.7.4): agenr_recall, agenr_store, agenr_extract, agenr_retire now appear as native agent tools; updated config example with signalMinImportance: 8 and new cooldown fields
- **MCP integration section** - corrected from 3 to 4 tools (added agenr_retire); clarifies OpenClaw registers natively vs MCP
- **Commands table** - full replacement with current command set
- **Status** - removed Alpha label; updated test count to 782
- **What's next** - updated roadmap: Cursor live signals, Claude Code UserPromptSubmit adapter, transitive project dependencies
- **Live watching** - removed stale --auto deprecation notice

README.md only. No source or test changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined installation process supporting both npm and pnpm
  * Introduced daemon-centric workflow with new commands (agenr daemon install/status/logs)
  * Added platform-specific onboarding for OpenClaw, Claude Code, Cursor, Codex, and MCP-compatible tools
  * Expanded CLI command reference with new commands including init, health, retire, and todo
  * Updated examples for memory injection and agent configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->