### PR TITLE
feat(session-query): blend stash and live prompt for session-start recall (#181)

### DIFF
--- a/src/openclaw-plugin/session-query.ts
+++ b/src/openclaw-plugin/session-query.ts
@@ -123,7 +123,18 @@ export function resolveSessionQuery(prompt: string | undefined, sessionKey?: str
 
   const normalized = (prompt ?? "").trim();
   if (!isThinPrompt(normalized)) {
-    return stripResetPrefix(normalized);
+    const stripped = stripResetPrefix(normalized);
+    if (!stashedText) {
+      // No stash - use live prompt as-is.
+      return stripped;
+    }
+    // Stash exists: blend when live prompt carries real signal; otherwise stash wins.
+    if (shouldStashTopic(stripped)) {
+      // High-signal live prompt: stash provides topic continuity, prompt appends new intent.
+      return `${stashedText} ${stripped}`;
+    }
+    // Low-signal live prompt (short opener like "did the plugin fire?"): stash wins.
+    return stashedText;
   }
   return stashedText;
 }


### PR DESCRIPTION
## Summary

Fixes #181.

When a user runs `/new` and then sends a short first message (the common real-world pattern), `resolveSessionQuery` was seeding the recall query with only the low-signal live prompt - ignoring the stash entirely.

The agent does not wake up until the user sends a message (hard architectural constraint), so the stash captured by `before_reset` is the only source of topic continuity across a `/new` boundary. This PR makes it count.

## Changes

**`session-query.ts` - `resolveSessionQuery`**

| Condition | Old behavior | New behavior |
|---|---|---|
| No stash, any prompt | live prompt | live prompt (unchanged) |
| Stash + high-signal live prompt | live prompt (stash discarded) | stash + " " + live prompt (blend) |
| Stash + low-signal live prompt | live prompt (stash discarded) | stash wins |
| Thin prompt + stash | stash | stash (unchanged) |

Signal threshold reuses the existing `shouldStashTopic` gate (40 chars / 5 words). Truncation is handled downstream in `recall.ts` (`RECALL_QUERY_MAX_CHARS`).

**`index.test.ts`**

- Updated 2 existing tests that had the old behavior baked in
- Added 3 new cases:
  - Low-signal live + stash = stash wins (unit)
  - High-signal live + stash = blend (unit)
  - High-signal live + stash = blend (integration, `before_prompt_build` level)

## Test Results

1025/1025 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Enhanced query resolution to better leverage cached content. The system now intelligently combines cached data with new prompts when appropriate, or defaults to cached content when new input is insufficient—improving query consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->