### PR TITLE
fix: update init for codex and openclaw MCP handling

### DIFF
--- a/docs/guides/scenarios.md
+++ b/docs/guides/scenarios.md
@@ -169,8 +169,8 @@ For Codex, the `~/.codex/config.toml` agenr entry looks like:
 agenr = { command = "/path/to/agenr", args = ["mcp"], env = { AGENR_PROJECT_DIR = "/Users/you/Code/my-project" } }
 ```
 
-Replace /path/to/agenr with the output of: which agenr
-agenr reads OPENAI_API_KEY from its own config file after agenr setup - do not include it in the TOML.
+> **Note:** Replace `/path/to/agenr` with the output of `which agenr`.
+> agenr reads `OPENAI_API_KEY` from its own config file after `agenr setup` - do not include it in the TOML.
 
 OpenClaw reads workspace `AGENTS.md`. Codex reads global `~/.codex/AGENTS.md`.
 
@@ -181,9 +181,10 @@ Both platforms connect to the same agenr MCP server, which reads the same `.agen
 **What you get:**
 - Both OpenClaw and Codex read from and write to the same `knowledge.db`, so decisions made in one agent surface in the other.
 - Both instruction files can carry the same agenr block (`AGENTS.md` for OpenClaw workspace, `~/.codex/AGENTS.md` for Codex global instructions).
+- `agenr init --platform codex` writes the `config.toml` entry automatically.
 
 **What you can't do yet:**
-- `agenr init --platform codex` now writes the `config.toml` entry automatically. You no longer need to add it by hand.
+- Codex MCP config is global (`~/.codex/config.toml`), so switching between multiple projects with Codex still requires managing `AGENR_PROJECT_DIR`.
 
 **Watch out for:**
 
@@ -208,7 +209,7 @@ agenr init --platform codex
 - System prompt block appended to `~/.codex/AGENTS.md`
 - Writes the agenr MCP entry to `~/.codex/config.toml` automatically.
 
-**Manual MCP step:**
+**MCP configuration:**
 
 This step is now handled automatically by `agenr init --platform codex`.
 The generated entry uses the resolved agenr binary path.

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -127,6 +127,7 @@ describe("recall command", () => {
 
   it("groups session-start output and includes category fields", async () => {
     const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const freshIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     const recallFn = vi.fn(async (_db: unknown, query: { expiry?: string }) => {
       if (query.expiry === "core") {
         return [
@@ -136,6 +137,8 @@ describe("recall command", () => {
               content: "Core identity",
               expiry: "core",
               type: "fact",
+              created_at: freshIso,
+              updated_at: freshIso,
               embedding: [1, 0, 0],
             }),
           }),
@@ -144,15 +147,36 @@ describe("recall command", () => {
 
       return [
         makeResult({
-          entry: makeEntry({ id: "todo-1", type: "todo", expiry: "temporary", content: "Active todo" }),
+          entry: makeEntry({
+            id: "todo-1",
+            type: "todo",
+            expiry: "temporary",
+            content: "Active todo",
+            created_at: freshIso,
+            updated_at: freshIso,
+          }),
           score: 0.92,
         }),
         makeResult({
-          entry: makeEntry({ id: "pref-1", type: "preference", expiry: "permanent", content: "Pref item" }),
+          entry: makeEntry({
+            id: "pref-1",
+            type: "preference",
+            expiry: "permanent",
+            content: "Pref item",
+            created_at: freshIso,
+            updated_at: freshIso,
+          }),
           score: 0.85,
         }),
         makeResult({
-          entry: makeEntry({ id: "recent-1", type: "event", expiry: "temporary", content: "Recent item" }),
+          entry: makeEntry({
+            id: "recent-1",
+            type: "event",
+            expiry: "temporary",
+            content: "Recent item",
+            created_at: freshIso,
+            updated_at: freshIso,
+          }),
           score: 0.8,
         }),
       ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup guide to reflect automated MCP/config updates and plugin-driven instruction injection; guidance on Codex (global TOML) and OpenClaw (native plugin) flows revised.

* **Enhancements**
  * Init now auto-writes Codex config entries and skips MCP writes for OpenClaw; improved agenr binary resolution and fallback behavior.

* **Tests**
  * Test coverage extended to verify new init behaviors and recall entries now include explicit timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->