### PR TITLE
fix(openclaw-plugin): webchat session-start recall fallback via archived reset sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [0.8.13]
+## [0.8.13] - 2026-02-23
 
 ### Fixed
-- fix(openclaw-plugin): session-start recall now falls back to reading the most recent archived OpenClaw session file (`*.reset.*`) when webchat `/new` bypasses `before_reset`; if stash-based seeding is unavailable and the opening prompt is low-signal, recall query text is built from the last 3 user messages in the archived session
+- fix(openclaw-plugin): session-start recall now falls back to reading the most recent archived OpenClaw session file (`*.reset.*`) when webchat `/new` bypasses `before_reset`. If stash-based seeding is unavailable and the opening prompt is short (< 40 characters), recall query text is built from the last 3 user messages in the archived session.
 
 ## [0.8.12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.13]
+
+### Fixed
+- fix(openclaw-plugin): session-start recall now falls back to reading the most recent archived OpenClaw session file (`*.reset.*`) when webchat `/new` bypasses `before_reset`; if stash-based seeding is unavailable and the opening prompt is low-signal, recall query text is built from the last 3 user messages in the archived session
+
 ## [0.8.12]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -13,7 +13,7 @@ import {
 import {
   clearStash,
   extractLastUserText,
-  readLatestArchivedMessages,
+  readLatestArchivedUserMessages,
   resolveSessionQuery,
   SESSION_TOPIC_MIN_LENGTH,
   SESSION_TOPIC_TTL_MS,
@@ -161,10 +161,11 @@ const plugin = {
             let recallQueryText = queryText;
 
             if (
+              isFirstInSession &&
               queryText === userPrompt &&
               userPrompt.length < SESSION_TOPIC_MIN_LENGTH
             ) {
-              const agentIdRaw = ctx["agentId"];
+              const agentIdRaw = ctx.agentId;
               const agentId = typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw : "main";
               const sessionsDir = path.join(
                 os.homedir(),
@@ -173,7 +174,7 @@ const plugin = {
                 agentId,
                 "sessions",
               );
-              const archivedMessages = await readLatestArchivedMessages(sessionsDir);
+              const archivedMessages = await readLatestArchivedUserMessages(sessionsDir);
               if (archivedMessages.length > 0) {
                 recallQueryText = archivedMessages.join(" ");
                 api.logger.info?.(
@@ -419,7 +420,7 @@ const plugin = {
 
 export const __testing = {
   SESSION_TOPIC_TTL_MS,
-  readLatestArchivedMessages,
+  readLatestArchivedUserMessages,
   clearState(): void {
     clearStash();
     seenSessions.clear();

--- a/src/openclaw-plugin/session-query.test.ts
+++ b/src/openclaw-plugin/session-query.test.ts
@@ -1,5 +1,32 @@
-import { describe, expect, it } from "vitest";
-import { stripPromptMetadata } from "./session-query.js";
+import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readLatestArchivedMessages, stripPromptMetadata } from "./session-query.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "agenr-session-query-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonlFile(
+  filePath: string,
+  entries: unknown[],
+  mtimeMs: number,
+): Promise<void> {
+  const content = entries.map((entry) => JSON.stringify(entry)).join("\n");
+  await writeFile(filePath, content, "utf8");
+  const mtime = new Date(mtimeMs);
+  await utimes(filePath, mtime, mtime);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
 
 describe("stripPromptMetadata", () => {
   it("returns just the user text for a full metadata envelope with timestamp", () => {
@@ -36,5 +63,99 @@ describe("stripPromptMetadata", () => {
 
   it("returns empty string when timestamp has no trailing content", () => {
     expect(stripPromptMetadata("[Sun 2026-02-22 21:08 CST] ")).toBe("");
+  });
+});
+
+describe("readLatestArchivedMessages", () => {
+  it("returns [] when dir does not exist", async () => {
+    const missingDir = path.join(os.tmpdir(), `agenr-missing-${Date.now()}`);
+    await expect(readLatestArchivedMessages(missingDir)).resolves.toEqual([]);
+  });
+
+  it("returns [] when no .reset.* files exist", async () => {
+    const dir = await createTempDir();
+    await writeFile(path.join(dir, "active-session.jsonl"), "", "utf8");
+
+    await expect(readLatestArchivedMessages(dir)).resolves.toEqual([]);
+  });
+
+  it("returns [] when only old .reset.* files are outside maxAgeMs", async () => {
+    const dir = await createTempDir();
+    const now = Date.now();
+    await writeJsonlFile(
+      path.join(dir, "a.jsonl.reset.2026-02-23T01:00:00.000Z"),
+      [
+        {
+          type: "message",
+          message: { role: "user", content: "keep this out due to age" },
+        },
+      ],
+      now - 10_000,
+    );
+
+    await expect(readLatestArchivedMessages(dir, 1_000)).resolves.toEqual([]);
+  });
+
+  it("returns last 3 user messages from the most recent .reset.* file", async () => {
+    const dir = await createTempDir();
+    const now = Date.now();
+
+    await writeJsonlFile(
+      path.join(dir, "older.jsonl.reset.2026-02-23T00:00:00.000Z"),
+      [
+        {
+          type: "message",
+          message: { role: "user", content: "older session text that should not be read" },
+        },
+      ],
+      now - 2_000,
+    );
+
+    await writeJsonlFile(
+      path.join(dir, "newer.jsonl.reset.2026-02-23T00:10:00.000Z"),
+      [
+        { type: "message", message: { role: "user", content: "first user message" } },
+        { type: "message", message: { role: "user", content: "second user message" } },
+        { type: "message", message: { role: "user", content: "third user message" } },
+        { type: "message", message: { role: "user", content: "fourth user message" } },
+      ],
+      now - 200,
+    );
+
+    await expect(readLatestArchivedMessages(dir, 60_000)).resolves.toEqual([
+      "second user message",
+      "third user message",
+      "fourth user message",
+    ]);
+  });
+
+  it("skips non-user messages and tool results", async () => {
+    const dir = await createTempDir();
+    const now = Date.now();
+    await writeJsonlFile(
+      path.join(dir, "mixed.jsonl.reset.2026-02-23T00:20:00.000Z"),
+      [
+        { type: "tool_result", content: "ignore tool result lines" },
+        { type: "message", message: { role: "assistant", content: "assistant text" } },
+        {
+          type: "message",
+          message: {
+            role: "user",
+            content: [
+              { type: "text", text: "first user text chunk" },
+              { type: "image", url: "ignore image parts" },
+              { type: "text", text: "second chunk" },
+            ],
+          },
+        },
+        { type: "message", message: { role: "user", content: "plain user text" } },
+      ],
+      now - 100,
+    );
+
+    await expect(readLatestArchivedMessages(dir, 60_000)).resolves.toEqual([
+      "first user text chunk second chunk",
+      "plain user text",
+    ]);
   });
 });

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -10,6 +10,7 @@ export type BeforeAgentStartEvent = {
 export type PluginHookAgentContext = {
   sessionKey?: string;
   sessionId?: string;
+  agentId?: string;
   workspaceDir?: string;
   [key: string]: unknown;
 };


### PR DESCRIPTION
## Problem

Webchat `/new` goes through the `sessions.reset` RPC handler, which does NOT fire the `before_reset` plugin hook. This means the stash is never populated for webchat new sessions, so session-start recall has no topic seed and fires a low-quality query.

Closes #186.

## Solution

When `isFirstInSession=true`, stash is empty (`queryText === userPrompt`), and the live prompt is short (< `SESSION_TOPIC_MIN_LENGTH`), read the most recent `.reset.*` archived session JSONL file and extract the last 3 user messages to augment the recall seed.

Key design decisions:
- Augments rather than replaces: `archived + " " + userPrompt` so short-but-specific queries keep their intent
- Loops through archived files in descending mtime order, skipping files with no user messages
- 24h max age window covers daily-use gaps
- Falls back gracefully to empty on any error (non-critical path)
- Respects `agentId` from ctx with fallback to `"main"`; logs when defaulting

## Changes

- `session-query.ts`: add `readLatestArchivedUserMessages()`, `ARCHIVED_SESSION_MAX_AGE_MS` constant
- `index.ts`: archive fallback block in `before_prompt_build`, agentId resolution, debug logging
- `types.ts`: add `agentId?: string` to `PluginHookAgentContext`
- Tests: 7 new tests in `session-query.test.ts` + 5 new tests in `index.test.ts` (1045 total, all passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session context recovery when initiating new conversations. The system now retrieves relevant discussion history from previous sessions and incorporates it automatically, particularly for conversations beginning with brief opening prompts. This ensures important topics and context are preserved across session restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->