### PR TITLE
docs: add security notice for child_process scanner warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ tools registered directly in the agent toolset.
 openclaw plugins install agenr
 ```
 
+> **Security notice:** OpenClaw's code scanner will flag a critical warning during install: _"Shell command execution detected (child_process)."_ This is expected. agenr shells out to its own CLI binary to run recall and store operations -- it does not make any external network calls, does not read your OpenClaw credentials, and does not send data anywhere. The plugin source is open and auditable at [github.com/agenr-ai/agenr](https://github.com/agenr-ai/agenr).
+
 That's it. Memory injection happens via the plugin's `before_agent_start` hook.
 No AGENTS.md edits needed. The bundled `SKILL.md` loads automatically and
 instructs the agent when to call `agenr_store` proactively.


### PR DESCRIPTION
OpenClaw's built-in code safety scanner flags agenr as `critical` during `openclaw plugins install` because the plugin uses `child_process.spawn` to shell out to the agenr CLI binary. This is expected and intentional -- agenr uses subprocess calls to run recall/store operations against its own bundled binary, not for anything malicious.

Without this notice, first-time users see a scary critical warning and may abandon the install.

This PR adds a blockquote security notice directly below the install command in the README that:
- Names the exact warning text so users can recognize it
- Explains why it appears (subprocess to own CLI binary)
- Clarifies what agenr does NOT do (no external network calls, no credential access)
- Links to the open source repo for auditability

Follow-up: raise a feature request with OpenClaw to add a manifest field (e.g. `capabilities: ["child_process"]`) that lets legitimate plugins declare subprocess use and suppress the critical severity in favor of an informational note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security notice clarifying shell command execution behavior and security properties of the plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->