### PR TITLE
chore: bump version to 0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump for 0.8.6 release. See PR #157 for changelog.