### PR TITLE
fix: extraction signal quality, ingest noise, adapter detection, and daemon path

### DIFF
--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -8,7 +8,7 @@ import type { SourceAdapter } from "./types.js";
 import { vscodeCopilotAdapter } from "./vscode-copilot.js";
 
 export async function detectAdapter(filePath: string): Promise<SourceAdapter> {
-  const strippedPath = filePath.replace(/\.deleted\.[^/\\]+$/, "");
+  const strippedPath = filePath.replace(/\.(deleted|reset)\.[^/\\]+$/, "");
   const ext = path.extname(strippedPath).toLowerCase();
 
   if (ext === ".jsonl") {

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -228,7 +228,7 @@ async function runLaunchctl(
 }
 
 function resolveCliPath(argv: string[]): string {
-  const cliArg = argv[1];
+  const cliArg = argv[1] ?? process.argv[1];
   if (cliArg && cliArg.trim().length > 0) {
     return path.resolve(cliArg);
   }

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -228,7 +228,7 @@ async function runLaunchctl(
 }
 
 function resolveCliPath(argv: string[]): string {
-  const cliArg = argv[1] ?? process.argv[1];
+  const cliArg = argv[1];
   if (cliArg && cliArg.trim().length > 0) {
     return path.resolve(cliArg);
   }

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -893,6 +893,7 @@ export async function runIngestCommand(
   let totalChunksFailed = 0;
   let filesWithChunkFailures = 0;
   const chunkStatsByFile = new Map<string, { successfulChunks: number; failedChunks: number }>();
+  const extractOnceFlags = { hasWarnedWholeFileIgnoredParams: false };
   let firstPassFailedIndexSet = new Set<number>();
   let bulkTeardownComplete = false;
   let bulkVectorRebuildDurationSeconds: number | null = null;
@@ -1062,6 +1063,7 @@ export async function runIngestCommand(
         db: options.noPreFetch ? undefined : db,
         embeddingApiKey: options.noPreFetch ? undefined : embeddingApiKey ?? undefined,
         noPreFetch: options.noPreFetch === true,
+        onceFlags: extractOnceFlags,
         onVerbose: verbose
           ? (line) => {
               clack.log.info(line, clackOutput);

--- a/src/consolidate/merge.ts
+++ b/src/consolidate/merge.ts
@@ -115,6 +115,7 @@ function buildMergeContext(cluster: Cluster): Context {
     "Only include information explicitly stated in the source entries. Do not infer or add details not present.",
     "Prefer preserving temporal changes in the merged narrative.",
     "Call merge_entries with your final merged result.",
+    'expiry must be exactly the string "permanent" or "temporary" -- never a date, timestamp, or other value.',
   ].join("\n");
 
   let contentLimit: number | undefined;

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -22,15 +22,15 @@ import { isShutdownRequested } from "./shutdown.js";
 
 export const SYSTEM_PROMPT = `You are a selective memory extraction engine. Extract only knowledge worth remembering beyond the immediate step.
 
-Default action: SKIP. Most chunks should produce zero entries -- EXCEPT personal facts about the user (health, family, home, lifestyle, relationships), which should be captured even from casual or passing mentions.
+Default action: SKIP. Most chunks should produce zero entries. Personal disclosures (health, diet, family structure, pets, occupation, location, values, relationships) are high-signal -- do not skip them just because the mention is brief or incidental. Apply the durability gate below to all entries including personal ones.
 
 ## Types
 
-FACT -- Verifiable information about a system, project, person, or concept. Personal facts count as first-class entries: health conditions, family members, pets, where the user lives or works, occupation, hobbies, recurring habits, and lifestyle circumstances.
+FACT — Verifiable information about a system, project, person, or concept. Personal facts count as first-class entries: health conditions, family members, pets, where the user lives or works, occupation, hobbies, recurring habits, and lifestyle circumstances.
 DECISION — A choice that constrains future options. Requires BOTH the choice AND the rationale. If rationale is missing, use fact or event instead.
 PREFERENCE — A stated or demonstrated preference that should influence future behavior.
 LESSON — An insight from experience that should change future behavior.
-EVENT -- A significant milestone, launch, completion, or one-time life moment. Includes project launches, deployments, merges; and personal milestones like starting a new job, relocating, major health events, or notable personal experiences. NOT recurring habits or routines (those are FACT or PREFERENCE). NOT "the assistant ran git status." NOT vague references with no anchoring detail.
+EVENT — A significant milestone, launch, completion, or one-time life moment. Includes project launches, deployments, merges; and personal milestones like starting a new job, relocating, major health events, or notable personal experiences. NOT recurring habits or routines (those are FACT or PREFERENCE). NOT "the assistant ran git status." NOT vague references with no anchoring detail. If a personal behavior is described as newly begun, prefer EVENT for the initiation; use FACT if the stable ongoing state is also established in the same context.
 RELATIONSHIP — A connection between named entities. Content must include both entities and the relation.
 TODO — A persistent future action not completed in this chunk and not a one-step session instruction.
 
@@ -343,7 +343,7 @@ FACT:
   "importance": 6,
   "expiry": "permanent",
   "tags": ["routine", "health", "personal"],
-  "source_context": "User described morning routine while discussing their schedule -- scored 6 as biographical context; recurring habit not requiring cross-session alert"
+  "source_context": "User described morning routine while discussing their schedule -- scored 6 not 8 because this is low-urgency biographical context; no parallel session needs to act on it immediately"
 }
 
 EVENT:
@@ -354,7 +354,7 @@ EVENT:
   "importance": 7,
   "expiry": "permanent",
   "tags": ["career", "work", "personal"],
-  "source_context": "User mentioned new job while discussing their schedule -- one-time life event worth remembering as context"
+  "source_context": "User mentioned new job while discussing their schedule -- scored 7 not 9 because this is a significant life milestone worth preserving but does not require immediate cross-session action"
 }
 
 // NOTE: These examples are drawn from OpenClaw transcripts (agent role labels, tool-verified claims). They provide soft cross-platform guidance for hedged-claim handling; mechanical enforcement (importance cap + unverified tag) is applied for openclaw, codex, and claude-code via applyConfidenceCap().

--- a/tests/adapters/registry.test.ts
+++ b/tests/adapters/registry.test.ts
@@ -47,6 +47,21 @@ describe("adapter registry", () => {
     expect(adapter.name).toBe("codex");
   });
 
+  it(".jsonl, .jsonl.deleted.TIMESTAMP, and .jsonl.reset.TIMESTAMP resolve to JSONL adapter family", async () => {
+    const content = '{"role":"user","content":"hello"}\n';
+    const plainPath = await makeTempFile("session.jsonl", content);
+    const deletedPath = await makeTempFile("session.jsonl.deleted.2026-02-22T17-00-14.068Z", content);
+    const resetPath = await makeTempFile("session.jsonl.reset.2026-02-20T04-16-49.269Z", content);
+
+    const plainAdapter = await detectAdapter(plainPath);
+    const deletedAdapter = await detectAdapter(deletedPath);
+    const resetAdapter = await detectAdapter(resetPath);
+
+    expect(plainAdapter.name).toBe("jsonl-generic");
+    expect(deletedAdapter.name).toBe("jsonl-generic");
+    expect(resetAdapter.name).toBe("jsonl-generic");
+  });
+
   it(".jsonl.deleted.TIMESTAMP with OpenClaw content routes to openclaw adapter", async () => {
     const filePath = await makeTempFile(
       "34da25ee.jsonl.deleted.2026-02-22T17-00-14.068Z",

--- a/tests/adapters/registry.test.ts
+++ b/tests/adapters/registry.test.ts
@@ -71,6 +71,15 @@ describe("adapter registry", () => {
     expect(adapter.name).toBe("openclaw");
   });
 
+  it(".jsonl.reset.TIMESTAMP with OpenClaw content routes to openclaw adapter", async () => {
+    const filePath = await makeTempFile(
+      "34da25ee.jsonl.reset.2026-02-22T17-00-14.068Z",
+      '{"type":"session","timestamp":"2026-02-06T12:32:50.848Z"}\n',
+    );
+    const adapter = await detectAdapter(filePath);
+    expect(adapter.name).toBe("openclaw");
+  });
+
   it(".jsonl.deleted.TIMESTAMP with Codex content routes to codex adapter", async () => {
     const filePath = await makeTempFile(
       "abc123.jsonl.deleted.2026-02-21T10-00-00.000Z",

--- a/tests/consolidate-merge.test.ts
+++ b/tests/consolidate-merge.test.ts
@@ -366,6 +366,21 @@ describe("extractMergeResultFromToolCall", () => {
     expect(result?.expiry).toBe("permanent");
   });
 
+  it("falls back to permanent and logs warning when expiry is an ISO timestamp", () => {
+    const onLog = vi.fn();
+    const isoTimestamp = "2026-02-21T19:28:54.672Z";
+    const result = extractMergeResultFromToolCall(makeToolCallMessage({ expiry: isoTimestamp }), {
+      verbose: true,
+      onLog,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.expiry).toBe("permanent");
+    expect(onLog).toHaveBeenCalledWith(
+      `[merge] LLM returned invalid expiry "${isoTimestamp}", falling back to "permanent"`,
+    );
+  });
+
   it("falls back to 5 when importance is non-numeric", () => {
     const result = extractMergeResultFromToolCall(makeToolCallMessage({ importance: "certain" }));
     expect(result).not.toBeNull();

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -1228,89 +1228,91 @@ describe("extractKnowledgeFromChunks", () => {
     expect(result.entries[0]?.source.context).toBe("user discussed preferred package manager");
   });
 
-  it("keeps personal dietary disclosures when mentioned as an aside", async () => {
-    const result = await extractKnowledgeFromChunks({
-      file: "session.jsonl",
-      chunks: [
-        {
-          ...fakeChunk(),
-          text: "[m00000][user] I follow keto -- anyway, back to the code.",
-        },
-      ],
-      client: fakeClient(),
-      verbose: false,
-      streamSimpleImpl: fakeStream([
-        {
-          type: "preference",
-          subject: "user dietary preference",
-          content: "User follows a strict ketogenic diet and avoids carbohydrates.",
-          importance: 7,
-          expiry: "permanent",
-          tags: ["diet", "keto", "personal", "health"],
-          source_context: "User mentioned diet as an aside mid-conversation",
-        },
-      ]),
-      sleepImpl: async () => {},
-      retryDelayMs: () => 0,
+  describe("pipeline: entry passthrough (fakeStream -- bypasses LLM)", () => {
+    it("processes personal preference entries returned by model", async () => {
+      const result = await extractKnowledgeFromChunks({
+        file: "session.jsonl",
+        chunks: [
+          {
+            ...fakeChunk(),
+            text: "[m00000][user] I follow keto -- anyway, back to the code.",
+          },
+        ],
+        client: fakeClient(),
+        verbose: false,
+        streamSimpleImpl: fakeStream([
+          {
+            type: "preference",
+            subject: "user dietary preference",
+            content: "User follows a strict ketogenic diet and avoids carbohydrates.",
+            importance: 7,
+            expiry: "permanent",
+            tags: ["diet", "keto", "personal", "health"],
+            source_context: "User mentioned diet as an aside mid-conversation",
+          },
+        ]),
+        sleepImpl: async () => {},
+        retryDelayMs: () => 0,
+      });
+
+      expect(result.entries.length).toBeGreaterThanOrEqual(1);
+      expect(
+        result.entries.some(
+          (entry) =>
+            (entry.type === "preference" || entry.type === "fact") &&
+            entry.tags.some((tag) => tag === "diet" || tag === "keto"),
+        ),
+      ).toBe(true);
     });
 
-    expect(result.entries.length).toBeGreaterThanOrEqual(1);
-    expect(
-      result.entries.some(
-        (entry) =>
-          (entry.type === "preference" || entry.type === "fact") &&
-          entry.tags.some((tag) => tag === "diet" || tag === "keto"),
-      ),
-    ).toBe(true);
-  });
+    it("pipeline returns empty array when model produces no entries", async () => {
+      const result = await extractKnowledgeFromChunks({
+        file: "session.jsonl",
+        chunks: [
+          {
+            ...fakeChunk(),
+            text: "[m00000][user] sounds good, thanks!",
+          },
+        ],
+        client: fakeClient(),
+        verbose: false,
+        streamSimpleImpl: fakeStream([]),
+        sleepImpl: async () => {},
+        retryDelayMs: () => 0,
+      });
 
-  it("produces zero entries for pure pleasantries", async () => {
-    const result = await extractKnowledgeFromChunks({
-      file: "session.jsonl",
-      chunks: [
-        {
-          ...fakeChunk(),
-          text: "[m00000][user] sounds good, thanks!",
-        },
-      ],
-      client: fakeClient(),
-      verbose: false,
-      streamSimpleImpl: fakeStream([]),
-      sleepImpl: async () => {},
-      retryDelayMs: () => 0,
+      expect(result.entries).toHaveLength(0);
     });
 
-    expect(result.entries).toHaveLength(0);
-  });
+    it("processes event entries returned by model", async () => {
+      const result = await extractKnowledgeFromChunks({
+        file: "session.jsonl",
+        chunks: [
+          {
+            ...fakeChunk(),
+            text: "[m00000][user] I just started a new job.",
+          },
+        ],
+        client: fakeClient(),
+        verbose: false,
+        streamSimpleImpl: fakeStream([
+          {
+            type: "event",
+            subject: "user job change",
+            content: "User started a new senior engineering role at a new company.",
+            importance: 7,
+            expiry: "permanent",
+            tags: ["career", "work", "personal"],
+            source_context: "User mentioned new job while discussing their schedule",
+          },
+        ]),
+        sleepImpl: async () => {},
+        retryDelayMs: () => 0,
+      });
 
-  it("keeps one-time personal milestones as event entries", async () => {
-    const result = await extractKnowledgeFromChunks({
-      file: "session.jsonl",
-      chunks: [
-        {
-          ...fakeChunk(),
-          text: "[m00000][user] I just started a new job.",
-        },
-      ],
-      client: fakeClient(),
-      verbose: false,
-      streamSimpleImpl: fakeStream([
-        {
-          type: "event",
-          subject: "user job change",
-          content: "User started a new senior engineering role at a new company.",
-          importance: 7,
-          expiry: "permanent",
-          tags: ["career", "work", "personal"],
-          source_context: "User mentioned new job while discussing their schedule",
-        },
-      ]),
-      sleepImpl: async () => {},
-      retryDelayMs: () => 0,
+      expect(result.entries.length).toBeGreaterThanOrEqual(1);
+      expect(result.entries.some((entry) => entry.type === "event")).toBe(true);
     });
-
-    expect(result.entries.length).toBeGreaterThanOrEqual(1);
-    expect(result.entries.some((entry) => entry.type === "event")).toBe(true);
   });
 
   it("sets created_at from chunk timestamp when model does not provide it", async () => {


### PR DESCRIPTION
## Summary

Four areas of improvement across two prompt passes, each followed by a swarm review + fix cycle.

---

### Part A -- Extraction signal quality improvements

Improves the LLM extraction prompt to better capture personal user context without over-extracting.

**Changes:**
- **SKIP-first framing restored**: Personal facts are now expressed as a high-signal positive signal rather than an exception to the default SKIP rule. Prevents LLMs from weighting the carve-out too heavily.
- **FACT and EVENT type definitions** extended with personal fact guidance and habit-initiation boundary (prefer EVENT for newly-begun behaviors, FACT for established ones).
- **Durability gate** updated with a 6-month test heuristic: personal disclosures (health, diet, family, occupation, location) are durable by default; transient states (current mood, today's fatigue) are not.
- **Skip rule #8** extended: personal disclosures embedded in pleasantries should still be extracted.
- **Skip rule #10** added: transient personal states are not personal facts.
- **New few-shot examples**: RELATIONSHIP (family), PREFERENCE (diet with scoring rationale), FACT (morning routine), EVENT (job change).
- **Dash style normalized**: FACT and EVENT type definitions now use em-dash consistently with the rest of the types block.
- **Pipeline tests labeled correctly**: fakeStream tests wrapped in a describe block making clear they test pipeline wiring, not LLM semantic behavior.

### Part B -- Consolidate merge expiry fix

Closes #172

- Added prompt instruction to consolidate merge context: expiry must be exactly `"permanent"` or `"temporary"`, never a date, timestamp, or other value.
- The runtime fallback in `extractMergeResultFromToolCall` already existed; the prompt instruction is defense-in-depth.
- New test covering ISO timestamp expiry fallback with warning log assertion.

### Part C -- Adapter detection for .reset files

Closes #169

- Extended `detectAdapter` regex from `/\.deleted\.[^/\\]+$/` to `/\.(deleted|reset)\.[^/\\]+$/`.
- `.reset.TIMESTAMP` files (e.g. `session.jsonl.reset.2026-02-20T04-16-49.269Z`) now correctly route to the JSONL adapter instead of falling through to the text adapter.
- Tests: plain JSONL, .deleted, and .reset variants all resolve correctly; .reset with OpenClaw content routes to the openclaw adapter.

### Part D -- Ingest noise reduction

Closes #168

**Pre-fetch vector index noise:**
- New `isVectorIndexNotFoundMessage` helper detects the specific `SQLITE_ERROR: vector index(search): index not found` error thrown during bulk ingest when the vector index is intentionally absent.
- Silently suppressed (returns `[]` without calling `onVerbose`); all other pre-fetch errors still log normally.

**Whole-file ignored-params warning:**
- New `ExtractRunOnceFlags` interface and optional `onceFlags` parameter on `extractKnowledgeFromChunks`.
- `runIngestCommand` creates one `extractOnceFlags` object per run and passes it through, so the `[whole-file] interChunkDelayMs and llmConcurrency have no effect` warning fires once per ingest run instead of once per file.
- When `onceFlags` is not provided, old behavior is preserved (backward compatible).

### Part E -- Daemon install CLI path

Closes #174

- `resolveCliPath` correctly uses `argv[1]` resolved via the injected `argvFn` (which defaults to `process.argv` via `resolveDeps`).
- Removed erroneous `?? process.argv[1]` fallback that violated the existing DI pattern.
- New tests: argv[1]-populated path appears in plist; argv[1]-undefined falls back to cwd-relative path without using the hardcoded homebrew path.

---

## Testing

All changes include targeted tests. Full suite passes: `pnpm test`.

## Swarm Review

Each Codex pass was reviewed by a three-agent swarm (algo + test + quality) before the next prompt was written. Swarm findings drove follow-up fix commits on the same branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced handling of personal disclosures with improved durability detection using a 6-month test.
  * One-time warning deduplication across ingestion runs to reduce log noise.

* **Bug Fixes**
  * Improved error handling for missing vector indexes—errors are now suppressed when indexes are unavailable.
  * Extended file-path normalization to handle reset-suffixed files correctly.

* **Tests**
  * Added comprehensive test coverage for adapter registry, daemon CLI paths, merge expiry validation, and extraction pipeline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->