### PR TITLE
fix(openclaw): move recall injection to before_prompt_build (v0.7.9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
## Problem

`before_agent_start` is called **twice** per agent run by OpenClaw:

1. **Model-resolve phase** - OpenClaw uses this only for `modelOverride`/`providerOverride`. The `prependContext` return is discarded. But the plugin ran full recall here and called `markSessionSeen(dedupeKey)`, consuming the dedup token.

2. **Prompt-build phase** - This is where `prependContext` would actually be injected. But `hasSeenSession(dedupeKey)` now returns true (burned by call #1), so the handler returned early with no context injected.

**Result:** memory context was never injected on any session.

## Fix

Move recall injection from `before_agent_start` to `before_prompt_build`.

`before_prompt_build` fires exactly once per agent run at the prompt-build phase. The merged handler:

- **First message of session**: runs recall, marks session seen, checks signals
- **Subsequent messages**: skips recall (dedup hit), checks signals only

Removes `before_agent_start` registration entirely (plugin does not use model overrides).

## Version

0.7.8 -> 0.7.9