### PR TITLE
fix(openclaw-plugin): dedupe session-start recall by sessionId, not sessionKey

### DIFF
--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -121,10 +121,11 @@ const plugin = {
       ): Promise<BeforeAgentStartResult | undefined> => {
         try {
           const sessionKey = ctx.sessionKey ?? "";
+          const dedupeKey = ctx.sessionId ?? sessionKey;
           if (shouldSkipSession(sessionKey)) {
             return;
           }
-          if (sessionKey && hasSeenSession(sessionKey)) {
+          if (dedupeKey && hasSeenSession(dedupeKey)) {
             return;
           }
 
@@ -132,8 +133,8 @@ const plugin = {
           if (config?.enabled === false) {
             return;
           }
-          if (sessionKey) {
-            markSessionSeen(sessionKey);
+          if (dedupeKey) {
+            markSessionSeen(dedupeKey);
           }
 
           const agenrPath = resolveAgenrPath(config);

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -9,6 +9,7 @@ export type BeforeAgentStartEvent = {
 
 export type PluginHookAgentContext = {
   sessionKey?: string;
+  sessionId?: string;
   workspaceDir?: string;
   [key: string]: unknown;
 };


### PR DESCRIPTION
## Problem

The `before_agent_start` hook deduplicates recall using `ctx.sessionKey` to
avoid re-running on every message. But `sessionKey` is a stable slot identifier
(e.g. `agent:main:tui`) -- it does NOT change across `/new` sessions within
the same gateway lifetime.

Result: after the first session, all subsequent `/new` sessions get
`hasSeenSession(sessionKey) === true` and the recall hook returns immediately,
injecting no memory context. Confirmed in gateway debug logs:

```
18:45:01.401Z  before_agent_start fires (1 handler)
18:45:01.409Z  embedded run start  ← 8ms later, hook returned early
```
No "hooks: prepended context to prompt" log line ever appears.

## Fix

Use `ctx.sessionId` (UUID, unique per session) as the dedup key instead of
`ctx.sessionKey`. OpenClaw already passes `sessionId` in the hook context at
runtime -- it just wasn't typed.

- `types.ts`: add `sessionId?: string` to `PluginHookAgentContext`
- `index.ts`: derive `dedupeKey = ctx.sessionId ?? sessionKey` in `before_agent_start`
- `before_prompt_build` (signals) intentionally unchanged -- signal cooldown/cap should persist across `/new` within the same slot

## Tests

Added 3 test cases covering the exact bug scenario:
1. First session with key+id-A: recall runs
2. Same key, new id-B (`/new`): recall runs again
3. Same key+id-B, second message: recall skipped (correct dedup)

## Related

OpenClaw SDK issue filed to add `sessionId` as typed field: https://github.com/openclaw/openclaw/issues/22126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session deduplication logic to better handle session identifiers when available, ensuring more accurate session tracking.

* **Tests**
  * Added comprehensive test coverage for session deduplication behavior to validate correct operation across multiple session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->