### PR TITLE
fix(ingest): WriteQueue backpressure deadlock + verbose start logs (v0.7.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Fixed
 - fix(ingest): WriteQueue backpressure deadlock when processing large session files; raised default highWatermark from 500 to 2000 and added configurable backpressure timeout (default 120s) that surfaces a clear error instead of hanging forever (#125)
-- feat(ingest): add `--queue-high-watermark` and `--queue-timeout-ms` CLI flags for tuning write queue behavior on large ingest jobs
-- feat(ingest): verbose mode now logs `[X/N] file -- starting` before extraction begins, eliminating the silent gap during large-file processing (#124)
+
+### Added
+- feat(ingest): --queue-high-watermark and --queue-backpressure-timeout-ms CLI flags for tuning write queue behavior on large ingest jobs
+- feat(ingest): verbose mode now logs "[X/N] file -- starting" before extraction begins, eliminating the silent gap during large-file processing (#124)
 
 ## [0.7.18] - 2026-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.19] - 2026-02-21
+
+### Fixed
+- fix(ingest): WriteQueue backpressure deadlock when processing large session files; raised default highWatermark from 500 to 2000 and added configurable backpressure timeout (default 120s) that surfaces a clear error instead of hanging forever (#125)
+- feat(ingest): add `--queue-high-watermark` and `--queue-timeout-ms` CLI flags for tuning write queue behavior on large ingest jobs
+- feat(ingest): verbose mode now logs `[X/N] file -- starting` before extraction begins, eliminating the silent gap during large-file processing (#124)
+
 ## [0.7.18] - 2026-02-21
 
 ### Fixed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -381,7 +381,7 @@ agenr ingest [options] <paths...>
 - `--concurrency <n>`: parallel chunk extractions (default `5`).
 - `--workers <n>`: files to process in parallel (default `10`). Total concurrent LLM chunk calls can reach `workers x concurrency`.
 - `--queue-high-watermark <n>`: max pending write-queue entries before workers apply backpressure (default `2000`).
-- `--queue-timeout-ms <n>`: max wait time for backpressure to clear before failing with guidance (default `120000`).
+- `--queue-backpressure-timeout-ms <n>`: max milliseconds workers wait for backpressure to clear before failing with guidance (default `120000ms = 2 min`).
 - `--skip-ingested`: skip already-ingested file/hash pairs (default `true`).
 - `--no-pre-fetch`: disable elaborative encoding pre-fetch before per-chunk extraction.
 - `--no-retry`: disable auto-retry for failed files.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -375,11 +375,13 @@ agenr ingest [options] <paths...>
 - `--provider <name>`: `anthropic|openai|openai-codex`.
 - `--platform <name>`: platform tag (`openclaw|claude-code|claude|codex`).
 - `--project <name>`: project tag (lowercase).
-- `--verbose`: per-file details.
+- `--verbose`: per-file details, including a `[X/N] file -- starting` line before extraction begins.
 - `--dry-run`: extract without storing.
 - `--json`: emit JSON summary.
 - `--concurrency <n>`: parallel chunk extractions (default `5`).
 - `--workers <n>`: files to process in parallel (default `10`). Total concurrent LLM chunk calls can reach `workers x concurrency`.
+- `--queue-high-watermark <n>`: max pending write-queue entries before workers apply backpressure (default `2000`).
+- `--queue-timeout-ms <n>`: max wait time for backpressure to clear before failing with guidance (default `120000`).
 - `--skip-ingested`: skip already-ingested file/hash pairs (default `true`).
 - `--no-pre-fetch`: disable elaborative encoding pre-fetch before per-chunk extraction.
 - `--no-retry`: disable auto-retry for failed files.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -693,6 +693,24 @@ export function createProgram(): Command {
       parseIntOption,
       10,
     )
+    .option(
+      "--queue-high-watermark <n>",
+      "Max pending entries in write queue before workers apply backpressure (default: 2000)",
+      (v: string) => {
+        const n = Number.parseInt(v, 10);
+        if (!Number.isInteger(n) || n < 1) throw new Error("--queue-high-watermark must be a positive integer");
+        return n;
+      },
+    )
+    .option(
+      "--queue-timeout-ms <n>",
+      "Max milliseconds a worker waits for write queue backpressure to clear (default: 120000)",
+      (v: string) => {
+        const n = Number.parseInt(v, 10);
+        if (!Number.isInteger(n) || n < 1) throw new Error("--queue-timeout-ms must be a positive integer");
+        return n;
+      },
+    )
     .option("--skip-ingested", "Skip already-ingested files", true)
     .option("--no-retry", "Disable auto-retry for failed files")
     .option("--no-pre-fetch", "Disable elaborative encoding pre-fetch")

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -703,11 +703,11 @@ export function createProgram(): Command {
       },
     )
     .option(
-      "--queue-timeout-ms <n>",
-      "Max milliseconds a worker waits for write queue backpressure to clear (default: 120000)",
+      "--queue-backpressure-timeout-ms <n>",
+      "Max milliseconds workers wait for write-queue backpressure to clear before failing with guidance (default: 120000ms = 2 min)",
       (v: string) => {
         const n = Number.parseInt(v, 10);
-        if (!Number.isInteger(n) || n < 1) throw new Error("--queue-timeout-ms must be a positive integer");
+        if (!Number.isInteger(n) || n < 1) throw new Error("--queue-backpressure-timeout-ms must be a positive integer");
         return n;
       },
     )

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -45,7 +45,7 @@ export interface IngestCommandOptions {
   concurrency?: number | string;
   workers?: number | string;
   queueHighWatermark?: number | string;
-  queueTimeoutMs?: number | string;
+  queueBackpressureTimeoutMs?: number | string;
   skipIngested?: boolean;
   force?: boolean;
   retry?: boolean;
@@ -538,7 +538,11 @@ export async function runIngestCommand(
   const llmConcurrency = parsePositiveInt(options.concurrency, 5, "--concurrency");
   const requestedFileWorkers = parsePositiveInt(options.workers, 10, "--workers");
   const queueHighWatermark = parsePositiveInt(options.queueHighWatermark, 2000, "--queue-high-watermark");
-  const queueTimeoutMs = parsePositiveInt(options.queueTimeoutMs, 120_000, "--queue-timeout-ms");
+  const queueBackpressureTimeoutMs = parsePositiveInt(
+    options.queueBackpressureTimeoutMs,
+    120_000,
+    "--queue-backpressure-timeout-ms",
+  );
   const retryEnabled = options.retry !== false;
   const maxRetries = retryEnabled ? parsePositiveInt(options.maxRetries, 3, "--max-retries") : 0;
   const platformRaw = options.platform?.trim();
@@ -664,7 +668,7 @@ export async function runIngestCommand(
       dbPath,
       batchSize: 40,
       highWatermark: queueHighWatermark,
-      backpressureTimeoutMs: queueTimeoutMs,
+      backpressureTimeoutMs: queueBackpressureTimeoutMs,
       retryOnFailure: retryEnabled,
       isShutdownRequested: resolvedDeps.shouldShutdownFn,
     });

--- a/src/ingest/write-queue.ts
+++ b/src/ingest/write-queue.ts
@@ -128,7 +128,7 @@ export class WriteQueue {
     this.dbPath = options.dbPath;
     this.batchSize = Math.max(1, Math.floor(options.batchSize ?? 40));
     this.highWatermark = Math.max(1, Math.floor(options.highWatermark ?? 2000));
-    this.backpressureTimeoutMs = options.backpressureTimeoutMs ?? 120_000;
+    this.backpressureTimeoutMs = Math.max(1, options.backpressureTimeoutMs ?? 120_000);
     this.retryOnFailure = options.retryOnFailure !== false;
     this.isShutdownRequested = options.isShutdownRequested;
 
@@ -152,9 +152,10 @@ export class WriteQueue {
       if (Date.now() - backpressureStart > this.backpressureTimeoutMs) {
         throw new Error(
           `WriteQueue backpressure timeout after ${this.backpressureTimeoutMs}ms: ` +
-            `${this.pendingEntries} pending entries, highWatermark=${this.highWatermark}. ` +
+            `${this.pendingEntries} pending entries, limit=${this.highWatermark} (--queue-high-watermark). ` +
             "The writer may be stalled. Try reducing --workers or --concurrency, " +
-            "or increase --queue-high-watermark.",
+            "increase --queue-high-watermark, " +
+            "or increase --queue-backpressure-timeout-ms if the writer is just slow.",
         );
       }
       await sleep(50);

--- a/tests/commands/ingest.test.ts
+++ b/tests/commands/ingest.test.ts
@@ -183,7 +183,7 @@ describe("ingest command", () => {
       "7",
       "--queue-high-watermark",
       "3000",
-      "--queue-timeout-ms",
+      "--queue-backpressure-timeout-ms",
       "240000",
       "--skip-ingested",
       "--no-retry",
@@ -206,7 +206,7 @@ describe("ingest command", () => {
       concurrency: 3,
       workers: 7,
       queueHighWatermark: 3000,
-      queueTimeoutMs: 240000,
+      queueBackpressureTimeoutMs: 240000,
       skipIngested: true,
       retry: false,
       maxRetries: 5,
@@ -232,7 +232,7 @@ describe("ingest command", () => {
 
     const result = await runIngestCommand(
       [dir],
-      { workers: 3, dryRun: true, queueHighWatermark: 777, queueTimeoutMs: 4567 },
+      { workers: 3, dryRun: true, queueHighWatermark: 777, queueBackpressureTimeoutMs: 4567 },
       deps,
     );
 


### PR DESCRIPTION
## Summary

Fixes two issues reported against large-session ingest jobs.

## Fix 1: WriteQueue backpressure deadlock (#125)

**Root cause:** The default `highWatermark` was 500. Large files (75KB+) can produce 600+ entries per batch. Combined with slow OpenAI embedding calls (~1-3s each), workers flooded the queue faster than the writer could drain it, causing `pendingEntries` to never drop below the threshold. Workers polled forever -- silent hang with no recovery path.

**Changes:**
- Raised default `highWatermark` from 500 to 2000
- Added `backpressureTimeoutMs` option (default 120s) with `Math.max(1, ...)` floor validation
- Timeout throws a clear, actionable error instead of hanging, referencing the CLI flags to tune
- New CLI flags: `--queue-high-watermark` and `--queue-backpressure-timeout-ms`

## Fix 2: Verbose mode silent gap (#124)

Long pause between chunker output and completion log with no feedback on large files. Added a `[X/N] file -- starting` log line before `processTarget` so users can see the worker is alive during extraction.

## Tests

- 9/9 write-queue tests pass (includes 2 new tests: timeout throws, backpressure clears on drain)
- 47/47 ingest tests pass (includes ordering assertion for verbose start log)
- Note: `watch-platform.test.ts` has 4 pre-existing failures (`vi.doMock`/`vi.resetModules` are Vitest APIs unsupported by Bun) -- not caused by this PR, tracked separately

## Closes

Closes #125
Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.7.19

* **Bug Fixes**
  * Fixed ingest write queue deadlock on large session files
  * Removed false-positive "another process writing" warnings during multi-worker ingest

* **New Features**
  * Added CLI options for queue tuning: `--queue-high-watermark` and `--queue-backpressure-timeout-ms`
  * Enhanced verbose mode with per-file processing status messages
  * Added `--max-retries` and `--force` options for ingest control
  * Configurable backpressure timeout with clear error messaging instead of hangs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->