### PR TITLE
feat(ingest): whole-file extraction mode (v0.8.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,18 @@ Importance: integer 1-10
 - 5: borderline -- only store if clearly durable beyond today
 - OpenClaw extractor confidence rule: hedged, unverified assistant factual
       claims are tagged `unverified` and capped at importance 5
+Whole-file extraction calibration (full-session extraction mode):
+- Typical session: 5-15 entries. Dense sessions may warrant 30-50.
+- You are seeing the complete conversation. Extract complete, coherent entries that
+  capture multi-part discussions as single entries, not fragments.
+- Score 9 or 10: very rare, at most 1 per session, often 0
+- Score 8: at most 2-3 per session; ask the cross-session-alert question before assigning
+- Score 7: this is your workhorse; most emitted entries should be 7
+- Score 6: routine dev observations worth storing
+- TODO completion: if a TODO is raised AND completed within this session, emit only
+  the completion event - not the original todo.
+- If more than 30% of your emitted entries are score 8 or higher, you are inflating.
+- Do NOT extract the same fact multiple times even if stated differently in the session.
 Expiry: `session-only`, `temporary`, `permanent`, `core`
 Scope: `private`, `shared`, `public`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.8.0] - 2026-02-22
+
+### Added
+- feat(ingest): whole-file extraction mode for transcript ingest. `extractKnowledgeFromChunks` now supports `wholeFile: "auto" | "force" | "never"` with automatic fit detection against known model context windows and single-call extraction when a file fits.
+- feat(ingest): new `--whole-file` and `--chunk` ingest flags to force whole-file or chunked extraction mode.
+- feat(ingest): new whole-file utilities in `src/ingest/whole-file.ts` for context-window detection, mode resolution, overlap-free message reconstruction, and hard-cap truncation.
+
+### Changed
+- ingest: whole-file mode now reconstructs extraction text from parsed `messages` via `renderTranscriptLine` instead of joining chunk text, avoiding overlap duplication at chunk boundaries.
+- extractor: whole-file mode now skips embedding pre-fetch and skips post-extraction LLM dedup, applies a 100-entry hard cap by importance, and retries failed whole-file extraction attempts before falling back to chunked mode.
+- watch: watcher calls now set `watchMode: true`, which enforces chunked extraction even if whole-file mode is requested.
+- mcp: ingest-style extraction now forwards parsed `messages` into extraction so whole-file mode can be resolved consistently.
+
 ## [0.7.21] - 2026-02-21
 
 ### Fixed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -384,11 +384,14 @@ agenr ingest [options] <paths...>
 - `--queue-backpressure-timeout-ms <n>`: max milliseconds workers wait for backpressure to clear before failing with guidance (default `120000ms = 2 min`).
 - `--skip-ingested`: skip already-ingested file/hash pairs (default `true`).
 - `--no-pre-fetch`: disable elaborative encoding pre-fetch before per-chunk extraction.
+- `--whole-file`: force whole-file extraction mode (single LLM call per file).
+- `--chunk`: force chunked extraction mode (disables whole-file auto-detect).
 - `--no-retry`: disable auto-retry for failed files.
 - `--max-retries <n>`: maximum auto-retry attempts (default `3`).
 - `--force`: clean re-ingest each matched file by deleting previous rows for that source file first.
 
 Ingest runs online dedup at store time (including LLM classification for ambiguous similarity bands).
+Whole-file mode defaults to `auto` when neither `--whole-file` nor `--chunk` is passed. `--whole-file` and `--chunk` are mutually exclusive.
 
 ### Example
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -296,6 +296,19 @@ hedged, unverified assistant factual claims are tagged `unverified` and capped
 at importance 5, while verified assistant claims and user statements keep normal
 importance handling.
 
+Whole-file extraction calibration (when the extractor processes a full session):
+- Typical session: 5-15 entries. Dense sessions may warrant 30-50.
+- You are seeing the complete conversation. Extract complete, coherent entries that
+  capture multi-part discussions as single entries, not fragments.
+- Score 9 or 10: very rare, at most 1 per session, often 0
+- Score 8: at most 2-3 per session; ask the cross-session-alert question before assigning
+- Score 7: this is your workhorse; most emitted entries should be 7
+- Score 6: routine dev observations worth storing
+- TODO completion: if a TODO is raised AND completed within this session, emit only
+  the completion event - not the original todo.
+- If more than 30% of your emitted entries are score 8 or higher, you are inflating.
+- Do NOT extract the same fact multiple times even if stated differently in the session.
+
 ## Troubleshooting
 
 ### Missing OpenAI API key

--- a/docs/OPENCLAW.md
+++ b/docs/OPENCLAW.md
@@ -128,6 +128,19 @@ Score anchors:
       "tests passing". Cap at 6 unless the result is surprising or breaking.
 - 5: Borderline. Only store if clearly durable beyond today.
 
