### PR TITLE
fix(openclaw-plugin): sync plugin version to 0.7.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.20.1] - 2026-02-21
+
+### Fixed
+- fix(openclaw-plugin): sync plugin version in openclaw.plugin.json to match npm package (was stale at 0.7.7, now 0.7.20.1)
+
 ## [0.7.20] - 2026-02-21
 
 ### Added

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "agenr",
   "name": "agenr Memory",
   "description": "Local memory layer - injects agenr context at session start",
-  "version": "0.7.7",
+  "version": "0.7.20.1",
   "skills": [
     "skills"
   ],


### PR DESCRIPTION
## Summary

Bumps `openclaw.plugin.json` version from `0.7.7` to `0.7.20.1` to match the current npm package version. The plugin version was significantly stale and would cause confusion when users install or update.

## Changes
- `openclaw.plugin.json`: version 0.7.7 -> 0.7.20.1
- `CHANGELOG.md`: added entry for v0.7.20.1

## Type
- [x] Bug fix / chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version synchronization issue where the plugin version was inconsistent with the package version. Version is now properly aligned across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->