### PR TITLE
fix(openclaw-plugin): sync plugin version to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.1] - 2026-02-22
+
+### Fixed
+- fix(openclaw-plugin): sync plugin version in openclaw.plugin.json to match npm package (was stale at 0.7.21, now 0.8.1)
+
 ## [0.8.0] - 2026-02-22
 
 ### Added

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "agenr",
   "name": "agenr Memory",
   "description": "Local memory layer - injects agenr context at session start",
-  "version": "0.7.21",
+  "version": "0.8.1",
   "skills": [
     "skills"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Sync openclaw.plugin.json version from stale 0.7.21 to 0.8.1 to match the npm package version. Same fix as PR #131 for the new release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.8.1 and synchronized plugin version to match the package release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->