### PR TITLE
fix: exclude retired entries from recall and consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.12] - 2026-02-21
+
+### Fixed
+- fix(recall): retired entries now correctly excluded from all recall queries -- missing `AND retired = 0` filter added to recall.ts and session-start.ts
+- fix(consolidate): retired entries excluded from Tier-1 and clustering queries in rules.ts and cluster.ts
+- fix(recall): consolidated duplicate parseSince implementations into shared utility supporting h/d/m/y units
+
 ## [0.7.11] - 2026-02-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/consolidate/cluster.ts
+++ b/src/consolidate/cluster.ts
@@ -143,6 +143,7 @@ export async function buildClusters(db: Client, options: ClusterOptions = {}): P
            recall_count, created_at, merged_from, consolidated_at
     FROM entries
     WHERE superseded_by IS NULL
+      AND retired = 0
       AND embedding IS NOT NULL
       ${platform ? "AND platform = ?" : ""}
       ${projectCondition}

--- a/src/consolidate/rules.ts
+++ b/src/consolidate/rules.ts
@@ -134,6 +134,7 @@ export async function countActiveEntries(
       SELECT COUNT(*) AS count
       FROM entries
       WHERE superseded_by IS NULL
+        AND retired = 0
         ${platform ? "AND platform = ?" : ""}
         ${projectSql.clause}
     `,
@@ -190,6 +191,7 @@ async function expireDecayedEntries(
     SELECT id, content, expiry, created_at
     FROM entries
     WHERE superseded_by IS NULL
+      AND retired = 0
       AND expiry = 'temporary'
       ${options.platform ? "AND platform = ?" : ""}
       ${projectSql.clause}
@@ -273,6 +275,7 @@ async function mergeNearExactDuplicates(
     SELECT COUNT(*) AS count
     FROM entries
     WHERE superseded_by IS NULL
+      AND retired = 0
       AND embedding IS NOT NULL
       ${options.platform ? "AND platform = ?" : ""}
       ${projectSql.clause}
@@ -300,6 +303,7 @@ async function mergeNearExactDuplicates(
     SELECT id, type, subject, content, project, embedding, confirmations, recall_count, created_at
     FROM entries
     WHERE superseded_by IS NULL
+      AND retired = 0
       AND embedding IS NOT NULL
       ${options.platform ? "AND platform = ?" : ""}
       ${projectSql.clause}

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -654,8 +654,7 @@ export async function recall(
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     const sinceValue = query.since ?? "";
-    process.stderr.write(`[recall] failed to parse since "${sinceValue}": ${reason}\n`);
-    cutoff = undefined;
+    throw new Error(`Invalid since value "${sinceValue}": ${reason}`);
   }
   const allowedScopes = resolveScopeSet(query.scope);
 

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -651,7 +651,10 @@ export async function recall(
   let cutoff: Date | undefined;
   try {
     cutoff = parseSince(query.since, now);
-  } catch {
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    const sinceValue = query.since ?? "";
+    process.stderr.write(`[recall] failed to parse since "${sinceValue}": ${reason}\n`);
     cutoff = undefined;
   }
   const allowedScopes = resolveScopeSet(query.scope);

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,39 @@
+const DURATION_PATTERN = /^(\d+)\s*([hdmy])$/i;
+
+const UNIT_TO_MILLISECONDS: Record<string, number> = {
+  h: 1000 * 60 * 60,
+  d: 1000 * 60 * 60 * 24,
+  m: 1000 * 60 * 60 * 24 * 30,
+  y: 1000 * 60 * 60 * 24 * 365,
+};
+
+export function parseSince(since: string | undefined, now: Date = new Date()): Date | undefined {
+  if (!since) {
+    return undefined;
+  }
+
+  const trimmed = since.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const durationMatch = trimmed.match(DURATION_PATTERN);
+  if (durationMatch) {
+    const amount = Number(durationMatch[1]);
+    const unit = durationMatch[2]?.toLowerCase();
+    const multiplier = unit ? UNIT_TO_MILLISECONDS[unit] : undefined;
+
+    if (!Number.isFinite(amount) || amount <= 0 || !multiplier) {
+      throw new Error("Invalid since value");
+    }
+
+    return new Date(now.getTime() - amount * multiplier);
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Invalid since value");
+  }
+
+  return parsed;
+}

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -83,10 +83,12 @@ describe("recall command", () => {
     const now = new Date("2026-02-15T12:00:00.000Z");
     const oneHour = parseSinceToIso("1h", now);
     const sevenDays = parseSinceToIso("7d", now);
+    const oneMonth = parseSinceToIso("1m", now);
     const oneYear = parseSinceToIso("1y", now);
 
     expect(oneHour).toBe("2026-02-15T11:00:00.000Z");
     expect(sevenDays).toBe("2026-02-08T12:00:00.000Z");
+    expect(oneMonth).toBe("2026-01-16T12:00:00.000Z");
     expect(oneYear).toBe("2025-02-15T12:00:00.000Z");
   });
 

--- a/tests/integration/retirement-zombie.test.ts
+++ b/tests/integration/retirement-zombie.test.ts
@@ -142,6 +142,6 @@ describe("integration: retirement zombie prevention", () => {
       "sk-test",
       { embedFn: mockEmbed, now: new Date("2026-02-19T00:00:00.000Z") },
     );
-    expect(explicit.some((result) => result.entry.subject === "Dead Project config")).toBe(true);
+    expect(explicit.some((result) => result.entry.subject === "Dead Project config")).toBe(false);
   });
 });

--- a/tests/utils/time.test.ts
+++ b/tests/utils/time.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseSince } from "../../src/utils/time.js";
+
+describe("utils time", () => {
+  it("parses h, d, m, and y durations", () => {
+    const now = new Date("2026-02-15T00:00:00.000Z");
+
+    expect(parseSince("1h", now)?.toISOString()).toBe("2026-02-14T23:00:00.000Z");
+    expect(parseSince("2d", now)?.toISOString()).toBe("2026-02-13T00:00:00.000Z");
+    expect(parseSince("1m", now)?.toISOString()).toBe("2026-01-16T00:00:00.000Z");
+    expect(parseSince("1y", now)?.toISOString()).toBe("2025-02-15T00:00:00.000Z");
+  });
+
+  it("returns undefined for empty since values", () => {
+    const now = new Date("2026-02-15T00:00:00.000Z");
+    expect(parseSince(undefined, now)).toBeUndefined();
+    expect(parseSince("   ", now)).toBeUndefined();
+  });
+
+  it("rejects invalid since values", () => {
+    const now = new Date("2026-02-15T00:00:00.000Z");
+    expect(() => parseSince("1w", now)).toThrow("Invalid since value");
+    expect(() => parseSince("0d", now)).toThrow("Invalid since value");
+    expect(() => parseSince("abc", now)).toThrow("Invalid since value");
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retired entries are now excluded across recall, session-start, clustering and consolidation flows so obsolete items no longer appear.
  * Time-based filtering parsing consolidated and extended: supports hours, days, months, years, and ISO dates with clearer validation and error messaging.

* **Chore**
  * Release bumped to v0.7.12 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->