### PR TITLE
fix(consolidate): use pipe separator in GROUP_CONCAT to prevent tag corruption

### DIFF
--- a/docs/CONSOLIDATION.md
+++ b/docs/CONSOLIDATION.md
@@ -73,6 +73,8 @@ Sources:
 - cross-type same-subject threshold: `0.89` (`CROSS_TYPE_SUBJECT_THRESHOLD`)
 - minimum cluster size: `2` (`DEFAULT_MIN_CLUSTER`)
 - max entries per validated cluster: `12` (`DEFAULT_MAX_CLUSTER_SIZE`)
+- Tag separator: tags are joined with `|` (pipe) in `GROUP_CONCAT` and split on `|` in the
+  result mapper. Pipe is used instead of comma because tag values may contain commas.
 - Additional idempotency guard:
 - skips recently consolidated merged entries for `7` days by default (`DEFAULT_IDEMPOTENCY_DAYS`)
 

--- a/src/consolidate/cluster.ts
+++ b/src/consolidate/cluster.ts
@@ -90,7 +90,7 @@ function mapActiveEmbeddedEntry(row: Record<string, InValue | undefined>): Activ
   const projectRaw = toStringValue(row.project);
   const project = projectRaw.trim().length > 0 ? projectRaw.trim().toLowerCase() : null;
   const tagsRaw = toStringValue(row.tags_csv);
-  const tags = tagsRaw.length > 0 ? tagsRaw.split(",").map((tag) => tag.trim()).filter(Boolean) : [];
+  const tags = tagsRaw.length > 0 ? tagsRaw.split("|").map((tag) => tag.trim()).filter(Boolean) : [];
 
   return {
     id,
@@ -156,7 +156,7 @@ export async function buildClusters(db: Client, options: ClusterOptions = {}): P
       e.merged_from,
       e.consolidated_at,
       (
-        SELECT GROUP_CONCAT(t.tag, ',')
+        SELECT GROUP_CONCAT(t.tag, '|')
         FROM tags t
         WHERE t.entry_id = e.id
       ) AS tags_csv

--- a/tests/consolidate/cluster.test.ts
+++ b/tests/consolidate/cluster.test.ts
@@ -1,0 +1,106 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildClusters } from "../../src/consolidate/cluster.js";
+import { initDb } from "../../src/db/client.js";
+import { hashText, insertEntry } from "../../src/db/store.js";
+import type { KnowledgeEntry } from "../../src/types.js";
+
+function vectorFromAngle(degrees: number): number[] {
+  const radians = (degrees * Math.PI) / 180;
+  const head = [Math.cos(radians), Math.sin(radians), 0];
+  return [...head, ...Array.from({ length: 1021 }, () => 0)];
+}
+
+function makeEntry(subject: string, content: string, tags: string[]): KnowledgeEntry {
+  return {
+    type: "fact",
+    subject,
+    content,
+    importance: 6,
+    expiry: "permanent",
+    tags,
+    source: {
+      file: "cluster.test.jsonl",
+      context: "cluster test",
+    },
+  };
+}
+
+describe("consolidate cluster tag mapping", () => {
+  const clients: Client[] = [];
+
+  afterEach(() => {
+    while (clients.length > 0) {
+      clients.pop()?.close();
+    }
+  });
+
+  async function makeDb(): Promise<Client> {
+    const client = createClient({ url: ":memory:" });
+    clients.push(client);
+    await initDb(client);
+    return client;
+  }
+
+  async function seed(params: { db: Client; subject: string; content: string; tags: string[]; angle: number }): Promise<string> {
+    return insertEntry(
+      params.db,
+      makeEntry(params.subject, params.content, params.tags),
+      vectorFromAngle(params.angle),
+      hashText(`${params.subject}:${params.content}:${params.angle}`),
+    );
+  }
+
+  it("preserves tag arrays when buildClusters maps grouped tags", async () => {
+    const db = await makeDb();
+    const idA = await seed({
+      db,
+      subject: "Tag Roundtrip",
+      content: "entry-a",
+      tags: ["alpha", "beta release"],
+      angle: 0,
+    });
+    const idB = await seed({
+      db,
+      subject: "Tag Roundtrip",
+      content: "entry-b",
+      tags: ["modeling", "nlp"],
+      angle: 8,
+    });
+
+    const clusters = await buildClusters(db, { minCluster: 2 });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]?.entries).toHaveLength(2);
+
+    const tagsById = new Map(clusters[0]?.entries.map((entry) => [entry.id, [...(entry.tags ?? [])].sort()]));
+    expect(tagsById.get(idA)).toEqual(["alpha", "beta release"]);
+    expect(tagsById.get(idB)).toEqual(["modeling", "nlp"]);
+  });
+
+  it("keeps comma-containing tags as a single token in buildClusters", async () => {
+    const db = await makeDb();
+    const commaTagEntryId = await seed({
+      db,
+      subject: "Comma Tag Regression",
+      content: "entry-with-comma-tag",
+      tags: ["machine learning, nlp", "retrieval"],
+      angle: 0,
+    });
+    await seed({
+      db,
+      subject: "Comma Tag Regression",
+      content: "entry-peer",
+      tags: ["baseline"],
+      angle: 8,
+    });
+
+    const clusters = await buildClusters(db, { minCluster: 2 });
+    expect(clusters).toHaveLength(1);
+
+    const commaTagEntry = clusters[0]?.entries.find((entry) => entry.id === commaTagEntryId);
+    expect(commaTagEntry).toBeTruthy();
+    expect(commaTagEntry?.tags).toContain("machine learning, nlp");
+    expect(commaTagEntry?.tags).not.toContain("machine learning");
+    expect(commaTagEntry?.tags).not.toContain("nlp");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #155.

`buildClusters` in `src/consolidate/cluster.ts` used a comma as the GROUP_CONCAT separator when fetching tags. Tags with commas (e.g. `machine learning, nlp`) would silently split into corrupt tokens on the round-trip.

## Changes

- `src/consolidate/cluster.ts`: change GROUP_CONCAT separator from `,` to `|`, and split on `|` in the result mapper
- `tests/consolidate/cluster.test.ts`: new test file with roundtrip test and comma-in-tag regression test
- `docs/CONSOLIDATION.md`: document the pipe separator choice and the reason for it

## Test Results

91 test files, 1047 tests, all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed tag parsing in clustering operations to properly handle tags containing commas.

* **Documentation**
  * Added documentation describing tag separator behavior used in clustering and result mapping.

* **Tests**
  * Added comprehensive test suite for tag mapping and clustering functionality, including validation of tags with embedded commas and tag array preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->