### PR TITLE
chore: bump version to 0.7.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.18] - 2026-02-21
+
+### Fixed
+- fix(lockfile): suppress false-positive "Another agenr process is writing" warning during multi-worker ingest; `isDbLocked` now returns false when the lock is held by the current process (#121)
+
 ## [0.7.17] - 2026-02-21
 
 ### Performance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump for fix(lockfile): suppress false-positive warnIfLocked warning (#122, closes #121)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved false-positive warnings when lockfile is held by multi-worker ingest operations.
  * Fixed lockfile detection to correctly identify when the current process holds the lock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->