### PR TITLE
feat(openclaw-plugin): expose until param in agenr_recall tool + update SKILL.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -17,4 +17,14 @@ Do not store secrets/credentials, temporary state, or verbatim conversation.
 
 Use `agenr_recall` mid-session when you need context you do not already have. Use a specific query so results stay relevant.
 
+`agenr_recall` parameters:
+- `query` (required): semantic search string
+- `limit`: max results (default 10)
+- `context`: `"default"` (semantic+vector) or `"session-start"` (fast bootstrap)
+- `since`: lower date bound - only entries newer than this (ISO or relative, e.g. `"7d"`, `"2026-01-01"`)
+- `until`: upper date bound - only entries older than this ceiling (ISO or relative, e.g. `"7d"` = entries created before 7 days ago). Use with `since` for a date window.
+- `types`: comma-separated entry types to filter (`fact,decision,preference,todo,lesson,event`)
+- `platform`: filter by platform (`openclaw`, `claude-code`, `codex`)
+- `project`: filter by project scope (pass `*` for all projects)
+
 Session-start recall is already handled automatically by the OpenClaw plugin. Do not call `agenr_recall` at turn 1 unless you need extra context beyond the injected summary.

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -221,6 +221,9 @@ const plugin = {
             since: Type.Optional(
               Type.String({ description: "Only entries newer than this (ISO date or relative, e.g. 7d)." }),
             ),
+            until: Type.Optional(
+              Type.String({ description: "Only entries older than this ceiling (ISO date or relative, e.g. 7d = entries created before 7 days ago). Use with since for a date window." }),
+            ),
             platform: Type.Optional(Type.String({ description: "Platform filter: openclaw, claude-code, codex." })),
             project: Type.Optional(Type.String({ description: "Project scope. Pass * for all projects." })),
           }),

--- a/src/openclaw-plugin/tools.ts
+++ b/src/openclaw-plugin/tools.ts
@@ -100,6 +100,7 @@ export async function runRecallTool(agenrPath: string, params: Record<string, un
   const limit = asNumber(params.limit);
   const types = asString(params.types);
   const since = asString(params.since);
+  const until = asString(params.until);
   const platform = asString(params.platform);
   const project = asString(params.project);
 
@@ -117,6 +118,9 @@ export async function runRecallTool(agenrPath: string, params: Record<string, un
   }
   if (since) {
     args.push("--since", since);
+  }
+  if (until) {
+    args.push("--until", until);
   }
   // threshold has no direct CLI equivalent in agenr recall
   if (platform) {


### PR DESCRIPTION
## Summary

The `until` upper-bound date filter was added to the CLI and MCP server in #113 but was not wired into the OpenClaw plugin tool definition. This meant `until` was silently dropped when called via the native `agenr_recall` tool.

## Changes

- `src/openclaw-plugin/tools.ts`: extract `until` from params and pass `--until` to the CLI args
- `src/openclaw-plugin/index.ts`: add `until` to the `agenr_recall` tool input schema with description
- `skills/SKILL.md`: document all `agenr_recall` parameters (query, limit, context, since, until, types, platform, project) - previously only the store tool was documented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `until` parameter to Agenr Recall tool to set upper date bounds for recall queries, complementing the existing `since` parameter for flexible date range filtering.

* **Documentation**
  * Updated Agenr Recall tool documentation with comprehensive parameter reference including query, limit, context, since, until, types, platform, and project parameters.

* **Chores**
  * Patch version updated to 0.7.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->