### PR TITLE
fix(plugin): correct tool spawn args for recall, store, extract, and retire (v0.7.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - fix(plugin): removed unsupported `--threshold` forwarding from `agenr_recall`; threshold has no direct CLI equivalent
 - fix(plugin): `agenr_store` now sends entries array directly on stdin and passes `platform`/`project` as CLI flags
 - fix(plugin): `agenr_store` now infers missing `subject` from `content` before CLI spawn, matching MCP server behavior
+- fix(plugin): `agenr_retire` now calls `agenr retire --id <entry_id>` instead of subject matching with UUIDs
+- fix(cli): `agenr retire` now supports `--id <id>` and enforces exactly one of subject or `--id`
+- fix(plugin): `agenr_extract` now uses a two-step flow for `store=true` (`extract --json` then `store`) and injects source metadata before storing
+- fix(cli): `agenr store` now accepts the `--aggressive` flag used by plugin dedup config forwarding
 
 ## [0.7.5] - 2026-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.6] - 2026-02-20
+
+### Fixed
+- fix(plugin): `agenr_recall` now passes query as a positional argument instead of unsupported `--query`
+- fix(plugin): `agenr_recall` now uses `--type` (singular) instead of invalid `--types`
+- fix(plugin): removed unsupported `--threshold` forwarding from `agenr_recall`; threshold has no direct CLI equivalent
+- fix(plugin): `agenr_store` now sends entries array directly on stdin and passes `platform`/`project` as CLI flags
+- fix(plugin): `agenr_store` now infers missing `subject` from `content` before CLI spawn, matching MCP server behavior
+
 ## [0.7.5] - 2026-02-20
 
 ### Changed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -121,6 +121,7 @@ agenr store [options] [files...]
 - `--dry-run`: show write decisions without persisting.
 - `--verbose`: show per-entry dedup decisions.
 - `--force`: bypass dedup checks and insert all as new.
+- `--aggressive`: lower online dedup similarity threshold and increase candidate lookups.
 - `--platform <name>`: platform tag (`openclaw|claude-code|claude|codex`).
 - `--project <name>`: project tag (lowercase).
 - `--online-dedup`: enable online LLM dedup at write time (default `true`).
@@ -497,13 +498,14 @@ Consolidation Health
 Retire a stale entry from active recall. The entry is hidden from recall but not deleted from the database.
 
 ```bash
-agenr retire <subject> [options]
+agenr retire [subject] [options]
 ```
 
 Arguments:
-  subject    Subject to match (exact match by default)
+  subject    Subject to match (exact by default; mutually exclusive with --id)
 
 Options:
+  --id <id>          Retire a specific entry by ID (mutually exclusive with subject)
   --contains         Use substring matching instead of exact match
   --dry-run          Preview matches without retiring
   --persist          Write to retirements ledger so retirement survives re-ingest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.5",
+  "version": "0.7.6",
 
   "openclaw": {
     "extensions": [

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -170,9 +170,10 @@ describe("openclaw plugin tool runners", () => {
 
     expect(result.content[0]?.text).toContain("Stored");
     expect(result.content[0]?.text).toContain("2");
-    const payload = JSON.parse(writtenStdin) as { entries: unknown[] };
-    expect(Array.isArray(payload.entries)).toBe(true);
-    expect(payload.entries).toHaveLength(2);
+    const payload = JSON.parse(writtenStdin) as Array<{ subject?: string }>;
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload).toHaveLength(2);
+    expect(payload[0]?.subject).toBe("test entry 1");
   });
 
   it("runStoreTool passes dedup flags from plugin config", async () => {

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -249,7 +249,6 @@ const plugin = {
             since: Type.Optional(
               Type.String({ description: "Only entries newer than this (ISO date or relative, e.g. 7d)." }),
             ),
-            threshold: Type.Optional(Type.Number({ description: "Minimum relevance score 0.0-1.0." })),
             platform: Type.Optional(Type.String({ description: "Platform filter: openclaw, claude-code, codex." })),
             project: Type.Optional(Type.String({ description: "Project scope. Pass * for all projects." })),
           }),


### PR DESCRIPTION
## Summary

Fixes 9 CLI argument mismatches found during live dogfooding of v0.7.5 native tools in OpenClaw.

All bugs are in the OpenClaw plugin's tool spawn layer (`src/openclaw-plugin/tools.ts`), with supporting changes to `src/cli-main.ts` and `src/commands/retire.ts`.

## Bugs Fixed

### recall
- **Bug 1**: `query` was passed as `--query` flag - it's a positional argument
- **Bug 2**: `--types` should be `--type`
- **Bug 3**: `--threshold` flag does not exist on the CLI (removed; no equivalent)

### store
- **Bug 4**: `platform` and `project` were in the JSON payload instead of as CLI flags; stdin should be `KnowledgeEntry[]` not a wrapper object
- **Bug 5**: `subject` is required by CLI but not in the tool schema - added inference from `content` (matches MCP server behavior)
- **Bug 9**: `--aggressive` was used in spawn args but was never wired as a CLI flag in `cli-main.ts`

### extract
- **Bug 7**: `--store` flag does not exist on the extract CLI - rewrote as two-step: extract to JSON, then pipe through `store` if `store=true`
- **Bug 8**: `--source` flag does not exist on the extract CLI - source is now injected into entries between the extract and store steps

### retire
- **Bug 6**: `entry_id` was passed as the positional `<subject>` arg, but the CLI matches by subject string - added `--id` flag and `queryById()` for direct ID-based retirement; subject is now optional when `--id` is used

## Files Changed
- `src/openclaw-plugin/tools.ts` - all tool spawn logic fixes
- `src/openclaw-plugin/index.ts` - removed `threshold` from `agenr_recall` schema
- `src/cli-main.ts` - added `--aggressive` to store; made retire subject optional; added `--id` to retire
- `src/commands/retire.ts` - added `id` option, `queryById()`, ID-based retirement path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.7.6

* **New Features**
  * Added `--aggressive` flag to store command for enhanced deduplication control.
  * Added `--id` option to retire command; subject is now optional when using `--id`.

* **Bug Fixes**
  * Fixed agenr_recall command argument handling and type flag usage.
  * Fixed agenr_store to properly handle entries and platform/project parameters.
  * Fixed agenr_extract to use proper two-step process with source metadata injection.
  * Fixed agenr_retire to support ID-based entry retirement.

* **Documentation**
  * Updated CLI documentation for store and retire commands with new options and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->