### PR TITLE
chore: bump to v0.7.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump after merging PR #96 (sessionId dedup fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor version bump (0.7.8 release)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->