+Whole-file extraction calibration (when the extractor processes a full session):
+- Typical session: 5-15 entries. Dense sessions may warrant 30-50.
+- You are seeing the complete conversation. Extract complete, coherent entries that
+  capture multi-part discussions as single entries, not fragments.
+- Score 9 or 10: very rare, at most 1 per session, often 0
+- Score 8: at most 2-3 per session; ask the cross-session-alert question before assigning
+- Score 7: this is your workhorse; most emitted entries should be 7
+- Score 6: routine dev observations worth storing
+- TODO completion: if a TODO is raised AND completed within this session, emit only
+  the completion event - not the original todo.
+- If more than 30% of your emitted entries are score 8 or higher, you are inflating.
+- Do NOT extract the same fact multiple times even if stated differently in the session.
+
 ### Confidence-aware extraction for OpenClaw transcripts
 
 OpenClaw transcript lines include `[user]` and `[assistant]` role labels.

--- a/docs/guides/scenarios.md
+++ b/docs/guides/scenarios.md
@@ -545,6 +545,19 @@ hedged assistant factual claims (for example, "I think", "probably") that are
 not tool-verified are tagged `unverified` and capped at importance 5. Verified
 assistant claims and all user statements keep normal scoring rules.
 
+Whole-file extraction calibration (from `src/extractor.ts`, used when the extractor sees the full session):
+- Typical session: 5-15 entries. Dense sessions may warrant 30-50.
+- You are seeing the complete conversation. Extract complete, coherent entries that
+  capture multi-part discussions as single entries, not fragments.
+- Score 9 or 10: very rare, at most 1 per session, often 0
+- Score 8: at most 2-3 per session; ask the cross-session-alert question before assigning
+- Score 7: this is your workhorse; most emitted entries should be 7
+- Score 6: routine dev observations worth storing
+- TODO completion: if a TODO is raised AND completed within this session, emit only
+  the completion event - not the original todo.
+- If more than 30% of your emitted entries are score 8 or higher, you are inflating.
+- Do NOT extract the same fact multiple times even if stated differently in the session.
+
 ---
 
 ## What Agents Should (and Should Not) Store
@@ -586,4 +599,4 @@ at 5 and tagged `unverified`.
 
 The system prompt sets the default to 7. In OpenClaw, 8+ fires real-time cross-session signals, so use it conservatively. Reserve 9 for critical breaking changes and immediate decisions only, not for generally important facts. Keep 10 for once-per-project permanent constraints.
 
