### PR TITLE
fix(consolidate): add merge coverage + keeper importance floor and created_at inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## [0.8.15] - 2026-02-23
 
 ### Fixed
+- fix(consolidate): switch GROUP_CONCAT separator from comma to pipe in buildClusters to prevent silent tag corruption when tag values contain commas (issue #155)
 - fix(consolidate): Tier 1 near-exact duplicate merge now preserves the highest importance across merged entries by raising the keeper's `importance` floor to the group max (issue #156)
 - fix(consolidate): Tier 1 near-exact duplicate merge now preserves oldest provenance by inheriting the oldest `created_at` across the merge group into the keeper (issue #156)
+- test(consolidate): new cluster.test.ts with pipe-separator roundtrip and comma-in-tag regression coverage (issue #155)
 - test(consolidate): added merge coverage for tag union transfer, keeper importance floor, and keeper `created_at` inheritance in rules consolidation tests (issue #156)
 
 ## [0.8.13] - 2026-02-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.15] - 2026-02-23
+
+### Fixed
+- fix(consolidate): Tier 1 near-exact duplicate merge now preserves the highest importance across merged entries by raising the keeper's `importance` floor to the group max (issue #156)
+- fix(consolidate): Tier 1 near-exact duplicate merge now preserves oldest provenance by inheriting the oldest `created_at` across the merge group into the keeper (issue #156)
+- test(consolidate): added merge coverage for tag union transfer, keeper importance floor, and keeper `created_at` inheritance in rules consolidation tests (issue #156)
+
 ## [0.8.13] - 2026-02-23
 
 ### Fixed

--- a/docs/CONSOLIDATION.md
+++ b/docs/CONSOLIDATION.md
@@ -53,6 +53,9 @@ Source:
 - max cluster size `12`
 - diameter floor `0.93` (`0.95 - 0.02`)
 - Keeper selection prefers higher `confirmations + recall_count`, then newer `created_at`.
+- After merge, keeper importance is raised to the max importance across all merged entries.
+- After merge, keeper `created_at` is set to the oldest `created_at` across all merged entries.
+- Tags from all source entries are merged into the keeper via `INSERT OR IGNORE` (union, no duplicates).
 
 ### 3) Orphaned relations cleanup
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
## Summary

Fixes #156. Combines with #155 (already in master) as v0.8.15.

Two behaviors were missing from `mergeNearExactDuplicates` in `src/consolidate/rules.ts`:
- Keeper importance was never updated after merge -- a low-importance keeper could shadow a high-importance source
- Keeper `created_at` was never updated -- oldest provenance was lost after merge

## Changes

- `src/consolidate/rules.ts`: add `importance` to SELECT + mapper; compute `maxImportance` and `oldestCreatedAt` across the merge group; apply both via defensive CASE WHEN guards in the final keeper UPDATE
- `tests/consolidate/rules.test.ts`: 3 new tests -- tag union, importance floor, created_at inheritance
- `CHANGELOG.md`: v0.8.15 entry consolidating both #155 and #156 fixes
- `docs/CONSOLIDATION.md`: document all three merge behaviors
- `package.json`: bump to 0.8.15

## Test Results

91 test files, 1050 tests, all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.8.15

* **Bug Fixes**
  * Fixed tag data loss when consolidating duplicate entries containing commas.
  * Improved data preservation during consolidation to maintain highest importance levels.
  * Ensured original creation dates are preserved when merging duplicate entries.

* **Tests**
  * Added comprehensive test coverage for data consolidation behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->