### PR TITLE
feat(recall): add until upper-bound date filter and window-relative recency scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - fix(recall): recency decay now anchors to the `until` ceiling for historical windows while freshness boost remains anchored to real query time
 - fix(recall): centralized `parseSinceToIso` in `src/utils/time.ts` and removed duplicate implementations from recall CLI and MCP server
+- fix(recall): added inverted date-range validation - recall now returns a descriptive error when `since > until` instead of returning an empty list
+- fix(recall): interim 3x candidate over-fetch under date bounds to improve in-window recall coverage until SQL-level date filtering is added
+- fix(recall): corrupt `created_at` values are now safely excluded under date-bound filters instead of leaking invalid rows into filtered recall
 
 ## [0.7.13] - 2026-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.14] - 2026-02-21
+
+### Added
+- feat(recall): added `until` upper date bound to recall query filtering in CLI, MCP, and DB recall paths (`since` + `until` now define an inclusive window)
+
+### Changed
+- fix(recall): recency decay now anchors to the `until` ceiling for historical windows while freshness boost remains anchored to real query time
+- fix(recall): centralized `parseSinceToIso` in `src/utils/time.ts` and removed duplicate implementations from recall CLI and MCP server
+
 ## [0.7.13] - 2026-02-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ agenr watch --platform openclaw --context ~/.agenr/CONTEXT.md
 
 ## How it works
 
-**Extract** - An LLM reads your transcripts and pulls out structured entries: facts, decisions, preferences, todos, relationships, events, lessons. Smart filtering removes noise (tool calls, file contents, boilerplate) before the LLM ever sees it.
+**Extract** - An LLM reads your transcripts and pulls out structured entries: facts, decisions, preferences, todos, relationships, events, lessons. Smart filtering removes noise (tool calls, file contents, boilerplate) before the LLM ever sees it. For OpenClaw sessions, hedged or unverified agent claims are detected and capped at importance 5 with an `unverified` tag - so speculative assistant statements do not pollute your memory as facts.
 
 **Store** - Entries get embedded and compared against what's already in the database. Near-duplicates reinforce existing knowledge. New information gets inserted. Online dedup catches copies in real-time.
 
@@ -201,7 +201,7 @@ MCP settings.
 | `agenr ingest <paths...>` | Bulk-ingest files and directories |
 | `agenr extract <files...>` | Extract knowledge entries from text files |
 | `agenr store [files...]` | Store entries with semantic dedup |
-| `agenr recall [query]` | Semantic + memory-aware recall |
+| `agenr recall [query]` | Semantic + memory-aware recall. Use `--since` / `--until` for date range queries (e.g. `--since 14d --until 7d` for entries from two weeks ago). |
 | `agenr retire [subject]` | Retire a stale entry (hidden, not deleted). Match by subject text or use --id <id> to target by entry ID. |
 | `agenr watch [file]` | Live-watch files/directories, auto-extract knowledge |
 | `agenr daemon install` | Install background watch daemon (macOS launchd) |
@@ -227,13 +227,12 @@ Deep dive: [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)
 
 ## Status
 
-The core pipeline is stable and tested (797 tests). We use it daily managing
+The core pipeline is stable and tested (841 tests). We use it daily managing
 thousands of knowledge entries across OpenClaw sessions.
 
 What works: extraction, storage, recall, MCP integration, online dedup, consolidation, smart filtering, live watching, daemon mode.
 
-What's next: Cursor live signals, Claude Code UserPromptSubmit adapter,
-transitive project dependencies.
+What's next: GUI Management Console (browse, search, and curate your knowledge database visually), Cursor live signals, Claude Code UserPromptSubmit adapter, transitive project dependencies.
 
 ## Philosophy
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -159,6 +159,7 @@ agenr recall [options] [query]
 - `--tags <tags>`: comma-separated tags filter.
 - `--min-importance <n>`: minimum importance (1-10).
 - `--since <duration>`: recency filter (`1h`, `7d`, `30d`, `1y`, or ISO timestamp).
+- `--until <date>`: upper recency cap (`1h`, `7d`, `1m`, `1y`, or ISO timestamp). Includes entries at or before this time.
 - `--expiry <level>`: `core|permanent|temporary`.
 - `--platform <name>`: platform filter (`openclaw|claude-code|claude|codex`).
 - `--project <name>`: project filter (comma-separated for multiple).
@@ -874,7 +875,7 @@ In **default** mode: entries are ranked by score, then consumed in order until t
 
 In **session-start** mode: the budget is split across categories dynamically via `computeBudgetSplit()` based on category counts (active ~10-30%, preferences ~20-40%, remainder to recent with a 20% minimum floor for recent). Each category consumes entries in score order until its quota is full. Leftover budget is redistributed to remaining entries across all categories.
 
