### PR TITLE
fix(consolidate+bulk): consolidate merge bugs #148/#149/#150 and bulk ingest CR followups

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,6 +197,8 @@ Migrations are defined as a series of column-presence checks followed by `ALTER 
 | `source_context` | TEXT | Extraction context |
 | `embedding` | F32_BLOB(1024) | 1024-dimensional float32 vector |
 | `content_hash` | TEXT | Content hash for idempotency (v2) |
+| `norm_content_hash` | TEXT | SHA-256 of lowercased, whitespace/punctuation-normalized content; used for exact-match dedup in bulk mode |
+| `minhash_sig` | BLOB | 512-byte (128x4) MinHash signature (5-gram, FNV32); used for near-duplicate dedup in bulk mode |
 | `created_at` | TEXT | ISO timestamp |
 | `updated_at` | TEXT | ISO timestamp |
 | `last_recalled_at` | TEXT | ISO timestamp of last recall |

--- a/src/consolidate/merge.ts
+++ b/src/consolidate/merge.ts
@@ -311,13 +311,14 @@ export async function mergeCluster(
   if (mergeResult.type !== dominantType) {
     mergeResult.type = dominantType;
   }
+  const maxSourceImportance = Math.max(...cluster.entries.map((entry) => entry.importance ?? 5));
   const sourceTagUnion = normalizeTags(cluster.entries.flatMap((entry) => entry.tags ?? []));
 
   const mergedEntry: KnowledgeEntry = {
     type: mergeResult.type,
     subject: mergeResult.subject,
     content: mergeResult.content,
-    importance: mergeResult.importance,
+    importance: Math.max(mergeResult.importance, maxSourceImportance),
     expiry: mergeResult.expiry,
     tags: normalizeTags([...mergeResult.tags, ...sourceTagUnion]),
     ...(expectedProject ? { project: expectedProject } : {}),

--- a/src/consolidate/merge.ts
+++ b/src/consolidate/merge.ts
@@ -312,6 +312,10 @@ export async function mergeCluster(
     mergeResult.type = dominantType;
   }
   const maxSourceImportance = Math.max(...cluster.entries.map((entry) => entry.importance ?? 5));
+  const oldestCreatedAt = cluster.entries
+    .map((entry) => entry.createdAt)
+    .filter((date): date is string => Boolean(date) && date.length > 0)
+    .sort()[0];
   const sourceTagUnion = normalizeTags(cluster.entries.flatMap((entry) => entry.tags ?? []));
 
   const mergedEntry: KnowledgeEntry = {
@@ -321,6 +325,7 @@ export async function mergeCluster(
     importance: Math.max(mergeResult.importance, maxSourceImportance),
     expiry: mergeResult.expiry,
     tags: normalizeTags([...mergeResult.tags, ...sourceTagUnion]),
+    ...(oldestCreatedAt ? { created_at: oldestCreatedAt } : {}),
     ...(expectedProject ? { project: expectedProject } : {}),
     source: {
       file: "agenr",

--- a/src/consolidate/merge.ts
+++ b/src/consolidate/merge.ts
@@ -102,6 +102,7 @@ function formatClusterEntries(cluster: Cluster, contentLimit?: number): string {
         `- confirmations: ${entry.confirmations}`,
         `- created_at: ${entry.createdAt}`,
         `- content: ${content}`,
+        `- tags: ${(entry.tags ?? []).join(", ") || "(none)"}`,
       ].join("\n");
     })
     .join("\n\n");
@@ -310,6 +311,7 @@ export async function mergeCluster(
   if (mergeResult.type !== dominantType) {
     mergeResult.type = dominantType;
   }
+  const sourceTagUnion = normalizeTags(cluster.entries.flatMap((entry) => entry.tags ?? []));
 
   const mergedEntry: KnowledgeEntry = {
     type: mergeResult.type,
@@ -317,7 +319,7 @@ export async function mergeCluster(
     content: mergeResult.content,
     importance: mergeResult.importance,
     expiry: mergeResult.expiry,
-    tags: mergeResult.tags,
+    tags: normalizeTags([...mergeResult.tags, ...sourceTagUnion]),
     ...(expectedProject ? { project: expectedProject } : {}),
     source: {
       file: "agenr",

--- a/src/consolidate/util.ts
+++ b/src/consolidate/util.ts
@@ -3,6 +3,7 @@ export interface ActiveEmbeddedEntry {
   type: string;
   subject: string;
   content: string;
+  tags?: string[];
   project?: string | null;
   embedding: number[];
   importance?: number;

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -177,7 +177,14 @@ export async function initDb(client: Client, opts?: { checkBulkRecovery?: boolea
   }
   await initSchema(client);
   if (opts?.checkBulkRecovery === true) {
-    await checkAndRecoverBulkIngest(client);
+    try {
+      await checkAndRecoverBulkIngest(client);
+    } catch (recoveryError) {
+      process.stderr.write(
+        `[agenr] Warning: bulk ingest recovery failed: ${recoveryError instanceof Error ? (recoveryError.stack ?? recoveryError.message) : String(recoveryError)}\n` +
+        `[agenr] Continuing without recovery. Run 'agenr ingest --bulk' again if FTS or vector search is degraded.\n`,
+      );
+    }
   }
 
   // Probe vector index health (best-effort; do not block normal commands).

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -162,9 +162,6 @@ export async function checkAndRecoverBulkIngest(client: Client): Promise<void> {
     await clearBulkIngestMeta(client);
     process.stderr.write("[agenr] Recovery complete.\n");
   } catch (error) {
-    process.stderr.write(
-      `[agenr] Bulk ingest recovery failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
-    );
     throw error;
   }
 }

