### PR TITLE
fix(init): resolve codex MCP command via execPath and argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - fix(init): codex platform now writes MCP entry directly to ~/.codex/config.toml instead of .mcp.json (which Codex does not read)
 - fix(init): openclaw platform no longer writes a .mcp.json file (OpenClaw native plugin handles MCP registration via openclaw plugins install agenr)
-- fix(init): agenr binary path is now resolved at init time via which or PNPM_HOME fallback -- GUI clients that launch with a restricted PATH will now find the correct binary
+- fix(init): agenr MCP command now uses process.execPath (node binary) and process.argv[1] (CLI script path) instead of which lookup -- avoids PATH resolution failures in GUI clients like Codex that launch with a restricted PATH
 - fix(init): codex config.toml write is idempotent -- re-running init replaces the agenr line without duplicating it
 - docs: remove redundant Memory (agenr) AGENTS.md block from OPENCLAW.md -- OpenClaw plugin handles agent instruction injection automatically via the built-in skill
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## [0.7.11] - 2026-02-20
+
+### Fixed
+- fix(init): agenr MCP command now resolved via process.execPath (node binary) and process.argv[1] (CLI entry script) instead of which lookup -- eliminates PATH failures in GUI clients like Codex that launch with restricted environments
+
 ## [0.7.10] - 2026-02-20
 
 ### Fixed
 - fix(init): codex platform now writes MCP entry directly to ~/.codex/config.toml instead of .mcp.json (which Codex does not read)
 - fix(init): openclaw platform no longer writes a .mcp.json file (OpenClaw native plugin handles MCP registration via openclaw plugins install agenr)
-- fix(init): agenr MCP command now uses process.execPath (node binary) and process.argv[1] (CLI script path) instead of which lookup -- avoids PATH resolution failures in GUI clients like Codex that launch with a restricted PATH
+- fix(init): agenr binary path is now resolved at init time via which or PNPM_HOME fallback -- GUI clients that launch with a restricted PATH will now find the correct binary
 - fix(init): codex config.toml write is idempotent -- re-running init replaces the agenr line without duplicating it
 - docs: remove redundant Memory (agenr) AGENTS.md block from OPENCLAW.md -- OpenClaw plugin handles agent instruction injection automatically via the built-in skill
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initialization now resolves the runtime command using the Node/CLI invocation instead of PATH lookups, improving reliability in restricted environments (e.g., GUI clients).

* **New Features**
  * Init summary output improved to render home-directory paths more clearly.

* **Tests**
  * Test suite updated to align with the new command-resolution behavior.

* **Chores**
  * Package version bumped to 0.7.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->