### PR TITLE
chore: bump to v0.7.21 (valid semver for plugin version sync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [0.7.20.1] - 2026-02-21
+## [0.7.21] - 2026-02-21
 
 ### Fixed
-- fix(openclaw-plugin): sync plugin version in openclaw.plugin.json to match npm package (was stale at 0.7.7, now 0.7.20.1)
+- fix(openclaw-plugin): sync plugin version in openclaw.plugin.json to match npm package (was stale at 0.7.7, now 0.7.21)
 
 ## [0.7.20] - 2026-02-21
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "agenr",
   "name": "agenr Memory",
   "description": "Local memory layer - injects agenr context at session start",
-  "version": "0.7.20.1",
+  "version": "0.7.21",
   "skills": [
     "skills"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
## Summary

Fixes the invalid semver introduced in #130. `0.7.20.1` is not valid semver so npm publish would fail. Bumps to `0.7.21` across all three files.

## Changes
- `package.json`: 0.7.20 -> 0.7.21
- `openclaw.plugin.json`: 0.7.20.1 -> 0.7.21
- `CHANGELOG.md`: rename \[0.7.20.1\] entry to \[0.7.21\]

## Type
- [x] Bug fix / chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.7.21 release with manifest and package updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->