-This is useful for keeping context windows manageable — e.g., `agenr recall --context session-start --budget 2000` loads ≈2000 tokens of the most relevant memories.
+This is useful for keeping context windows manageable - e.g., `agenr recall --context session-start --budget 2000` loads ≈2000 tokens of the most relevant memories.
 
 
 ## Interrupted Processes and Data Safety

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -120,6 +120,7 @@ Parameters:
 - `limit` (integer, optional, default `10`): max results
 - `types` (string, optional): comma-separated entry types
 - `since` (string, optional): ISO date or relative (`7d`, `24h`, `1m`, `1y`)
+- `until` (string, optional): ISO date or relative (`7d`, `24h`, `1m`, `1y`), treated as an upper bound (entries at or before this time)
 - `threshold` (number, optional, default `0`): minimum score `0.0..1.0`
 - Note: threshold is only available when using the MCP server directly. The native
   OpenClaw plugin does not expose this parameter.

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -502,7 +502,7 @@ export function createProgram(): Command {
     .option("--tags <tags>", "Filter by comma-separated tags")
     .option("--min-importance <n>", "Minimum importance: 1-10")
     .option("--since <duration>", "Filter by recency (1h, 7d, 30d, 1y) or ISO timestamp")
-    .option("--until <date>", "Only entries older than this (ISO date or relative, e.g. 7d, 1m)")
+    .option("--until <date>", "Only entries at or before this time (ISO date or relative, e.g. 7d, 1m)")
     .option("--expiry <level>", "Filter by expiry: core|permanent|temporary")
     .option("--platform <name>", "Filter by platform: openclaw, claude-code, codex")
     .option("--project <name>", "Filter by project (repeatable)", (val: string, prev: string[]) => [...prev, val], [] as string[])

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -502,6 +502,7 @@ export function createProgram(): Command {
     .option("--tags <tags>", "Filter by comma-separated tags")
     .option("--min-importance <n>", "Minimum importance: 1-10")
     .option("--since <duration>", "Filter by recency (1h, 7d, 30d, 1y) or ISO timestamp")
+    .option("--until <date>", "Only entries older than this (ISO date or relative, e.g. 7d, 1m)")
     .option("--expiry <level>", "Filter by expiry: core|permanent|temporary")
     .option("--platform <name>", "Filter by platform: openclaw, claude-code, codex")
     .option("--project <name>", "Filter by project (repeatable)", (val: string, prev: string[]) => [...prev, val], [] as string[])
@@ -521,6 +522,7 @@ export function createProgram(): Command {
         tags: opts.tags as string | undefined,
         minImportance: opts.minImportance as string | undefined,
         since: opts.since as string | undefined,
+        until: opts.until as string | undefined,
         expiry: opts.expiry as string | undefined,
         platform: opts.platform as string | undefined,
         project: opts.project as string | string[] | undefined,

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -693,6 +693,7 @@ export async function recall(
   }
   const allowedScopes = resolveScopeSet(query.scope);
 
+  const hasDateBounds = cutoff !== undefined || ceiling !== undefined;
   let candidates: CandidateRow[];
   let effectiveText = text;
 
@@ -706,7 +707,6 @@ export async function recall(
     }
     // Over-fetch when date bounds narrow the post-filter window.
     // Proper fix: push filtering into fetchVectorCandidates SQL (see TODO #111).
-    const hasDateBounds = cutoff !== undefined || ceiling !== undefined;
     const vectorLimit = hasDateBounds
       ? (options.vectorCandidateLimit ?? DEFAULT_VECTOR_CANDIDATE_LIMIT) * 3
       : (options.vectorCandidateLimit ?? DEFAULT_VECTOR_CANDIDATE_LIMIT);
@@ -722,9 +722,12 @@ export async function recall(
       projectStrict,
     );
   } else {
+    const sessionLimit = hasDateBounds
+      ? (options.sessionCandidateLimit ?? DEFAULT_SESSION_CANDIDATE_LIMIT) * 3
+      : (options.sessionCandidateLimit ?? DEFAULT_SESSION_CANDIDATE_LIMIT);
     candidates = await fetchSessionCandidates(
       db,
-      options.sessionCandidateLimit ?? DEFAULT_SESSION_CANDIDATE_LIMIT,
+      sessionLimit,
       context,
       platform,
       project,

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -706,11 +706,11 @@ export async function recall(
       throw new Error("Embedding provider returned no vector for recall query.");
     }
     // Over-fetch when date bounds narrow the post-filter window.
-    // Proper fix: push filtering into fetchVectorCandidates SQL (see TODO #111).
+    // Proper fix: push filtering into fetchVectorCandidates SQL (see #114).
     const vectorLimit = hasDateBounds
       ? (options.vectorCandidateLimit ?? DEFAULT_VECTOR_CANDIDATE_LIMIT) * 3
       : (options.vectorCandidateLimit ?? DEFAULT_VECTOR_CANDIDATE_LIMIT);
-    // TODO(#111): Proper fix is date filtering inside fetchVectorCandidates SQL.
+    // TODO(#114): Proper fix is SQL-level date filtering inside fetchVectorCandidates (and fetchSessionCandidates).
     // Interim: 3x candidate limit when bounds are active to improve in-window coverage.
     candidates = await fetchVectorCandidates(
       db,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -136,7 +136,7 @@ const TOOL_DEFINITIONS: McpToolDefinition[] = [
         until: {
           type: "string",
           description:
-            "Only entries older than this (ISO date or relative, e.g. 7d, 1m). Use with since for date range queries: since sets the lower bound, until the upper bound.",
+            "Only entries created before this point in time (ISO date or relative, e.g. 7d = entries older than 7 days). Use with since for a date range: since sets the lower bound, until the upper bound.",
         },
         threshold: {
           type: "number",

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,7 @@ export interface RecallQuery {
   tags?: string[];
   minImportance?: number;
   since?: string;
+  until?: string; // upper bound; same subtraction semantics as since (e.g. "7d" = entries older than 7 days ago)
   expiry?: Expiry | Expiry[];
   scope?: Scope;
   context?: string;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -37,3 +37,16 @@ export function parseSince(since: string | undefined, now: Date = new Date()): D
 
   return parsed;
 }
+
+export function parseSinceToIso(
+  since: string | undefined,
+  now: Date = new Date(),
+  invalidMessage = "Invalid since value",
+): string | undefined {
+  try {
+    const parsed = parseSince(since, now);
+    return parsed ? parsed.toISOString() : undefined;
+  } catch {
+    throw new Error(invalidMessage);
+  }
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -41,7 +41,7 @@ export function parseSince(since: string | undefined, now: Date = new Date()): D
 export function parseSinceToIso(
   since: string | undefined,
   now: Date = new Date(),
-  invalidMessage = "Invalid since value",
+  invalidMessage = "Invalid date value",
 ): string | undefined {
   try {
     const parsed = parseSince(since, now);

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -218,6 +218,16 @@ describe("recall command", () => {
     expect(firstCall?.[1]?.platform).toBe("openclaw");
   });
 
+  it("passes --until into recall query when provided", async () => {
+    const recallFn = vi.fn(async () => []);
+    const deps = makeDeps({ recallFn });
+
+    await runRecallCommand("work", { context: "default", json: true, until: "2026-02-01T00:00:00.000Z" }, deps);
+
+    const firstCall = (recallFn.mock.calls as unknown[][])[0] as [unknown, { until?: string }] | undefined;
+    expect(firstCall?.[1]?.until).toBe("2026-02-01T00:00:00.000Z");
+  });
+
   it("passes --project into recall query when provided", async () => {
     const recallFn = vi.fn(async () => []);
     const deps = makeDeps({ recallFn });

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { estimateEntryTokens, parseSinceToIso, runRecallCommand } from "../../src/commands/recall.js";
+import { estimateEntryTokens, runRecallCommand } from "../../src/commands/recall.js";
+import { parseSinceToIso } from "../../src/utils/time.js";
 import type { RecallResult, StoredEntry } from "../../src/types.js";
 
 function makeEntry(overrides: Partial<StoredEntry> = {}): StoredEntry {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -268,7 +268,7 @@ describe("mcp server", () => {
       expect(parseSinceToIso(input, now)).toBe(parsed?.toISOString());
     }
 
-    expect(() => parseSinceToIso("not-a-duration", now)).toThrow("Invalid since value");
+    expect(() => parseSinceToIso("not-a-duration", now)).toThrow("Invalid date value");
   });
 
   it("handles initialize handshake", async () => {

--- a/tests/utils/time.test.ts
+++ b/tests/utils/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSince } from "../../src/utils/time.js";
+import { parseSince, parseSinceToIso } from "../../src/utils/time.js";
 
 describe("utils time", () => {
   it("parses h, d, m, and y durations", () => {
@@ -22,5 +22,19 @@ describe("utils time", () => {
     expect(() => parseSince("1w", now)).toThrow("Invalid since value");
     expect(() => parseSince("0d", now)).toThrow("Invalid since value");
     expect(() => parseSince("abc", now)).toThrow("Invalid since value");
+  });
+
+  it("converts parsed since values to ISO", () => {
+    const now = new Date("2026-02-15T00:00:00.000Z");
+    expect(parseSinceToIso("7d", now)).toBe("2026-02-08T00:00:00.000Z");
+    expect(parseSinceToIso("2026-02-10T00:00:00.000Z", now)).toBe("2026-02-10T00:00:00.000Z");
+  });
+
+  it("throws configured invalid parse messages for parseSinceToIso", () => {
+    const now = new Date("2026-02-15T00:00:00.000Z");
+    expect(() => parseSinceToIso("oops", now)).toThrow("Invalid since value");
+    expect(() => parseSinceToIso("oops", now, "Invalid --until value. Use 1h, 7d, 1m, 1y, or an ISO date.")).toThrow(
+      "Invalid --until value. Use 1h, 7d, 1m, 1y, or an ISO date.",
+    );
   });
 });

--- a/tests/utils/time.test.ts
+++ b/tests/utils/time.test.ts
@@ -32,7 +32,7 @@ describe("utils time", () => {
 
   it("throws configured invalid parse messages for parseSinceToIso", () => {
     const now = new Date("2026-02-15T00:00:00.000Z");
-    expect(() => parseSinceToIso("oops", now)).toThrow("Invalid since value");
+    expect(() => parseSinceToIso("oops", now)).toThrow("Invalid date value");
     expect(() => parseSinceToIso("oops", now, "Invalid --until value. Use 1h, 7d, 1m, 1y, or an ISO date.")).toThrow(
       "Invalid --until value. Use 1h, 7d, 1m, 1y, or an ISO date.",
     );

--- a/tests/utils/time.test.ts
+++ b/tests/utils/time.test.ts
@@ -26,6 +26,7 @@ describe("utils time", () => {
 
   it("converts parsed since values to ISO", () => {
     const now = new Date("2026-02-15T00:00:00.000Z");
+    expect(parseSinceToIso(undefined, now)).toBeUndefined();
     expect(parseSinceToIso("7d", now)).toBe("2026-02-08T00:00:00.000Z");
     expect(parseSinceToIso("2026-02-10T00:00:00.000Z", now)).toBe("2026-02-10T00:00:00.000Z");
   });


### PR DESCRIPTION
## Summary

Closes #111

Adds an `until` parameter to `agenr_recall` (and the MCP `agenr_recall` tool) that sets an upper date bound on results. Entries created after the ceiling are excluded. Pairs with `since` to support precise date windows.

## Behavior

- `until: "7d"` means ceiling = `now - 7 days`; entries newer than that are excluded
- `since: "14d" until: "7d"` = entries created in the 7-day window between 7 and 14 days ago
- `since > until` (inverted range) throws a descriptive error rather than silently returning empty results
- Recency decay anchors to `ceiling ?? now` so historical queries score properly without spurious freshness boosts
- `freshnessBoost` (1.5x live-query signal) uses real `now` only -- no boost for historical window queries
- Over-fetch multiplier (3x) applied when date bounds are active to compensate for vector-layer not filtering by date

## Changes

- `src/db/recall.ts`: `ceiling` param, window-relative recency anchor, 3x over-fetch, NaN `created_at` guard
- `src/utils/time.ts`: consolidate `parseSinceToIso` to `parseDateBound` (shared by `since` and `until`); improved error message
- `src/mcp/server.ts`: expose `until` on MCP `agenr_recall` tool with clear description
- `tests/db/recall.test.ts`: vector-path filter test, NaN guard test, point-window test, recency-score assertion
- `docs/README.md`: updated test count, date range recall examples, added confidence extraction and GUI console to What's Next

## CHANGELOG

```
## [0.7.14] - 2026-02-21

### Added
- recall --until: upper date bound for agenr_recall (MCP + CLI)
- Window-relative recency scoring: anchor decay to ceiling when until is set
- parseDateBound utility consolidates since/until parsing in src/utils/time.ts

### Changed
- freshnessBoost skipped for historical window queries (ceiling set, no real-now anchor)
- Over-fetch 3x multiplier when date bounds active to compensate for vector-layer pre-filter gap
- Inverted range (since > until) throws descriptive error instead of silently returning empty

### Fixed
- NaN guard on created_at in recall scoring
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inclusive upper-date bound (--until) for recall queries and temporal-windowed recall.

* **Bug Fixes**
  * Recency decay now anchors to the window end while freshness uses real query time.
  * Returns a clear error when since > until, excludes corrupt timestamps from date-bound filters, and applies a 3x interim over‑fetch to improve in-window coverage.
  * Centralized time parsing with a standardized invalid-date error message.

* **Documentation**
  * CLI, MCP, architecture, and README updated with --since/--until guidance and temporal-window semantics.

* **Tests**
  * New suites covering until parsing, windowed recall behavior, scoring, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->