### PR TITLE
fix: tighten EmbeddingCache maxSize guard to reject NaN

### DIFF
--- a/src/embeddings/cache.ts
+++ b/src/embeddings/cache.ts
@@ -11,8 +11,8 @@ export class EmbeddingCache {
   private tail: string | null = null; // least recently used key
 
   constructor(maxSize = 5000) {
-    if (maxSize < 1) {
-      throw new RangeError("EmbeddingCache maxSize must be at least 1.");
+    if (!(maxSize >= 1)) {
+      throw new RangeError(`EmbeddingCache maxSize must be at least 1. Received: ${String(maxSize)}.`);
     }
     this.maxSize = maxSize;
   }

--- a/tests/embedding-cache.test.ts
+++ b/tests/embedding-cache.test.ts
@@ -78,8 +78,9 @@ describe("EmbeddingCache", () => {
     expect(cache.get("c")).toEqual([3]);
   });
 
-  it("throws RangeError when maxSize is less than 1", () => {
+  it("throws RangeError when maxSize is less than 1 or NaN", () => {
     expect(() => new EmbeddingCache(0)).toThrow(RangeError);
     expect(() => new EmbeddingCache(-1)).toThrow(RangeError);
+    expect(() => new EmbeddingCache(NaN)).toThrow(RangeError);
   });
 });


### PR DESCRIPTION
## What this does

Fixes a silent bug in the EmbeddingCache constructor guard.

**Problem:** `if (maxSize < 1)` silently passes NaN because NaN comparisons always return false. A caller passing NaN gets a cache that calls evictTail() on every set(), immediately dereferencing a null tail.

**Fix:** `if (!(maxSize >= 1))` correctly rejects NaN, 0, and negative values. Error message now includes the received value for easier debugging.

**Test:** NaN added to the constructor boundary test alongside 0 and -1.

## Changes
- `src/embeddings/cache.ts` - guard + error message
- `tests/embedding-cache.test.ts` - NaN coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for EmbeddingCache configuration validation to include the received value for better debugging.

* **Tests**
  * Enhanced test coverage for edge cases in configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->