### PR TITLE
chore: bump version to 0.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.15] - 2026-02-21
+
+### Fixed
+- fix(openclaw-plugin): agenr_recall tool now correctly passes --until flag to CLI (was silently dropped)
+- docs(skill): document all agenr_recall parameters in SKILL.md (since, until, types, platform, project, limit, context)
+
 ## [0.7.14] - 2026-02-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump following publish of agenr@0.7.15 (openclaw-plugin until fix, PR #116).