### PR TITLE
fix(openclaw-plugin): strip OpenClaw metadata envelope from session-start recall query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.12]
+
+### Fixed
+- fix(openclaw-plugin): strip OpenClaw metadata envelope from `before_prompt_build` prompts before session-start recall query resolution; query seeding now uses the user message after the final timestamp marker instead of prepended metadata, with last-match handling for repeated timestamp patterns
+
 ## [0.8.11]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -155,6 +155,7 @@ const plugin = {
             const rawPrompt = event.prompt;
             const userPrompt = stripPromptMetadata(rawPrompt ?? "");
             const queryText = resolveSessionQuery(userPrompt, ctx.sessionKey);
+            console.log("[agenr] session-start recall query:", JSON.stringify(queryText));
             const recallResult = await runRecall(agenrPath, budget, project, queryText);
             if (recallResult) {
               const formatted = formatRecallAsMarkdown(recallResult);

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -152,10 +152,8 @@ const plugin = {
             const agenrPath = resolveAgenrPath(config);
             const budget = resolveBudget(config);
             const project = config?.project?.trim() || undefined;
-            const rawPrompt = event.prompt;
-            const userPrompt = stripPromptMetadata(rawPrompt ?? "");
+            const userPrompt = stripPromptMetadata(event.prompt ?? "");
             const queryText = resolveSessionQuery(userPrompt, ctx.sessionKey);
-            console.log("[agenr] session-start recall query:", JSON.stringify(queryText));
             const recallResult = await runRecall(agenrPath, budget, project, queryText);
             if (recallResult) {
               const formatted = formatRecallAsMarkdown(recallResult);

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -13,6 +13,7 @@ import {
   extractLastUserText,
   resolveSessionQuery,
   SESSION_TOPIC_TTL_MS,
+  stripPromptMetadata,
   shouldStashTopic,
   stashSessionTopic,
 } from "./session-query.js";
@@ -151,7 +152,9 @@ const plugin = {
             const agenrPath = resolveAgenrPath(config);
             const budget = resolveBudget(config);
             const project = config?.project?.trim() || undefined;
-            const queryText = resolveSessionQuery(event.prompt, ctx.sessionKey);
+            const rawPrompt = event.prompt;
+            const userPrompt = stripPromptMetadata(rawPrompt ?? "");
+            const queryText = resolveSessionQuery(userPrompt, ctx.sessionKey);
             const recallResult = await runRecall(agenrPath, budget, project, queryText);
             if (recallResult) {
               const formatted = formatRecallAsMarkdown(recallResult);

--- a/src/openclaw-plugin/session-query.test.ts
+++ b/src/openclaw-plugin/session-query.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { stripPromptMetadata } from "./session-query.js";
+
+describe("stripPromptMetadata", () => {
+  it("returns just the user text for a full metadata envelope with timestamp", () => {
+    const input = `Conversation info (untrusted metadata):
+\`\`\`json
+{
+  "message_id": "08f2ed82-1111-2222-3333-444455556666",
+  "sender_id": "gateway-client",
+  "sender": "gateway-client"
+}
+\`\`\`
+
+[Sun 2026-02-22 21:08 CST] hey`;
+
+    expect(stripPromptMetadata(input)).toBe("hey");
+  });
+
+  it("returns trimmed input when there is no envelope", () => {
+    expect(stripPromptMetadata("  what should we work on next?  ")).toBe(
+      "what should we work on next?",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripPromptMetadata("")).toBe("");
+  });
+
+  it("strips at the last timestamp-like pattern", () => {
+    const input =
+      "I said [Mon 2026-01-01 09:00 CST] something\n[Tue 2026-01-02 10:00 CST] actual message";
+
+    expect(stripPromptMetadata(input)).toBe("actual message");
+  });
+
+  it("returns empty string when timestamp has no trailing content", () => {
+    expect(stripPromptMetadata("[Sun 2026-02-22 21:08 CST] ")).toBe("");
+  });
+});

--- a/src/openclaw-plugin/session-query.ts
+++ b/src/openclaw-plugin/session-query.ts
@@ -52,6 +52,31 @@ export function isThinPrompt(prompt: string): boolean {
   return trimmed === "" || trimmed === "/new" || trimmed === "/reset";
 }
 
+const OPENCLAW_PROMPT_TIMESTAMP_PATTERN = /\[\w{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2} [A-Z]{2,5}\] /g;
+
+export function stripPromptMetadata(raw: string): string {
+  if (!raw) {
+    return "";
+  }
+
+  try {
+    let lastMatchEnd = -1;
+    let match: RegExpExecArray | null = null;
+    OPENCLAW_PROMPT_TIMESTAMP_PATTERN.lastIndex = 0;
+    while ((match = OPENCLAW_PROMPT_TIMESTAMP_PATTERN.exec(raw)) !== null) {
+      lastMatchEnd = match.index + match[0].length;
+    }
+
+    if (lastMatchEnd >= 0) {
+      return raw.slice(lastMatchEnd).trim();
+    }
+
+    return raw.trim();
+  } catch {
+    return "";
+  }
+}
+
 export function extractLastUserText(messages: unknown[]): string {
   try {
     const collected: string[] = [];

--- a/src/openclaw-plugin/session-query.ts
+++ b/src/openclaw-plugin/session-query.ts
@@ -52,18 +52,18 @@ export function isThinPrompt(prompt: string): boolean {
   return trimmed === "" || trimmed === "/new" || trimmed === "/reset";
 }
 
-const OPENCLAW_PROMPT_TIMESTAMP_PATTERN = /\[\w{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2} [A-Z]{2,5}\] /g;
-
 export function stripPromptMetadata(raw: string): string {
   if (!raw) {
     return "";
   }
 
   try {
+    // Local regex (no g-flag state leak): matches OpenClaw timestamp prefixes.
+    // Covers named abbreviations (CST, AEST) and offset-style (GMT+5, GMT-10).
+    const pattern = /\[\w{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2} (?:[A-Z]{2,5}|GMT[+-]\d{1,2})\] /g;
     let lastMatchEnd = -1;
     let match: RegExpExecArray | null = null;
-    OPENCLAW_PROMPT_TIMESTAMP_PATTERN.lastIndex = 0;
-    while ((match = OPENCLAW_PROMPT_TIMESTAMP_PATTERN.exec(raw)) !== null) {
+    while ((match = pattern.exec(raw)) !== null) {
       lastMatchEnd = match.index + match[0].length;
     }
 


### PR DESCRIPTION
## Problem

`event.prompt` in `before_prompt_build` includes the full OpenClaw metadata envelope prepended to the user's actual message:

```
Conversation info (untrusted metadata):
```json
{
  "message_id": "08f2ed82-...",
  "sender_id": "gateway-client",
  "sender": "gateway-client"
}
```

[Sun 2026-02-22 21:08 CST] hey
```

This raw string was passed directly to `resolveSessionQuery` as the live prompt, so the recall query was dominated by metadata tokens (message IDs, sender IDs, numeric noise) instead of user intent. Confirmed via gateway log.

**Observed symptom:** On Telegram, EJA drifted back to already-closed issues because the vector search had no real topic signal to anchor on. See #184 for the full before/after log evidence.

## Fix

Added `stripPromptMetadata(raw: string): string` to `session-query.ts`:
- Finds the last OpenClaw timestamp pattern `[Weekday YYYY-MM-DD HH:MM TZ] `
- Returns everything after it (the actual user text)
- Falls back to trimmed input if no match
- Handles named TZ abbreviations (CST, AEST) and GMT+offset format (GMT+5, GMT-10)
- Regex is local to the function (no module-level `g`-flag state leak)

In `index.ts`, strips before calling `resolveSessionQuery`:
```ts
const userPrompt = stripPromptMetadata(event.prompt ?? "");
const queryText = resolveSessionQuery(userPrompt, ctx.sessionKey);
```

## Tests

- 5 unit tests for `stripPromptMetadata` (full envelope, no envelope, empty string, multiple timestamps, timestamp with no trailing content)
- Integration test verifying metadata envelope is stripped before stash-blend decision fires

## Closes

Fixes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.8.12

* **Bug Fixes**
  * Fixed OpenClaw plugin metadata handling in session-start recall queries. The plugin now properly processes prompts by removing metadata envelopes, ensuring recall queries use the actual user message content instead of wrapper information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->