--- a/src/db/minhash.ts
+++ b/src/db/minhash.ts
@@ -91,7 +91,7 @@ export function minhashJaccard(a: Uint32Array, b: Uint32Array): number {
 }
 
 export function minhashSigToBuffer(sig: Uint32Array): Buffer {
-  return Buffer.from(sig.buffer);
+  return Buffer.from(sig.buffer, sig.byteOffset, sig.byteLength);
 }
 
 export function bufferToMinhashSig(buf: Buffer | Uint8Array): Uint32Array {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -284,7 +284,7 @@ export async function dropFtsTriggersAndIndex(db: Client): Promise<void> {
 }
 
 export async function rebuildFtsAndTriggers(db: Client): Promise<void> {
-  await db.execute("BEGIN");
+  await db.execute("BEGIN IMMEDIATE");
   try {
     await db.execute(REBUILD_ENTRIES_FTS_SQL);
     await db.execute(CREATE_ENTRIES_FTS_TRIGGER_AI_SQL);

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -589,7 +589,7 @@ export async function backfillBulkColumns(db: Client): Promise<number> {
       break;
     }
 
-    await db.execute("BEGIN");
+    await db.execute("BEGIN IMMEDIATE");
     try {
       for (const row of batch.rows) {
         const id = toStringValue(row.id);

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -39,6 +39,7 @@ describe("db schema", () => {
       "idx_entries_created",
       "idx_entries_superseded",
       "idx_entries_content_hash",
+      "idx_entries_norm_content_hash",
       "idx_tags_tag",
       "idx_relations_source",
       "idx_relations_target",
@@ -92,6 +93,7 @@ describe("db schema", () => {
         'idx_entries_created',
         'idx_entries_superseded',
         'idx_entries_content_hash',
+        'idx_entries_norm_content_hash',
         'idx_tags_tag',
         'idx_relations_source',
         'idx_relations_target',
@@ -102,7 +104,7 @@ describe("db schema", () => {
       )
       GROUP BY name
     `);
-    expect(namesResult.rows).toHaveLength(23);
+    expect(namesResult.rows).toHaveLength(24);
     for (const row of namesResult.rows as Array<{ count?: unknown }>) {
       expect(Number(row.count)).toBe(1);
     }


### PR DESCRIPTION
## Summary

Nine fixes in two groups: three consolidate merge correctness bugs and six bulk ingest followups from CodeRabbit's second pass on PR #152.

---

## Part A — Consolidate Bug Fixes

### #148 — Source entry tags lost during merge
Tags on source entries were never passed to the LLM prompt and were silently discarded on merge. Fixed by:
- Adding `tags?: string[]` to `ActiveEmbeddedEntry` in `util.ts`
- Adding `GROUP_CONCAT` subquery to `buildClusters()` SQL in `cluster.ts`
- Rendering source tags in `formatClusterEntries()` so the LLM sees them
- Unioning source tags with LLM-returned tags via `normalizeTags` in `mergeCluster()`

### #149 — Merged entry importance can drop below source maximum
LLM could return importance 5 for two entries with importance 9 and 8. Fixed by computing `maxSourceImportance = Math.max(...cluster.entries.map(e => e.importance ?? 5))` and applying it as a floor.

### #150 — Merged entry `created_at` is consolidation time, not oldest source
Merged entries were getting an artificial freshness boost. Fixed by computing the oldest source `created_at` via lexicographic sort and spreading it onto `mergedEntry`.

---

## Part B — Bulk Ingest CR Followups (PR #152 second pass)

- **initDb graceful degradation**: `checkAndRecoverBulkIngest` errors now caught and logged with a recovery hint instead of propagating and crashing callers
- **`rebuildFtsAndTriggers`**: `BEGIN` upgraded to `BEGIN IMMEDIATE` for consistency with all other bulk write transactions (prevents SQLITE_BUSY under WAL with concurrent writers)
- **`backfillBulkColumns`**: same `BEGIN` → `BEGIN IMMEDIATE` fix
- **`minhashSigToBuffer`**: `Buffer.from(sig.buffer)` → `Buffer.from(sig.buffer, sig.byteOffset, sig.byteLength)` to correctly handle Uint32Array sub-views
- **ARCHITECTURE.md**: `norm_content_hash` and `minhash_sig` added to entries table reference
- **schema.test.ts**: `idx_entries_norm_content_hash` added to expected objects list and idempotency count bumped 23 → 24

---

## Swarm Review

Reviewed by algo + test + quality swarm. Verdict: **PASS-WITH-NOTES** — no P0/P1 issues found.

Notable P2 from algo/quality (filed as issue #155): `GROUP_CONCAT(t.tag, ',')` uses comma as separator; a tag value containing a comma would corrupt the round-trip. Low probability in practice, tracked for a follow-up fix.

Test gap (filed as issue #156): no new tests added for the three consolidate fixes. The fixes are mechanically correct and verified by swarm — test coverage is a follow-up item.

## Testing

953/953 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tags added to knowledge entries and visible in cluster/merge results; merged entries now combine and normalize source tags, and may preserve oldest creation date and max source importance.
  * Bulk ingest enhanced with exact-match and near-duplicate detection for improved deduplication.

* **Bug Fixes**
  * Bulk recovery no longer blocks ingest on failure; non-fatal warning is emitted instead of interrupting flow.

* **Chores**
  * Minor concurrency/transaction and correctness tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->