### PR TITLE
perf(ingest): two-phase extract+write pipeline with batched write queue (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Performance
 - perf(ingest): two-phase extract+write pipeline eliminates SQLite write-lock contention; extraction workers run in parallel while a single background writer drains entries in batched transactions (#107)
 - feat(ingest): add `--workers` flag (default 10) for file-level parallelism; previously hardcoded to 1
+- The write queue retries each write sub-batch once on transient failure (2s delay) before surfacing the error to the outer file-level retry loop. Use `--no-retry` to disable all retries including the inner write retry.
 
 ### Changed
 - ingest: `entriesStored` now counts `added + superseded` (previously only `added`); superseded entries are written before the previous entry is marked superseded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.17] - 2026-02-21
+
+### Performance
+- perf(ingest): two-phase extract+write pipeline eliminates SQLite write-lock contention; extraction workers run in parallel while a single background writer drains entries in batched transactions (#107)
+- feat(ingest): add `--workers` flag (default 10) for file-level parallelism; previously hardcoded to 1
+
+### Changed
+- ingest: `entriesStored` now counts `added + superseded` (previously only `added`); superseded entries are written before the previous entry is marked superseded
+
 ## [0.7.16] - 2026-02-21
 
 ### Fixed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -379,6 +379,7 @@ agenr ingest [options] <paths...>
 - `--dry-run`: extract without storing.
 - `--json`: emit JSON summary.
 - `--concurrency <n>`: parallel chunk extractions (default `5`).
+- `--workers <n>`: files to process in parallel (default `10`). Total concurrent LLM chunk calls can reach `workers x concurrency`.
 - `--skip-ingested`: skip already-ingested file/hash pairs (default `true`).
 - `--no-pre-fetch`: disable elaborative encoding pre-fetch before per-chunk extraction.
 - `--no-retry`: disable auto-retry for failed files.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -687,6 +687,12 @@ export function createProgram(): Command {
     .option("--dry-run", "Extract without storing", false)
     .option("--json", "Output JSON results", false)
     .option("--concurrency <n>", "Parallel chunk extractions", parseIntOption, 5)
+    .option(
+      "--workers <n>",
+      "Number of files to process in parallel (default: 10). Each worker uses --concurrency chunk parallelism. Total concurrent LLM calls = workers x concurrency. Reduce if hitting rate limits.",
+      parseIntOption,
+      10,
+    )
     .option("--skip-ingested", "Skip already-ingested files", true)
     .option("--no-retry", "Disable auto-retry for failed files")
     .option("--no-pre-fetch", "Disable elaborative encoding pre-fetch")

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -689,7 +689,7 @@ export function createProgram(): Command {
     .option("--concurrency <n>", "Parallel chunk extractions", parseIntOption, 5)
     .option(
       "--workers <n>",
-      "Number of files to process in parallel (default: 10). Each worker uses --concurrency chunk parallelism. Total concurrent LLM calls = workers x concurrency. Reduce if hitting rate limits.",
+      "Number of files to process in parallel (default: 10). Each worker uses --concurrency chunk parallelism. Total concurrent LLM calls = workers x concurrency. Reduce if hitting rate limits. Writes retry once per sub-batch unless --no-retry is set.",
       parseIntOption,
       10,
     )

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -638,7 +638,7 @@ export async function runIngestCommand(
 
   let embeddingApiKey: string | null = null;
   try {
-    if (!embeddingApiKey && !options.noPreFetch) {
+    if (!embeddingApiKey) {
       embeddingApiKey = resolvedDeps.resolveEmbeddingApiKeyFn(config, process.env);
     }
   } catch (error) {
@@ -660,6 +660,7 @@ export async function runIngestCommand(
       dbPath,
       batchSize: 40,
       highWatermark: 500,
+      retryOnFailure: retryEnabled,
       isShutdownRequested: resolvedDeps.shouldShutdownFn,
     });
   } catch (error) {

--- a/src/ingest/write-queue.ts
+++ b/src/ingest/write-queue.ts
@@ -1,0 +1,472 @@
+import type { Client } from "@libsql/client";
+import type { KnowledgeEntry, LlmClient } from "../types.js";
+
+export interface BatchWriteResult {
+  added: number;
+  updated: number;
+  skipped: number;
+  superseded: number;
+  llm_dedup_calls: number;
+}
+
+export type StoreEntriesFn = typeof import("../db/store.js").storeEntries;
+
+export interface WriteQueueOptions {
+  db: Client;
+  storeEntriesFn: StoreEntriesFn;
+  apiKey: string;
+  llmClient: LlmClient;
+  dbPath: string | undefined;
+  batchSize?: number;
+  highWatermark?: number;
+  isShutdownRequested?: () => boolean;
+}
+
+export class CancelledError extends Error {
+  constructor(message = "Write queue item was cancelled.") {
+    super(message);
+    this.name = "CancelledError";
+  }
+}
+
+export class ShutdownError extends Error {
+  constructor(message = "Write queue is shutting down.") {
+    super(message);
+    this.name = "ShutdownError";
+  }
+}
+
+interface WriteQueueItem {
+  kind: "write";
+  entries: KnowledgeEntry[];
+  fileKey: string;
+  fileHash: string;
+  resolve: (result: BatchWriteResult) => void;
+  reject: (err: Error) => void;
+}
+
+interface ExclusiveQueueItem<T = unknown> {
+  kind: "exclusive";
+  fn: () => Promise<T>;
+  resolve: (result: T) => void;
+  reject: (err: Error) => void;
+}
+
+type QueueItem = WriteQueueItem | ExclusiveQueueItem;
+
+const ZERO_RESULT: BatchWriteResult = {
+  added: 0,
+  updated: 0,
+  skipped: 0,
+  superseded: 0,
+  llm_dedup_calls: 0,
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function mergeBatchResult(a: BatchWriteResult, b: BatchWriteResult): BatchWriteResult {
+  return {
+    added: a.added + b.added,
+    updated: a.updated + b.updated,
+    skipped: a.skipped + b.skipped,
+    superseded: a.superseded + b.superseded,
+    llm_dedup_calls: a.llm_dedup_calls + b.llm_dedup_calls,
+  };
+}
+
+function chunkEntries(entries: KnowledgeEntry[], size: number): KnowledgeEntry[][] {
+  if (entries.length <= size) {
+    return [entries];
+  }
+
+  const chunks: KnowledgeEntry[][] = [];
+  for (let i = 0; i < entries.length; i += size) {
+    chunks.push(entries.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(String(error));
+}
+
+export class WriteQueue {
+  private readonly db: Client;
+  private readonly storeEntriesFn: StoreEntriesFn;
+  private readonly apiKey: string;
+  private readonly llmClient: LlmClient;
+  private readonly dbPath: string | undefined;
+  private readonly batchSize: number;
+  private readonly highWatermark: number;
+  private readonly isShutdownRequested: (() => boolean) | undefined;
+
+  private readonly queue: QueueItem[] = [];
+  private pendingEntries = 0;
+  private destroyed = false;
+  private writerStopping = false;
+  private writerStopped = false;
+  private inflightWrites = 0;
+  private activeWorkItems = 0;
+  private readonly activeByFileKey = new Map<string, number>();
+  private readonly fileWaiters = new Map<string, Array<() => void>>();
+  private readonly drainWaiters: Array<() => void> = [];
+  private readonly writerWaiters: Array<() => void> = [];
+
+  constructor(options: WriteQueueOptions) {
+    this.db = options.db;
+    this.storeEntriesFn = options.storeEntriesFn;
+    this.apiKey = options.apiKey;
+    this.llmClient = options.llmClient;
+    this.dbPath = options.dbPath;
+    this.batchSize = Math.max(1, Math.floor(options.batchSize ?? 40));
+    this.highWatermark = Math.max(1, Math.floor(options.highWatermark ?? 500));
+    this.isShutdownRequested = options.isShutdownRequested;
+
+    void this.runWriterLoop();
+  }
+
+  get pendingCount(): number {
+    return this.pendingEntries;
+  }
+
+  async push(entries: KnowledgeEntry[], fileKey: string, fileHash: string): Promise<BatchWriteResult> {
+    if (this.destroyed) {
+      throw new ShutdownError("WriteQueue has been destroyed and cannot accept new items.");
+    }
+
+    while (this.pendingEntries >= this.highWatermark) {
+      if (this.destroyed) {
+        throw new ShutdownError("WriteQueue has been destroyed and cannot accept new items.");
+      }
+      await sleep(50);
+    }
+
+    if (entries.length === 0) {
+      return { ...ZERO_RESULT };
+    }
+
+    return await new Promise<BatchWriteResult>((resolve, reject) => {
+      if (this.destroyed) {
+        reject(new ShutdownError("WriteQueue has been destroyed and cannot accept new items."));
+        return;
+      }
+
+      this.pendingEntries += entries.length;
+      this.queue.push({
+        kind: "write",
+        entries,
+        fileKey,
+        fileHash,
+        resolve,
+        reject,
+      });
+      this.wakeWriter();
+    });
+  }
+
+  async cancel(fileKey: string): Promise<void> {
+    const kept: QueueItem[] = [];
+    const cancelled: WriteQueueItem[] = [];
+
+    for (const item of this.queue) {
+      if (item.kind === "write" && item.fileKey === fileKey) {
+        cancelled.push(item);
+        this.pendingEntries = Math.max(0, this.pendingEntries - item.entries.length);
+      } else {
+        kept.push(item);
+      }
+    }
+
+    if (cancelled.length > 0) {
+      this.queue.splice(0, this.queue.length, ...kept);
+      for (const item of cancelled) {
+        item.reject(new CancelledError(`Cancelled queued write for ${fileKey}.`));
+      }
+      this.resolveDrainIfIdle();
+    }
+
+    await this.waitForFileIdle(fileKey);
+  }
+
+  async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.destroyed) {
+      throw new ShutdownError("WriteQueue has been destroyed and cannot accept new items.");
+    }
+
+    return await new Promise<T>((resolve, reject) => {
+      if (this.destroyed) {
+        reject(new ShutdownError("WriteQueue has been destroyed and cannot accept new items."));
+        return;
+      }
+
+      this.queue.push({
+        kind: "exclusive",
+        fn,
+        resolve: resolve as (result: unknown) => void,
+        reject,
+      });
+      this.wakeWriter();
+    });
+  }
+
+  async drain(): Promise<void> {
+    if (this.isIdle()) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this.drainWaiters.push(resolve);
+    });
+  }
+
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.writerStopping = true;
+
+    const pending = this.queue.splice(0, this.queue.length);
+    this.pendingEntries = 0;
+    for (const item of pending) {
+      item.reject(new ShutdownError("WriteQueue destroyed before item was processed."));
+    }
+
+    this.wakeWriter();
+    this.resolveDrainIfIdle();
+  }
+
+  private async runWriterLoop(): Promise<void> {
+    while (true) {
+      if (this.isShutdownRequested?.() && this.hasPendingWriteItems()) {
+        this.shutdownFromSignal();
+      }
+
+      if ((this.writerStopping || this.destroyed) && this.queue.length === 0) {
+        break;
+      }
+
+      if (this.queue.length === 0) {
+        await this.waitForWork();
+        continue;
+      }
+
+      const batch = this.queue.splice(0, this.queue.length);
+      this.markBatchAsDispatched(batch);
+      await this.processBatch(batch);
+    }
+
+    this.writerStopped = true;
+    this.resolveDrainIfIdle();
+  }
+
+  private hasPendingWriteItems(): boolean {
+    return this.queue.some((item) => item.kind === "write");
+  }
+
+  private async processBatch(batch: QueueItem[]): Promise<void> {
+    let index = 0;
+
+    while (index < batch.length) {
+      const item = batch[index];
+      if (!item) {
+        index += 1;
+        continue;
+      }
+
+      if (item.kind === "exclusive") {
+        await this.processExclusive(item);
+        index += 1;
+        continue;
+      }
+
+      const segment: WriteQueueItem[] = [];
+      while (index < batch.length) {
+        const segmentItem = batch[index];
+        if (!segmentItem || segmentItem.kind !== "write") {
+          break;
+        }
+        segment.push(segmentItem);
+        index += 1;
+      }
+
+      await this.processWriteSegment(segment);
+    }
+  }
+
+  private async processExclusive(item: ExclusiveQueueItem): Promise<void> {
+    try {
+      const result = await item.fn();
+      item.resolve(result);
+    } catch (error) {
+      item.reject(toError(error));
+    } finally {
+      this.activeWorkItems = Math.max(0, this.activeWorkItems - 1);
+      this.resolveDrainIfIdle();
+    }
+  }
+
+  private async processWriteSegment(segment: WriteQueueItem[]): Promise<void> {
+    const grouped = new Map<string, WriteQueueItem[]>();
+    for (const item of segment) {
+      const group = grouped.get(item.fileKey);
+      if (group) {
+        group.push(item);
+      } else {
+        grouped.set(item.fileKey, [item]);
+      }
+    }
+
+    for (const items of grouped.values()) {
+      for (const item of items) {
+        await this.processWriteItem(item);
+      }
+    }
+  }
+
+  private async processWriteItem(item: WriteQueueItem): Promise<void> {
+    let result = { ...ZERO_RESULT };
+    const subBatches = chunkEntries(item.entries, this.batchSize);
+
+    try {
+      for (const subBatch of subBatches) {
+        const writeResult = await this.writeSubBatchWithRetry(subBatch, item.fileKey, item.fileHash);
+        result = mergeBatchResult(result, writeResult);
+      }
+      item.resolve(result);
+    } catch (error) {
+      item.reject(toError(error));
+    } finally {
+      this.activeWorkItems = Math.max(0, this.activeWorkItems - 1);
+      this.decrementActiveFile(item.fileKey);
+      this.resolveDrainIfIdle();
+    }
+  }
+
+  private async writeSubBatchWithRetry(
+    entries: KnowledgeEntry[],
+    fileKey: string,
+    fileHash: string,
+  ): Promise<BatchWriteResult> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      this.inflightWrites += 1;
+      try {
+        const result = await this.storeEntriesFn(this.db, entries, this.apiKey, {
+          sourceFile: fileKey,
+          ingestContentHash: fileHash,
+          skipIngestLog: true,
+          onlineDedup: true,
+          skipLlmDedup: false,
+          llmClient: this.llmClient,
+          dbPath: this.dbPath,
+        });
+        return {
+          added: result.added,
+          updated: result.updated,
+          skipped: result.skipped,
+          superseded: result.superseded,
+          llm_dedup_calls: result.llm_dedup_calls,
+        };
+      } catch (error) {
+        lastError = toError(error);
+        if (attempt < 2) {
+          await sleep(2_000);
+        }
+      } finally {
+        this.inflightWrites = Math.max(0, this.inflightWrites - 1);
+        this.resolveDrainIfIdle();
+      }
+    }
+
+    throw lastError ?? new Error("Write queue failed to store sub-batch.");
+  }
+
+  private markBatchAsDispatched(batch: QueueItem[]): void {
+    for (const item of batch) {
+      this.activeWorkItems += 1;
+      if (item.kind === "write") {
+        this.pendingEntries = Math.max(0, this.pendingEntries - item.entries.length);
+        this.activeByFileKey.set(item.fileKey, (this.activeByFileKey.get(item.fileKey) ?? 0) + 1);
+      }
+    }
+    this.resolveDrainIfIdle();
+  }
+
+  private decrementActiveFile(fileKey: string): void {
+    const current = this.activeByFileKey.get(fileKey) ?? 0;
+    if (current <= 1) {
+      this.activeByFileKey.delete(fileKey);
+      const waiters = this.fileWaiters.get(fileKey) ?? [];
+      this.fileWaiters.delete(fileKey);
+      for (const waiter of waiters) {
+        waiter();
+      }
+      return;
+    }
+
+    this.activeByFileKey.set(fileKey, current - 1);
+  }
+
+  private async waitForFileIdle(fileKey: string): Promise<void> {
+    if ((this.activeByFileKey.get(fileKey) ?? 0) === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const existing = this.fileWaiters.get(fileKey);
+      if (existing) {
+        existing.push(resolve);
+      } else {
+        this.fileWaiters.set(fileKey, [resolve]);
+      }
+    });
+  }
+
+  private waitForWork(): Promise<void> {
+    return new Promise((resolve) => {
+      this.writerWaiters.push(resolve);
+    });
+  }
+
+  private wakeWriter(): void {
+    while (this.writerWaiters.length > 0) {
+      const waiter = this.writerWaiters.shift();
+      waiter?.();
+    }
+  }
+
+  private shutdownFromSignal(): void {
+    this.destroyed = true;
+    this.writerStopping = true;
+
+    const pending = this.queue.splice(0, this.queue.length);
+    this.pendingEntries = 0;
+    for (const item of pending) {
+      item.reject(new ShutdownError("Shutdown requested. Dropping queued writes."));
+    }
+    this.wakeWriter();
+    this.resolveDrainIfIdle();
+  }
+
+  private isIdle(): boolean {
+    return this.pendingEntries === 0 && this.activeWorkItems === 0 && this.inflightWrites === 0;
+  }
+
+  private resolveDrainIfIdle(): void {
+    if (!this.isIdle()) {
+      return;
+    }
+
+    while (this.drainWaiters.length > 0) {
+      const waiter = this.drainWaiters.shift();
+      waiter?.();
+    }
+  }
+}

--- a/src/ingest/write-queue.ts
+++ b/src/ingest/write-queue.ts
@@ -141,7 +141,7 @@ export class WriteQueue {
       throw new ShutdownError("WriteQueue has been destroyed and cannot accept new items.");
     }
 
-    while (this.pendingEntries >= this.highWatermark) {
+    while (this.pendingEntries > 0 && this.pendingEntries + entries.length > this.highWatermark) {
       if (this.destroyed) {
         throw new ShutdownError("WriteQueue has been destroyed and cannot accept new items.");
       }

--- a/tests/commands/write-queue.test.ts
+++ b/tests/commands/write-queue.test.ts
@@ -1,0 +1,371 @@
+import type { Client } from "@libsql/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { KnowledgeEntry, LlmClient } from "../../src/types.js";
+import {
+  CancelledError,
+  ShutdownError,
+  WriteQueue,
+  type StoreEntriesFn,
+} from "../../src/ingest/write-queue.js";
+
+function makeEntry(content: string): KnowledgeEntry {
+  return {
+    type: "fact",
+    subject: "WriteQueue Test",
+    content,
+    importance: 7,
+    expiry: "temporary",
+    tags: ["test"],
+    source: {
+      file: "source.txt",
+      context: "test",
+    },
+  };
+}
+
+function makeStoreResult(overrides?: Partial<Awaited<ReturnType<StoreEntriesFn>>>) {
+  return {
+    added: 1,
+    updated: 0,
+    skipped: 0,
+    superseded: 0,
+    llm_dedup_calls: 0,
+    relations_created: 0,
+    total_entries: 1,
+    duration_ms: 1,
+    ...overrides,
+  };
+}
+
+function makeLlmClient(): LlmClient {
+  return {
+    auth: "openai-api-key",
+    resolvedModel: {
+      provider: "openai",
+      modelId: "gpt-4o",
+      model: {} as never,
+    },
+    credentials: {
+      apiKey: "sk-test",
+      source: "test",
+    },
+  };
+}
+
+function createQueue(storeEntriesFn: StoreEntriesFn, options?: { batchSize?: number; highWatermark?: number; isShutdownRequested?: () => boolean }) {
+  return new WriteQueue({
+    db: {} as Client,
+    storeEntriesFn,
+    apiKey: "sk-test",
+    llmClient: makeLlmClient(),
+    dbPath: ":memory:",
+    batchSize: options?.batchSize,
+    highWatermark: options?.highWatermark,
+    isShutdownRequested: options?.isShutdownRequested,
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("Timed out waiting for condition.");
+    }
+    await sleep(10);
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("WriteQueue", () => {
+  it("pushes entries and drains with expected storeEntries args", async () => {
+    const storeEntriesFn = vi.fn(async (_db, entries) => makeStoreResult({ added: entries.length })) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn, { batchSize: 40 });
+
+    const entries = [makeEntry("a"), makeEntry("b")];
+    const result = await queue.push(entries, "file-a", "hash-a");
+    await queue.drain();
+    queue.destroy();
+
+    expect(result.added).toBe(2);
+    expect(storeEntriesFn).toHaveBeenCalledTimes(1);
+    const [dbArg, entriesArg, apiKeyArg, optionsArg] = (storeEntriesFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      unknown,
+      KnowledgeEntry[],
+      string,
+      Record<string, unknown>,
+    ];
+    expect(dbArg).toBeDefined();
+    expect(entriesArg).toEqual(entries);
+    expect(apiKeyArg).toBe("sk-test");
+    expect(optionsArg).toMatchObject({
+      sourceFile: "file-a",
+      ingestContentHash: "hash-a",
+      onlineDedup: true,
+      skipLlmDedup: false,
+      skipIngestLog: true,
+      dbPath: ":memory:",
+    });
+  });
+
+  it("drain on an empty queue resolves immediately", async () => {
+    const storeEntriesFn = vi.fn(async () => makeStoreResult()) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    await expect(queue.drain()).resolves.toBeUndefined();
+    queue.destroy();
+  });
+
+  it("push after destroy rejects with a descriptive error", async () => {
+    const storeEntriesFn = vi.fn(async () => makeStoreResult()) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+    queue.destroy();
+
+    await expect(queue.push([makeEntry("x")], "file-a", "hash-a")).rejects.toThrow(/destroyed/i);
+  });
+
+  it("destroy before drain rejects pending push promises", async () => {
+    let releaseFirst: (() => void) | null = null;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const storeEntriesFn = vi.fn(async (_db, entries) => {
+      if (entries[0]?.content === "first") {
+        await firstGate;
+      }
+      return makeStoreResult({ added: entries.length });
+    }) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const firstPromise = queue.push([makeEntry("first")], "file-a", "hash-a");
+    await waitFor(() => (storeEntriesFn as unknown as ReturnType<typeof vi.fn>).mock.calls.length === 1);
+    const secondPromise = queue.push([makeEntry("second")], "file-b", "hash-b");
+
+    queue.destroy();
+    await expect(secondPromise).rejects.toBeInstanceOf(ShutdownError);
+    releaseFirst?.();
+    await firstPromise;
+    await queue.drain();
+  });
+
+  it("handles concurrent push from 10 workers with no dropped entries", async () => {
+    const storeEntriesFn = vi.fn(async (_db, entries) => makeStoreResult({ added: entries.length })) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const pushes = await Promise.all(
+      Array.from({ length: 10 }, (_, index) => queue.push([makeEntry(`e-${index}-1`), makeEntry(`e-${index}-2`)], `file-${index}`, `hash-${index}`)),
+    );
+
+    await queue.drain();
+    queue.destroy();
+
+    const totalAdded = pushes.reduce((sum, result) => sum + result.added, 0);
+    expect(totalAdded).toBe(20);
+    expect(storeEntriesFn).toHaveBeenCalledTimes(10);
+  });
+
+  it("applies backpressure when pending entries exceed highWatermark", async () => {
+    const storeEntriesFn = vi.fn(async (_db, entries) => makeStoreResult({ added: entries.length })) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn, { highWatermark: 2 });
+
+    const first = queue.push([makeEntry("a"), makeEntry("b")], "file-a", "hash-a");
+    const startedAt = Date.now();
+    const second = queue.push([makeEntry("c")], "file-b", "hash-b");
+    const secondResult = await second;
+    const elapsed = Date.now() - startedAt;
+    await first;
+    await queue.drain();
+    queue.destroy();
+
+    expect(secondResult.added).toBe(1);
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+  });
+
+  it("retries once after a write error and then succeeds", async () => {
+    vi.useFakeTimers();
+    const storeEntriesFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockResolvedValueOnce(makeStoreResult({ added: 1 })) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const pushPromise = queue.push([makeEntry("x")], "file-a", "hash-a");
+    await vi.runAllTimersAsync();
+    const result = await pushPromise;
+    await queue.drain();
+    queue.destroy();
+
+    expect(result.added).toBe(1);
+    expect(storeEntriesFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when both retry attempts fail", async () => {
+    vi.useFakeTimers();
+    const storeEntriesFn = vi.fn().mockRejectedValue(new Error("always fails")) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const pushExpectation = expect(queue.push([makeEntry("x")], "file-a", "hash-a")).rejects.toThrow("always fails");
+    await vi.runAllTimersAsync();
+    await pushExpectation;
+    await queue.drain();
+    queue.destroy();
+    expect(storeEntriesFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("drain resolves only after all pushed items are written", async () => {
+    let releaseGate: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const storeEntriesFn = vi.fn(async (_db, entries) => {
+      if (entries[0]?.content === "wait") {
+        await gate;
+      }
+      return makeStoreResult({ added: entries.length });
+    }) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const first = queue.push([makeEntry("wait")], "file-a", "hash-a");
+    const second = queue.push([makeEntry("done")], "file-b", "hash-b");
+    const drainPromise = queue.drain();
+
+    let drained = false;
+    void drainPromise.then(() => {
+      drained = true;
+    });
+    await sleep(50);
+    expect(drained).toBe(false);
+
+    releaseGate?.();
+    await Promise.all([first, second, drainPromise]);
+    queue.destroy();
+    expect(drained).toBe(true);
+  });
+
+  it("returns per-push stats for different file keys", async () => {
+    const storeEntriesFn = vi.fn(async (_db, entries) => makeStoreResult({ added: entries.length })) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const fileA = queue.push([makeEntry("a")], "file-a", "hash-a");
+    const fileB = queue.push([makeEntry("b"), makeEntry("c")], "file-b", "hash-b");
+    const [resultA, resultB] = await Promise.all([fileA, fileB]);
+    await queue.drain();
+    queue.destroy();
+
+    expect(resultA).toMatchObject({ added: 1 });
+    expect(resultB).toMatchObject({ added: 2 });
+  });
+
+  it("cancel removes pending items for a file and rejects them with CancelledError", async () => {
+    let releaseFirst: (() => void) | null = null;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const storeEntriesFn = vi.fn(async (_db, entries) => {
+      if (entries[0]?.content === "first") {
+        await firstGate;
+      }
+      return makeStoreResult({ added: entries.length });
+    }) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const first = queue.push([makeEntry("first")], "file-a", "hash-a");
+    await waitFor(() => (storeEntriesFn as unknown as ReturnType<typeof vi.fn>).mock.calls.length === 1);
+    const pendingCancelled = queue.push([makeEntry("cancel-me")], "file-a", "hash-a");
+
+    const cancelPromise = queue.cancel("file-a");
+    releaseFirst?.();
+    await Promise.all([first, cancelPromise]);
+    await expect(pendingCancelled).rejects.toBeInstanceOf(CancelledError);
+
+    await queue.drain();
+    queue.destroy();
+  });
+
+  it("runExclusive executes inside writer serialization order", async () => {
+    let releaseFirst: (() => void) | null = null;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const order: string[] = [];
+
+    const storeEntriesFn = vi.fn(async (_db, entries) => {
+      if (entries[0]?.content === "first") {
+        order.push("write-1-start");
+        await firstGate;
+        order.push("write-1-end");
+      } else {
+        order.push("write-2");
+      }
+      return makeStoreResult({ added: entries.length });
+    }) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const first = queue.push([makeEntry("first")], "file-a", "hash-a");
+    await waitFor(() => order.includes("write-1-start"));
+    const exclusive = queue.runExclusive(async () => {
+      order.push("exclusive");
+      return 42;
+    });
+    const second = queue.push([makeEntry("second")], "file-b", "hash-b");
+
+    releaseFirst?.();
+    const [exclusiveResult] = await Promise.all([exclusive, first, second]);
+    await queue.drain();
+    queue.destroy();
+
+    expect(exclusiveResult).toBe(42);
+    expect(order).toEqual(["write-1-start", "write-1-end", "exclusive", "write-2"]);
+  });
+
+  it("honors isShutdownRequested by rejecting pending items with ShutdownError", async () => {
+    let shutdown = false;
+    let releaseFirst: (() => void) | null = null;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const storeEntriesFn = vi.fn(async (_db, entries) => {
+      if (entries[0]?.content === "first") {
+        await firstGate;
+      }
+      return makeStoreResult({ added: entries.length });
+    }) as unknown as StoreEntriesFn;
+
+    const queue = createQueue(storeEntriesFn, { isShutdownRequested: () => shutdown });
+    const first = queue.push([makeEntry("first")], "file-a", "hash-a");
+    await waitFor(() => (storeEntriesFn as unknown as ReturnType<typeof vi.fn>).mock.calls.length === 1);
+    const pending = queue.push([makeEntry("pending")], "file-b", "hash-b");
+
+    shutdown = true;
+    releaseFirst?.();
+    await first;
+    await expect(pending).rejects.toBeInstanceOf(ShutdownError);
+    await queue.drain();
+    queue.destroy();
+  });
+
+  it("tracks pendingCount for queued (not yet written) entries", async () => {
+    const storeEntriesFn = vi.fn(async (_db, entries) => makeStoreResult({ added: entries.length })) as unknown as StoreEntriesFn;
+    const queue = createQueue(storeEntriesFn);
+
+    const first = queue.push([makeEntry("a"), makeEntry("b")], "file-a", "hash-a");
+    expect(queue.pendingCount).toBe(2);
+    const second = queue.push([makeEntry("c")], "file-b", "hash-b");
+    expect(queue.pendingCount).toBe(3);
+
+    await Promise.all([first, second]);
+    await queue.drain();
+    expect(queue.pendingCount).toBe(0);
+    queue.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #107. Decouples the extraction phase from the write phase to eliminate SQLite write-lock contention during ingest.

### Problem

The previous pipeline called `storeEntries()` synchronously per chunk inside `onChunkComplete`, with `workerCount` hardcoded to 1 to avoid cross-file lock contention. Full re-ingests of ~540 sessions took 6-7 hours even with Tier 4 API access.

### Solution

All extraction workers push extracted entries into an in-memory async write queue. A single dedicated writer drains the queue in batches. Extraction runs at full parallelism with zero write contention.

### Changes

**New: `src/ingest/write-queue.ts`**
- `WriteQueue` class with `push()`, `cancel()`, `runExclusive()`, `drain()`, `destroy()`
- Single background writer loop draining in batches grouped by file key
- Backpressure via high-watermark (default 500 entries)
- Configurable retry (`retryOnFailure` option, default true - disabled when `--no-retry` is passed)
- Shutdown integration via `isShutdownRequested` callback
- Fully injectable via `IngestCommandDeps` for unit tests

**Modified: `src/commands/ingest.ts`**
- `workerCount` now uses `--workers` option (default 10) instead of hardcoded 1
- `withDbLock`/`dbChain` removed; replaced by write queue serialization
- `insertIngestLogForFile` and `cleanupFailedFileIngest` routed through `queue.runExclusive()`
- `embeddingApiKey` resolved eagerly before queue construction
- Progress display shows queue depth: `(queue: N)`
- `deduplicateEntriesFn` still called before `queue.push()` (in-memory, belongs with producer)

### Test coverage

- 14 `write-queue.test.ts` cases covering drain-on-empty, push-after-destroy, destroy-before-drain, concurrent workers, backpressure, retry, permanent failure, stats attribution, cancel, runExclusive ordering, shutdown signal, pendingCount
- 6 new `ingest.test.ts` cases: workers wiring, mock queue injection, dry-run no-push, invalid workers values, failure path calls cancel(), noPreFetch regression, workers capping

### Behavioral notes

- `entriesStored` now counts `added + superseded` (previously only `added`)
- With retries enabled, each outer retry round makes up to 2 inner write attempts per sub-batch (2s transient-fault hedge). `--no-retry` disables both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable file-level parallelism flag (--workers) to speed ingestion.
  * Introduced a queued, batched write pipeline to improve concurrent writes and orderly shutdown.

* **Performance**
  * Two-phase ingest reduces SQLite write-lock contention and enables higher throughput.

* **Improvements**
  * Write retry behavior with a 2s delay and optional disable flag (--no-retry); superseded entries counted with added items.

* **Tests**
  * Expanded integration and unit tests covering concurrency, retries, cancellation, and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->