### PR TITLE
chore: bump to v0.8.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump following PR #187 (webchat session-start recall fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version update (0.8.13 → 0.8.14) with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->