### PR TITLE
docs: fix stale content and mcporter references across all docs (v0.7.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ MCP settings.
 | `agenr extract <files...>` | Extract knowledge entries from text files |
 | `agenr store [files...]` | Store entries with semantic dedup |
 | `agenr recall [query]` | Semantic + memory-aware recall |
-| `agenr retire <subject>` | Retire a stale entry (hidden, not deleted) |
+| `agenr retire [subject]` | Retire a stale entry (hidden, not deleted). Match by subject text or use --id <id> to target by entry ID. |
 | `agenr watch [file]` | Live-watch files/directories, auto-extract knowledge |
 | `agenr daemon install` | Install background watch daemon (macOS launchd) |
 | `agenr daemon status` | Show daemon status (running/stopped, pid, watched file, recent logs) |
@@ -227,7 +227,7 @@ Deep dive: [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 
 ## Status
 
-The core pipeline is stable and tested (782 tests). We use it daily managing
+The core pipeline is stable and tested (797 tests). We use it daily managing
 thousands of knowledge entries across OpenClaw sessions.
 
 What works: extraction, storage, recall, MCP integration, online dedup, consolidation, smart filtering, live watching, daemon mode.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,7 +1,7 @@
 # agenr CLI Reference
 
 Source of truth for this document:
-- `src/cli.ts`
+- `src/cli-main.ts`
 
 All syntax below is validated against `pnpm exec agenr <command> -h`.
 
@@ -536,7 +536,7 @@ $A mcp --db ~/.agenr/knowledge.db
 ### Example Output
 
 ```text
-[mcp] agenr MCP server started (protocol 2024-11-05, version 0.4.0)
+[mcp] agenr MCP server started (protocol 2024-11-05, version 0.7.6)
 ```
 
 ## `auth status`
@@ -716,8 +716,8 @@ $A db version
 ### Example Output
 
 ```text
-agenr v0.4.0
-Database schema version: 0.4.0
+agenr v0.7.6
+Database schema version: 0.7.6
 Database created: 2026-02-14 00:00:00
 Last migration: 2026-02-17 00:00:00
 ```

--- a/docs/CONSOLIDATION.md
+++ b/docs/CONSOLIDATION.md
@@ -137,16 +137,16 @@ This allows rollback/audit logic to reconstruct original support metrics for mer
 
 ```bash
 # Full two-tier consolidation
-pnpm exec agenr consolidate
+agenr consolidate
 
 # Tier 1 only
-pnpm exec agenr consolidate --rules-only
+agenr consolidate --rules-only
 
 # Preview changes without writing
-pnpm exec agenr consolidate --dry-run
+agenr consolidate --dry-run
 
 # Inspect flagged merges
-pnpm exec agenr consolidate --show-flagged
+agenr consolidate --show-flagged
 ```
 
 Useful advanced flags:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -8,6 +8,10 @@
 
 agenr centralizes memory in one local database, while MCP lets multiple AI clients read/write that same memory. Instead of separate memory silos per tool, you get one shared memory layer with consistent extraction, storage, and recall behavior.
 
+Note: OpenClaw users do not use the MCP server. agenr ships as a native OpenClaw
+plugin. See [OPENCLAW.md](./OPENCLAW.md) for OpenClaw-specific setup. This document
+covers Codex, Claude Code, and other MCP-compatible clients.
+
 ## Start the MCP Server
 
 ```bash
@@ -117,6 +121,8 @@ Parameters:
 - `types` (string, optional): comma-separated entry types
 - `since` (string, optional): ISO date or relative (`7d`, `24h`, `1m`, `1y`)
 - `threshold` (number, optional, default `0`): minimum score `0.0..1.0`
+- Note: threshold is only available when using the MCP server directly. The native
+  OpenClaw plugin does not expose this parameter.
 - `platform` (string, optional): platform filter (`openclaw`, `claude-code`, `codex`)
 - `project` (string, optional):
   - omit to use configured project scope (project + dependencies from `.agenr/config.json`)
@@ -235,10 +241,11 @@ Stored: 1 new, 0 updated, 1 duplicates skipped, 0 superseded.
 
 ### `agenr_retire`
 
-Mark one or more memory entries as retired (soft delete). Retired entries are excluded from recall.
+agenr_retire marks a single memory entry as retired (soft delete). Retired entries
+are excluded from all recall but are not deleted from the database.
 
 Parameters:
-- `entry_id` (string, required): entry id to retire.
+- `entry_id` (string, required): single entry ID to retire. To retire multiple entries, make multiple calls.
 - `reason` (string, optional): retirement reason.
 - `persist` (boolean, optional, default `false`): persist retirement to ledger so it survives re-ingest.
 


### PR DESCRIPTION
## Summary

Documentation fix pass against v0.7.6. All changes are docs-only - no source code, tests, or CHANGELOG touched.

## Files Changed

**README.md**
- Test count updated: 782 -> 797
- retire command signature: `<subject>` -> `[subject]` with --id note

**docs/CLI.md**
- Source filename corrected: `src/cli.ts` -> `src/cli-main.ts`
- Stale version in mcp and db version examples: 0.4.0 -> 0.7.6

**docs/OPENCLAW.md** (major)
- Entire integration model corrected: mcporter is not involved; agenr is a native OpenClaw plugin (`openclaw plugins install agenr`)
- Removed all mcporter references from Quick Setup, verify block, architecture diagram, multi-agent isolation section
- Added `agenr_retire` to all tool lists and AGENTS.md snippet
- Fixed `agenr_recall` param signature: removed `budget` and `threshold` (not in plugin schema); added `platform` and `project`
- Signal config expanded from 3 to all 6 fields (signalsEnabled, signalMinImportance, signalMaxPerSignal, signalCooldownMs, signalMaxPerSession, signalMaxAgeSec)
- Architecture diagram updated to show native plugin -> child_process -> SQLite

**docs/MCP.md**
- Added OpenClaw callout (uses native plugin, not MCP server)
- agenr_retire clarified as single entry_id per call
- threshold param note: available in MCP server, not in native OpenClaw plugin

**docs/ARCHITECTURE.md**
- Dedup threshold default corrected: 0.8 -> 0.72 (0.62 aggressive)
- entries table: added retired, retired_at, retired_reason columns
- Schema policy note corrected: migrations do exist and auto-apply

**docs/CONSOLIDATION.md**
- CLI examples: removed `pnpm exec` prefix (published package, not dev clone)

**docs/guides/scenarios.md**
- Removed stale v0.7.1 version references (2 locations)
- Scenario 2A: added Watch Out note about signalMinImportance=8 filter for proactive signals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `agenr_retire` tool now available for soft-deleting memory entries
  * Deduplication with new SUPERSEDE option to mark entries as superseded
  * Signal filtering for recall entries (importance-based threshold)

* **Documentation**
  * Updated all docs to reflect agenr as a native OpenClaw plugin
  * Clarified retire command usage with explicit --id option
  * Enhanced configuration examples and architectural diagrams

* **Chores**
  * Test count increased from 782 to 797
  * Updated version references across documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->