### PR TITLE
docs(skill): comprehensive SKILL.md refresh

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -3,28 +3,54 @@ name: agenr
 description: Use when storing new knowledge (decisions, preferences, lessons, todos) or recalling context mid-session. The agenr plugin auto-injects memory at session start - this skill covers proactive store and on-demand recall.
 ---
 
-Use `agenr_store` proactively. Call it immediately after any decision, user preference, lesson learned, important event, or fact worth remembering. Do not ask first.
+## agenr_store
 
-Required fields: `type`, `content`, `importance`.
-Types: `fact | decision | preference | todo | lesson | event`.
-Importance: `1-10` (default `7`), use `9` for critical items, use `10` sparingly.
-Importance calibration: entries at importance 7 (the default) are saved to
-memory but will NOT trigger mid-session signals to active sessions. Use
-importance 8+ only for updates that other active sessions need to know about
-NOW. Routine facts should stay at 7.
+Use proactively. Call immediately after any decision, user preference, lesson learned, important event, or fact worth remembering. Do not ask first.
 
+Required: `type`, `content`, `importance`.
+Optional: `subject` (short label), `tags` (array), `scope` (`private`|`personal`|`public`), `project`, `platform`, `source`.
+
+Types: `fact | decision | preference | todo | lesson | event | relationship`
 Do not store secrets/credentials, temporary state, or verbatim conversation.
 
-Use `agenr_recall` mid-session when you need context you do not already have. Use a specific query so results stay relevant.
+### Importance calibration
 
-`agenr_recall` parameters:
+- **10**: Once-per-project permanent constraints. At most 1-2 per project lifetime.
+- **9**: Critical breaking changes or immediate cross-session decisions. At most 1 per significant session, often 0.
+- **8**: Things an active parallel session would act on right now. Fires a cross-session signal. Use conservatively.
+- **7**: Default. Project facts, decisions, preferences, milestones. No signal fired.
+- **6**: Routine dev observations (verified X, tests passing). Cap here unless the result is surprising.
+- **5**: Borderline. Only store if clearly durable beyond today.
+
+Entries at 7 are saved silently. Use 8+ only if other active sessions need to know NOW.
+
+### Confidence-aware extraction (OpenClaw transcripts)
+
+OpenClaw transcripts include `[user]` / `[assistant]` role labels. The extractor uses this signal:
+- Hedged or unverified assistant factual claims are tagged `unverified` and hard-capped at importance 5.
+- Tool-verified assistant claims follow normal importance rules.
+- User messages are never capped.
+
+This means: if you say something unverified, it will be stored at max importance 5. To store a fact at higher importance, verify it with a tool call first.
+
+## agenr_recall
+
+Use mid-session when you need context you don't already have. Session-start recall is handled automatically - do not call at turn 1 unless you need extra context beyond the injected summary.
+
+Parameters:
 - `query` (required): semantic search string
 - `limit`: max results (default 10)
 - `context`: `"default"` (semantic+vector) or `"session-start"` (fast bootstrap)
 - `since`: lower date bound - only entries newer than this (ISO or relative, e.g. `"7d"`, `"2026-01-01"`)
-- `until`: upper date bound - only entries older than this ceiling (ISO or relative, e.g. `"7d"` = entries created before 7 days ago). Use with `since` for a date window.
-- `types`: comma-separated entry types to filter (`fact,decision,preference,todo,lesson,event`)
+- `until`: upper date bound - only entries older than this ceiling (e.g. `"7d"` = entries created before 7 days ago). Use with `since` for a date window.
+- `types`: comma-separated entry types (`fact,decision,preference,todo,lesson,event`)
 - `platform`: filter by platform (`openclaw`, `claude-code`, `codex`)
 - `project`: filter by project scope (pass `*` for all projects)
 
-Session-start recall is already handled automatically by the OpenClaw plugin. Do not call `agenr_recall` at turn 1 unless you need extra context beyond the injected summary.
+## agenr_retire
+
+Soft-deletes an entry. Use when something is outdated, wrong, or superseded. Pass `entry_id` (from recall results) and optionally `reason` and `persist: true` to write to the retirements ledger.
+
+## agenr_extract
+
+Extracts structured knowledge entries from raw text without storing them. Useful for previewing what would be stored from a block of text before committing.


### PR DESCRIPTION
Catches SKILL.md up with PR #112 and #116.

**Added:**
- Full importance calibration scale (5-10 with anchors)
- Confidence-aware extraction section: unverified assistant claims capped at importance 5; tool-verified claims use normal rules
- `agenr_retire` tool documentation
- `agenr_extract` tool documentation
- Full `agenr_store` optional params: subject, tags, scope, project, platform, source
- `relationship` type added to types list

**Updated:**
- `agenr_recall` params already updated in #116 (since, until, types, platform, project)