### PR TITLE
chore: bump version to 0.7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.16] - 2026-02-21
+
+### Fixed
+- docs(skill): comprehensive SKILL.md refresh covering all four tools, full importance scale, confidence-aware extraction, store optional params (subject, scope, tags, project), retire and extract tool docs
+
 ## [0.7.15] - 2026-02-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump following publish of agenr@0.7.16 (SKILL.md refresh, PR #118).