-This calibration prevents importance inflation. The real risk is at 8+: if more than 20% of stored entries are 8 or higher, importance is being inflated and cross-session signals lose meaning.
+Chunked extraction calibration keeps the 20% guardrail for score 8+. Whole-file extraction calibration uses a 30% guardrail. Use the calibration block above for whole-file sessions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.7.21",
+  "version": "0.8.0",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -264,6 +264,7 @@ export async function runExtractCommand(
           const extracted = await resolvedDeps.extractKnowledgeFromChunksFn({
             file: key,
             chunks: parsed.chunks,
+            messages: parsed.messages,
             client,
             verbose: true,
             noDedup: options.noDedup === true,
@@ -300,6 +301,7 @@ export async function runExtractCommand(
               const extracted = await resolvedDeps.extractKnowledgeFromChunksFn({
                 file: key,
                 chunks: parsed.chunks,
+                messages: parsed.messages,
                 client,
                 verbose: false,
                 noDedup: options.noDedup === true,

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -714,6 +714,16 @@ export function createProgram(): Command {
     .option("--skip-ingested", "Skip already-ingested files", true)
     .option("--no-retry", "Disable auto-retry for failed files")
     .option("--no-pre-fetch", "Disable elaborative encoding pre-fetch")
+    .option(
+      "--whole-file",
+      "Force whole-file extraction mode. Sends each file as a single LLM call. Auto-detected for large-context models; use this flag to force it for any model. Ignored in watch mode.",
+      false,
+    )
+    .option(
+      "--chunk",
+      "Force chunked extraction. Disables whole-file auto-detect. Use if whole-file mode produces unexpected results.",
+      false,
+    )
     .option("--max-retries <n>", "Maximum auto-retry attempts", parseIntOption, 3)
     .option("--force", "Clean re-ingest: delete previous rows for each file before processing", false)
     .action(async (paths: string[], opts: IngestCommandOptions) => {

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -473,7 +473,24 @@ export async function runIngestCommand(
 ): Promise<IngestCommandResult> {
   if (options.wholeFile === true && options.chunk === true) {
     console.error("Error: Cannot use --whole-file and --chunk together");
-    process.exit(1);
+    return {
+      exitCode: 1,
+      filesProcessed: 0,
+      filesSkipped: 0,
+      filesFailed: 0,
+      totalEntriesExtracted: 0,
+      totalEntriesStored: 0,
+      dedupStats: {
+        entries_added: 0,
+        entries_updated: 0,
+        entries_skipped: 0,
+        entries_reinforced: 0,
+        entries_superseded: 0,
+        dedup_llm_calls: 0,
+      },
+      durationMs: 0,
+      results: [],
+    };
   }
 
   const resolvedDeps: IngestCommandDeps = {

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1380,7 +1380,8 @@ export async function storeEntries(
   }
 
   const textsToEmbed: string[] = [];
-  if (!options.dryRun) {
+  if (!options.dryRun && !onlineDedup) {
+    // Preserve per-entry behavior for online dedup (content-hash short-circuit and partial progress on failures).
     for (const entry of entries) {
       const text = composeEmbeddingText(entry);
       if (cache.get(text) === undefined) {

--- a/src/ingest/whole-file.ts
+++ b/src/ingest/whole-file.ts
@@ -24,17 +24,17 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "gemini-2.0-pro": 1_000_000,
 };
 
-const OUTPUT_BUDGET_TOKENS = 16_384;
-const SYSTEM_PROMPT_BUDGET_TOKENS = 4_000;
-const BYTES_PER_TOKEN = 4;
-const MAX_ENTRIES_HARD_CAP = 100;
+export const OUTPUT_BUDGET_TOKENS = 16_384;
+export const SYSTEM_PROMPT_BUDGET_TOKENS = 4_000;
+export const BYTES_PER_TOKEN = 4;
+export const MAX_ENTRIES_HARD_CAP = 100;
 
-function getClientModelId(client: LlmClient): string {
+function getClientModelId(client: LlmClient): string | undefined {
   const modelId = client.resolvedModel?.modelId;
   if (typeof modelId === "string" && modelId.trim().length > 0) {
     return modelId;
   }
-  return "";
+  return undefined;
 }
 
 function estimateTokens(messages: TranscriptMessage[]): number {
@@ -48,6 +48,12 @@ function usableWindowTokens(contextWindow: number): number {
 
 export function getContextWindowTokens(client: LlmClient, verbose?: boolean): number | undefined {
   const modelId = getClientModelId(client);
+  if (!modelId) {
+    if (verbose) {
+      console.warn("[whole-file] No model ID resolved; falling back to chunked mode.");
+    }
+    return undefined;
+  }
   const bare = modelId.includes("/") ? (modelId.split("/").at(-1) ?? modelId) : modelId;
   const normalized = bare.replace(/-\d{4}-\d{2}-\d{2}$/, "");
   const contextWindow = MODEL_CONTEXT_WINDOWS[normalized];
@@ -71,6 +77,9 @@ export function fileFitsInContext(messages: TranscriptMessage[], client: LlmClie
 }
 
 export function resolveWholeFileMode(
+  /**
+   * @param wholeFile - Resolution mode. undefined is treated identically to "auto".
+   */
   wholeFile: "auto" | "force" | "never" | undefined,
   messages: TranscriptMessage[],
   client: LlmClient,
@@ -79,16 +88,19 @@ export function resolveWholeFileMode(
   if (wholeFile === "never") {
     return false;
   }
-  if (messages.length === 0) {
-    return false;
-  }
 
   if (wholeFile === "force") {
+    if (messages.length === 0) {
+      throw new Error(
+        "[whole-file] force mode requires messages to be provided. Pass messages from parseTranscriptFile.",
+      );
+    }
+
     const contextWindow = getContextWindowTokens(client, verbose);
     const estimatedTokens = estimateTokens(messages);
     if (contextWindow !== undefined && estimatedTokens > usableWindowTokens(contextWindow)) {
       throw new Error(
-        `[whole-file] force mode: estimated ${estimatedTokens} tokens exceeds ${contextWindow}-token context window for model "${getClientModelId(client)}". Use --chunk to force chunked mode instead.`,
+        `[whole-file] force mode: estimated ${estimatedTokens} tokens exceeds ${contextWindow}-token context window. Use --chunk to force chunked mode instead.`,
       );
     }
     if (estimatedTokens > 500_000 && verbose) {
@@ -99,6 +111,10 @@ export function resolveWholeFileMode(
     return true;
   }
 
+  if (messages.length === 0) {
+    return false;
+  }
+
   return fileFitsInContext(messages, client, verbose);
 }
 
@@ -107,18 +123,18 @@ export function buildWholeFileChunkFromMessages(messages: TranscriptMessage[]): 
     throw new Error("[whole-file] cannot build whole-file chunk from empty messages");
   }
 
-  const first = messages[0];
-  const last = messages[messages.length - 1];
+  const first = messages[0]!;
+  const last = messages[messages.length - 1]!;
   return {
     chunk_index: 0,
     index: 0,
     totalChunks: 1,
-    message_start: first?.index ?? 0,
-    message_end: last?.index ?? first?.index ?? 0,
-    text: messages.map((message) => renderTranscriptLine(message)).join(""),
-    context_hint: `whole-file (${messages.length} messages)`,
-    timestamp_start: first?.timestamp,
-    timestamp_end: last?.timestamp,
+    message_start: first.index,
+    message_end: last.index,
+    text: messages.map((message) => renderTranscriptLine(message)).join("\n"),
+    context_hint: "whole-file (" + messages.length + " messages)",
+    timestamp_start: first.timestamp,
+    timestamp_end: last.timestamp,
   };
 }
 
@@ -132,7 +148,7 @@ export function applyEntryHardCap(entries: KnowledgeEntry[], verbose?: boolean):
     .slice(0, MAX_ENTRIES_HARD_CAP);
   if (verbose) {
     console.warn(
-      `[whole-file] Extracted ${entries.length} entries, exceeding hard cap of ${MAX_ENTRIES_HARD_CAP}. Truncating to top ${MAX_ENTRIES_HARD_CAP} by importance score.`,
+      `[whole-file] Received ${entries.length} entries, exceeding hard cap of ${MAX_ENTRIES_HARD_CAP}. Truncating to top ${MAX_ENTRIES_HARD_CAP} by importance score.`,
     );
   }
   return truncated;

--- a/src/ingest/whole-file.ts
+++ b/src/ingest/whole-file.ts
@@ -1,0 +1,139 @@
+import { renderTranscriptLine } from "../parser.js";
+import type { KnowledgeEntry, LlmClient, TranscriptChunk, TranscriptMessage } from "../types.js";
+
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "gpt-4.1-nano": 1_000_000,
+  "gpt-4.1-mini": 1_000_000,
+  "gpt-4.1": 1_000_000,
+  "gpt-4o": 128_000,
+  "gpt-4o-mini": 128_000,
+  "gpt-4-turbo": 128_000,
+  "gpt-3.5-turbo": 16_385,
+  "claude-3-haiku": 200_000,
+  "claude-3-sonnet": 200_000,
+  "claude-3-opus": 200_000,
+  "claude-3-5-haiku": 200_000,
+  "claude-3-5-sonnet": 200_000,
+  "claude-3-7-sonnet": 200_000,
+  "claude-opus-4": 200_000,
+  "claude-sonnet-4": 200_000,
+  "claude-haiku-4": 200_000,
+  "gemini-1.5-pro": 1_000_000,
+  "gemini-1.5-flash": 1_000_000,
+  "gemini-2.0-flash": 1_000_000,
+  "gemini-2.0-pro": 1_000_000,
+};
+
+const OUTPUT_BUDGET_TOKENS = 16_384;
+const SYSTEM_PROMPT_BUDGET_TOKENS = 4_000;
+const BYTES_PER_TOKEN = 4;
+const MAX_ENTRIES_HARD_CAP = 100;
+
+function getClientModelId(client: LlmClient): string {
+  const modelId = client.resolvedModel?.modelId;
+  if (typeof modelId === "string" && modelId.trim().length > 0) {
+    return modelId;
+  }
+  return "";
+}
+
+function estimateTokens(messages: TranscriptMessage[]): number {
+  const totalChars = messages.reduce((sum, message) => sum + renderTranscriptLine(message).length, 0);
+  return Math.ceil(totalChars / BYTES_PER_TOKEN);
+}
+
+function usableWindowTokens(contextWindow: number): number {
+  return contextWindow - OUTPUT_BUDGET_TOKENS - SYSTEM_PROMPT_BUDGET_TOKENS;
+}
+
+export function getContextWindowTokens(client: LlmClient, verbose?: boolean): number | undefined {
+  const modelId = getClientModelId(client);
+  const bare = modelId.includes("/") ? (modelId.split("/").at(-1) ?? modelId) : modelId;
+  const normalized = bare.replace(/-\d{4}-\d{2}-\d{2}$/, "");
+  const contextWindow = MODEL_CONTEXT_WINDOWS[normalized];
+
+  if (contextWindow === undefined && verbose) {
+    console.warn(
+      `[whole-file] Unknown model "${modelId}": context window unknown, falling back to chunked mode. Set modelContextWindow config to override.`,
+    );
+  }
+
+  return contextWindow;
+}
+
+export function fileFitsInContext(messages: TranscriptMessage[], client: LlmClient, verbose?: boolean): boolean {
+  const contextWindow = getContextWindowTokens(client, verbose);
+  if (contextWindow === undefined) {
+    return false;
+  }
+
+  return estimateTokens(messages) <= usableWindowTokens(contextWindow);
+}
+
+export function resolveWholeFileMode(
+  wholeFile: "auto" | "force" | "never" | undefined,
+  messages: TranscriptMessage[],
+  client: LlmClient,
+  verbose?: boolean,
+): boolean {
+  if (wholeFile === "never") {
+    return false;
+  }
+  if (messages.length === 0) {
+    return false;
+  }
+
+  if (wholeFile === "force") {
+    const contextWindow = getContextWindowTokens(client, verbose);
+    const estimatedTokens = estimateTokens(messages);
+    if (contextWindow !== undefined && estimatedTokens > usableWindowTokens(contextWindow)) {
+      throw new Error(
+        `[whole-file] force mode: estimated ${estimatedTokens} tokens exceeds ${contextWindow}-token context window for model "${getClientModelId(client)}". Use --chunk to force chunked mode instead.`,
+      );
+    }
+    if (estimatedTokens > 500_000 && verbose) {
+      console.warn(
+        `[whole-file] force mode with ~${estimatedTokens} estimated tokens on a large-context model. This may be slow and expensive.`,
+      );
+    }
+    return true;
+  }
+
+  return fileFitsInContext(messages, client, verbose);
+}
+
+export function buildWholeFileChunkFromMessages(messages: TranscriptMessage[]): TranscriptChunk {
+  if (messages.length === 0) {
+    throw new Error("[whole-file] cannot build whole-file chunk from empty messages");
+  }
+
+  const first = messages[0];
+  const last = messages[messages.length - 1];
+  return {
+    chunk_index: 0,
+    index: 0,
+    totalChunks: 1,
+    message_start: first?.index ?? 0,
+    message_end: last?.index ?? first?.index ?? 0,
+    text: messages.map((message) => renderTranscriptLine(message)).join(""),
+    context_hint: `whole-file (${messages.length} messages)`,
+    timestamp_start: first?.timestamp,
+    timestamp_end: last?.timestamp,
+  };
+}
+
+export function applyEntryHardCap(entries: KnowledgeEntry[], verbose?: boolean): KnowledgeEntry[] {
+  if (entries.length <= MAX_ENTRIES_HARD_CAP) {
+    return entries;
+  }
+
+  const truncated = [...entries]
+    .sort((left, right) => (right.importance ?? 0) - (left.importance ?? 0))
+    .slice(0, MAX_ENTRIES_HARD_CAP);
+  if (verbose) {
+    console.warn(
+      `[whole-file] Extracted ${entries.length} entries, exceeding hard cap of ${MAX_ENTRIES_HARD_CAP}. Truncating to top ${MAX_ENTRIES_HARD_CAP} by importance score.`,
+    );
+  }
+  return truncated;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -979,6 +979,7 @@ export function createMcpServer(
       const extraction = await resolvedDeps.extractKnowledgeFromChunksFn({
         file: tempFile,
         chunks: parsed.chunks,
+        messages: parsed.messages,
         client,
         verbose: false,
       });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -198,7 +198,7 @@ export async function expandInputFiles(inputs: string[]): Promise<string[]> {
   return Array.from(resolved).sort((a, b) => a.localeCompare(b));
 }
 
-function renderTranscriptLine(message: TranscriptMessage): string {
+export function renderTranscriptLine(message: TranscriptMessage): string {
   const index = String(message.index).padStart(5, "0");
   return `[m${index}][${message.role}] ${message.text}`;
 }

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -570,6 +570,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
         await resolvedDeps.extractKnowledgeFromChunksFn({
           file: targetFilePath,
           chunks: parsed.chunks,
+          watchMode: true,
           client,
           verbose: options.verbose,
           platform:

--- a/tests/commands/ingest.test.ts
+++ b/tests/commands/ingest.test.ts
@@ -238,19 +238,17 @@ describe("ingest command", () => {
 
   it("exits with code 1 when --whole-file and --chunk are used together", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
-      throw new Error(`process.exit(${String(code)})`);
-    }) as never);
+    const result = await runIngestCommand(
+      ["/tmp/does-not-matter"],
+      { wholeFile: true, chunk: true },
+      makeDeps(),
+    );
 
-    await expect(
-      runIngestCommand(["/tmp/does-not-matter"], { wholeFile: true, chunk: true }, makeDeps()),
-    ).rejects.toThrow("process.exit(1)");
-
+    expect(result.exitCode).toBe(1);
+    expect(result.filesProcessed).toBe(0);
+    expect(result.filesFailed).toBe(0);
+    expect(result.filesSkipped).toBe(0);
     expect(errorSpy).toHaveBeenCalledWith("Error: Cannot use --whole-file and --chunk together");
-    expect(exitSpy).toHaveBeenCalledWith(1);
-
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
   });
 
   it("processes files with --workers and wires createWriteQueueFn options", async () => {

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -49,10 +49,11 @@ function fakeClient(): LlmClient {
 }
 
 function fakeClientWithModelId(modelId: string): LlmClient {
+  const base = fakeClient();
   return {
-    ...fakeClient(),
+    ...base,
     resolvedModel: {
-      ...fakeClient().resolvedModel,
+      ...base.resolvedModel,
       modelId,
     },
   };

--- a/tests/ingest/whole-file.test.ts
+++ b/tests/ingest/whole-file.test.ts
@@ -25,13 +25,13 @@ function fakeModel(id: string): Model<Api> {
   };
 }
 
-function makeClient(modelId: string | undefined): LlmClient {
+function makeClient(modelId: string): LlmClient {
   return {
     auth: "openai-api-key",
     resolvedModel: {
       provider: "openai",
-      modelId: modelId as string,
-      model: fakeModel(modelId ?? "unknown"),
+      modelId,
+      model: fakeModel(modelId),
     },
     credentials: {
       apiKey: "test-key",
@@ -41,11 +41,12 @@ function makeClient(modelId: string | undefined): LlmClient {
 }
 
 function makeMessage(index: number, role: "user" | "assistant", text: string): TranscriptMessage {
+  const minutes = index.toString().padStart(2, "0");
   return {
     index,
     role,
     text,
-    timestamp: `2026-02-21T00:0${index}:00.000Z`,
+    timestamp: `2026-02-21T00:${minutes}:00.000Z`,
   };
 }
 

--- a/tests/ingest/whole-file.test.ts
+++ b/tests/ingest/whole-file.test.ts
@@ -1,0 +1,195 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyEntryHardCap,
+  buildWholeFileChunkFromMessages,
+  fileFitsInContext,
+  getContextWindowTokens,
+  resolveWholeFileMode,
+} from "../../src/ingest/whole-file.js";
+import { renderTranscriptLine } from "../../src/parser.js";
+import type { KnowledgeEntry, LlmClient, TranscriptMessage } from "../../src/types.js";
+
+function fakeModel(id: string): Model<Api> {
+  return {
+    id,
+    name: id,
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://api.openai.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: 16_384,
+  };
+}
+
+function makeClient(modelId: string | undefined): LlmClient {
+  return {
+    auth: "openai-api-key",
+    resolvedModel: {
+      provider: "openai",
+      modelId: modelId as string,
+      model: fakeModel(modelId ?? "unknown"),
+    },
+    credentials: {
+      apiKey: "test-key",
+      source: "test",
+    },
+  };
+}
+
+function makeMessage(index: number, role: "user" | "assistant", text: string): TranscriptMessage {
+  return {
+    index,
+    role,
+    text,
+    timestamp: `2026-02-21T00:0${index}:00.000Z`,
+  };
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) {
+    return 0;
+  }
+  let count = 0;
+  let cursor = 0;
+  while (true) {
+    const found = haystack.indexOf(needle, cursor);
+    if (found < 0) {
+      return count;
+    }
+    count += 1;
+    cursor = found + needle.length;
+  }
+}
+
+function makeEntry(importance: number): KnowledgeEntry {
+  return {
+    type: "fact",
+    subject: `subject-${importance}`,
+    content: `content-${importance}`,
+    importance,
+    expiry: "temporary",
+    tags: ["test"],
+    source: {
+      file: "test.jsonl",
+      context: "test",
+    },
+  };
+}
+
+describe("buildWholeFileChunkFromMessages", () => {
+  it("rebuilds a whole-file chunk without overlap duplication", () => {
+    const overlap = Array.from({ length: 300 }, (_value, index) => index.toString(36).padStart(4, "0")).join("");
+    const messages: TranscriptMessage[] = [
+      makeMessage(0, "user", `prefix-${overlap}`),
+      makeMessage(1, "assistant", "suffix"),
+    ];
+
+    const output = buildWholeFileChunkFromMessages(messages);
+    const expectedRenderedChars = messages.reduce((total, message) => total + renderTranscriptLine(message).length, 0);
+
+    expect(countOccurrences(output.text, overlap)).toBe(1);
+    expect(output.text.length).toBe(expectedRenderedChars);
+  });
+
+  it("throws for empty messages", () => {
+    expect(() => buildWholeFileChunkFromMessages([])).toThrow("empty messages");
+  });
+});
+
+describe("getContextWindowTokens", () => {
+  it("returns context window for known model ids", () => {
+    expect(getContextWindowTokens(makeClient("gpt-4o"))).toBe(128_000);
+  });
+
+  it("strips provider prefix before lookup", () => {
+    expect(getContextWindowTokens(makeClient("openai/gpt-4o-mini"))).toBe(128_000);
+  });
+
+  it("strips date suffix before lookup", () => {
+    expect(getContextWindowTokens(makeClient("gpt-4.1-nano-2025-04-14"))).toBe(1_000_000);
+  });
+
+  it("returns undefined and warns for unknown models in verbose mode", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getContextWindowTokens(makeClient("unknown-model"), true)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe("fileFitsInContext", () => {
+  it("uses rendered transcript length instead of raw message text length", () => {
+    const client = makeClient("gpt-4o");
+    const usableTokens = 128_000 - 16_384 - 4_000;
+    const message = makeMessage(0, "user", "a".repeat(usableTokens * 4));
+    const messages: TranscriptMessage[] = [message];
+
+    expect(Math.ceil(message.text.length / 4)).toBeLessThanOrEqual(usableTokens);
+    expect(fileFitsInContext(messages, client)).toBe(false);
+  });
+});
+
+describe("resolveWholeFileMode", () => {
+  it("handles never/auto/force modes", () => {
+    const client = makeClient("gpt-4.1-nano");
+    const smallMessages = [makeMessage(0, "user", "small file")];
+
+    expect(resolveWholeFileMode("never", smallMessages, client)).toBe(false);
+    expect(resolveWholeFileMode("auto", smallMessages, client)).toBe(true);
+    expect(resolveWholeFileMode("force", smallMessages, client)).toBe(true);
+  });
+
+  it("returns false for empty messages", () => {
+    const client = makeClient("gpt-4.1-nano");
+    expect(resolveWholeFileMode("auto", [], client)).toBe(false);
+    expect(resolveWholeFileMode("force", [], client)).toBe(false);
+  });
+
+  it("returns false for unknown model in auto mode", () => {
+    const client = makeClient("some-new-model");
+    const messages = [makeMessage(0, "user", "hello")];
+    expect(resolveWholeFileMode("auto", messages, client)).toBe(false);
+  });
+
+  it("throws in force mode when estimated tokens exceed a known context window", () => {
+    const client = makeClient("gpt-4o");
+    const tooLarge = [makeMessage(0, "user", "x".repeat(600_000))];
+
+    expect(() => resolveWholeFileMode("force", tooLarge, client)).toThrow("force mode");
+  });
+});
+
+describe("applyEntryHardCap", () => {
+  it("truncates to top 100 entries by importance and warns", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const entries = Array.from({ length: 147 }, (_value, index) => makeEntry(index + 1));
+
+    const capped = applyEntryHardCap(entries, true);
+    const importances = capped.map((entry) => entry.importance);
+
+    expect(capped).toHaveLength(100);
+    expect(Math.max(...importances)).toBe(147);
+    expect(Math.min(...importances)).toBe(48);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it("keeps exactly 100 entries without warning", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const entries = Array.from({ length: 100 }, (_value, index) => makeEntry(index + 1));
+
+    const capped = applyEntryHardCap(entries, true);
+
+    expect(capped).toHaveLength(100);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -4,7 +4,14 @@ import type { Client } from "@libsql/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMcpServer } from "../../src/mcp/server.js";
 import type { McpServerDeps } from "../../src/mcp/server.js";
-import type { KnowledgeEntry, LlmClient, RecallResult, StoreResult, TranscriptChunk } from "../../src/types.js";
+import type {
+  KnowledgeEntry,
+  LlmClient,
+  ParsedTranscript,
+  RecallResult,
+  StoreResult,
+  TranscriptChunk,
+} from "../../src/types.js";
 import { parseSince, parseSinceToIso } from "../../src/utils/time.js";
 import { createScopedProjectConfig } from "../helpers/scoped-config.js";
 
@@ -125,7 +132,7 @@ function makeHarness(): TestHarness {
   });
   const retireEntriesFn = vi.fn(async () => ({ count: 1 }));
 
-  const parseTranscriptFileFn = vi.fn(async (filePath: string) => {
+  const parseTranscriptFileFn = vi.fn(async (filePath: string): Promise<ParsedTranscript> => {
     const chunks: TranscriptChunk[] = [
       {
         chunk_index: 0,
@@ -137,7 +144,13 @@ function makeHarness(): TestHarness {
     ];
     return {
       file: filePath,
-      messages: [],
+      messages: [
+        {
+          index: 0,
+          role: "user",
+          text: "sample",
+        },
+      ],
       chunks,
       warnings: [],
     };
@@ -1252,6 +1265,7 @@ describe("mcp server", () => {
     expect(harness.writeFileFn).toHaveBeenCalledTimes(1);
     expect(harness.parseTranscriptFileFn).toHaveBeenCalledTimes(1);
     expect(harness.extractKnowledgeFromChunksFn).toHaveBeenCalledTimes(1);
+    expect(harness.extractKnowledgeFromChunksFn.mock.calls[0]?.[0]?.messages).toHaveLength(1);
     expect(harness.storeEntriesFn).toHaveBeenCalledTimes(1);
     expect(harness.rmFn).toHaveBeenCalledTimes(1);
 

--- a/tests/watch/watcher.test.ts
+++ b/tests/watch/watcher.test.ts
@@ -1049,6 +1049,30 @@ describe("watcher", () => {
     expect(deps.storeEntriesFn).not.toHaveBeenCalled();
   });
 
+  it("passes watchMode=true to extraction calls", async () => {
+    const filePath = "/tmp/watch.jsonl";
+    const deps = makeDeps({
+      statFileFn: vi.fn(async () => ({ size: 25, isFile: () => true })),
+      readFileFn: vi.fn(async () => Buffer.from("this content passes threshold")),
+    });
+
+    await runWatcher(
+      {
+        filePath,
+        intervalMs: 1,
+        minChunkChars: 5,
+        dryRun: true,
+        verbose: false,
+        once: true,
+      },
+      deps,
+    );
+
+    expect(deps.extractKnowledgeFromChunksFn).toHaveBeenCalledTimes(1);
+    expect(deps.extractKnowledgeFromChunksFn.mock.calls[0]?.[0]?.watchMode).toBe(true);
+    expect(deps.extractKnowledgeFromChunksFn.mock.calls[0]?.[0]?.messages).toBeUndefined();
+  });
+
   it("watcher does not call embedFn when noPreFetch=true", async () => {
     const filePath = "/tmp/watch.jsonl";
     const embedFn = vi.fn(async () => [[1, 0, 0]]);


### PR DESCRIPTION
## Summary

Replaces per-chunk LLM extraction with a single whole-file call when the session fits within the model context window. Auto-detected by default. Falls back to chunked for large files, unknown models, and watch mode.

Closes #128.

---

## Problem

Current chunked extraction (3K tokens per chunk) fragments sessions that span multiple chunks:
- TODO raised in chunk 1, completed in chunk 5 - chunk 5 never sees the original TODO
- Multi-part decisions split across boundaries
- 90+ raw entries on dense sessions before dedup

## Solution

- New `wholeFile: 'auto' | 'force' | 'never'` param on `extractKnowledgeFromChunks`
- Auto-detects fit using rendered message token estimate vs model context window
- Text rebuilt from `messages[]` via `renderTranscriptLine()` - no chunk overlap contamination
- Pre-fetch skipped (embedding limit exceeded by whole-file chunk size)
- Dedup pass skipped (model sees full session, handles within-session dedup via prompt)
- 3-attempt retry with exponential backoff (2s/4s/8s + jitter) + chunked fallback on failure
- Post-extraction hard cap: top 100 entries by importance score
- Watch mode: `watchMode: true` enforces chunked at runtime (cost amplification prevention)
- New CLI flags: `--whole-file` (force) and `--chunk` (never), mutually exclusive

## New File

`src/ingest/whole-file.ts` - context window registry, token estimation, fit check, chunk builder, hard cap

## Model Support

gpt-4.1-nano/mini/full (1M), gpt-4o/mini (128K), gpt-4-turbo (128K), gpt-3.5-turbo (16K), Claude 3/3.5/3.7/4 family (200K), Gemini 1.5/2.0 (1M). Unknown models fall back to chunked with a verbose warning.

## Changes

- `src/ingest/whole-file.ts` (new, 139 lines)
- `src/extractor.ts` (+321)
- `src/commands/ingest.ts` (+15)
- `src/watch/watcher.ts` (+1)
- `tests/ingest/whole-file.test.ts` (new, 195 lines)
- `tests/extractor.test.ts` (+448)
- `tests/commands/ingest.test.ts` (+176)
- 15 files total, +1320 / -50

## Test Results

910 passing, 2 failing (pre-existing on master, tracked in #132, unrelated to this PR)

---

*Two-pass swarm reviewed: spec review (arch + test + risk) and code review (algo + test + CR). Swarm fixes applied in follow-up commit.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes - Version 0.8.0

* **New Features**
  * Whole-file extraction mode: Process entire transcripts in a single LLM call when they fit your model's context window for improved efficiency.
  * Added `--whole-file` and `--chunk` CLI flags to explicitly control extraction mode; auto-detection is now the default.

* **Documentation**
  * Updated architecture and CLI documentation with details on extraction strategies and new mode flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->