### PR TITLE
fix(lockfile): suppress false-positive warnIfLocked when ingest holds its own lock

### DIFF
--- a/src/db/lockfile.ts
+++ b/src/db/lockfile.ts
@@ -77,6 +77,9 @@ export function isDbLocked(lockDir?: string): boolean {
   if (!pid) {
     return false;
   }
+  if (pid === process.pid) {
+    return false;
+  }
   return isPidAlive(pid);
 }
 

--- a/tests/consolidate-lock.test.ts
+++ b/tests/consolidate-lock.test.ts
@@ -50,7 +50,8 @@ describe("consolidate lock", () => {
     const mod = await loadLockModule();
     const lockPath = lockPathFromHome(process.env.HOME || "");
     await fs.mkdir(path.dirname(lockPath), { recursive: true });
-    await fs.writeFile(lockPath, String(process.pid), "utf8");
+    // Use parent PID — always alive and always a different process than us
+    await fs.writeFile(lockPath, String(process.ppid), "utf8");
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mod.warnIfLocked();

--- a/tests/db/lockfile.test.ts
+++ b/tests/db/lockfile.test.ts
@@ -70,7 +70,9 @@ describe("db lockfile", () => {
 
   it("isDbLocked returns true when lock exists with live pid", async () => {
     const lockDir = await makeLockDir();
-    acquireDbLock(lockDir);
+    const pathToLock = lockPath(lockDir, "db");
+    // Use parent PID — always alive and always a different process than us
+    await fs.writeFile(pathToLock, String(process.ppid), "utf8");
     expect(isDbLocked(lockDir)).toBe(true);
   });
 


### PR DESCRIPTION
## Problem

During `agenr ingest` with multiple workers, hundreds of spurious warnings filled the output:

```
Another agenr process is writing to the database. Writes may be delayed.
```

This happened even when no other agenr process existed. `lsof` confirmed only the single ingest PID had the DB open.

## Root Cause

`isDbLocked()` checks if the PID in `db.lock` is alive — but never checks if it's *the current process*. The ingest writes its own PID to `db.lock` via `acquireDbLock()`, then `warnIfLocked()` sees that PID, confirms it's alive, and warns. It was flagging itself as a competing process.

## Fix

Added a self-PID guard in `isDbLocked()`:

```typescript
if (pid === process.pid) {
  return false;
}
```

## Tests

Updated two tests that used `process.pid` to simulate a live lock holder — switched to `process.ppid` (parent PID: always alive, always a different process) to properly simulate an external lock.

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database lock detection to prevent false positives when checking lock status from the current process. The system now properly distinguishes between locks held by the same process versus those held by external processes, ensuring accurate lock status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->