### PR TITLE
feat(recall): temporal browse mode (closes #190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.8.16] - 2026-02-23
+
+### Added
+- feat(recall): new temporal browse mode for recall via `agenr recall --browse` and MCP `agenr_recall` with `context="browse"` (issue #190)
+- docs(recall): added `docs/usage/recall.md` with browse-mode CLI and MCP usage examples
+
+### Changed
+- recall browse mode now uses a SQL-only path that requires no query and performs zero embedding/OpenAI API calls
+- browse mode does not increment recall metadata (`recall_count`, `last_recalled_at`, `recall_intervals`)
+- OpenClaw plugin tool wiring now maps `context="browse"` to the CLI `--browse` flag (and omits query/context positional args appropriately)
+
+### Tests
+- test(recall): added browse-mode coverage in DB recall, CLI command recall, MCP server recall, and OpenClaw plugin recall tool argument wiring
+
 ## [0.8.15] - 2026-02-23
 
 ### Fixed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -169,6 +169,7 @@ agenr recall [options] [query]
 - `--db <path>`: database path override.
 - `--budget <tokens>`: approximate token budget cap.
 - `--context <mode>`: `default|session-start|topic:<query>`.
+- `--browse`: SQL-only temporal browse mode (importance/date ordering, no semantic search, no query required).
 - `--scope <level>`: `private|personal|public`.
 - `--no-boost`: use raw vector similarity only.
 - `--no-update`: do not increment recall metadata.
@@ -884,6 +885,15 @@ The `--context` flag changes how recall behaves:
   When used with `--budget`, allocates tokens across categories dynamically via `computeBudgetSplit()` based on category counts: active receives ~10-30%, preferences ~20-40%, and the remainder goes to recent (with a minimum 20% floor for recent), with overflow redistribution.
 
 - **`topic:<query>`**: Prepends `[topic: <query>]` to the search text before embedding, biasing results toward that topic. Useful for scoping recall to a specific area (e.g., `--context topic:authentication`).
+
+### `--browse` mode
+
+The `--browse` flag activates a SQL-only temporal browse path:
+
+- No query string is required.
+- Results are sorted by importance and date (with deterministic recency-decay scoring).
+- Zero embedding/OpenAI API calls are made.
+- Recall metadata is not incremented in browse mode.
 
 ### `--budget` behavior
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -115,8 +115,11 @@ Source of truth:
 Retrieve relevant memories using semantic search.
 
 Parameters:
-- `query` (string, optional): search text. Required when context is `default` (or omitted). Not needed for `session-start` context.
-- `context` (string, optional, default `default`): Use `session-start` for fast bootstrap without embedding call (no `query` needed). Other value: `default`.
+- `query` (string, optional): search text. Required when context is `default` (or omitted). Not needed for `session-start` or `browse`.
+- `context` (string, optional, default `default`):
+  - `default`: semantic search (requires `query`)
+  - `session-start`: fast bootstrap without embedding call (no `query` needed)
+  - `browse`: temporal browse mode sorted by importance/date (no `query`, zero embedding/API calls)
 - `limit` (integer, optional, default `10`): max results
 - `types` (string, optional): comma-separated entry types
 - `since` (string, optional): ISO date or relative (`7d`, `24h`, `1m`, `1y`)
@@ -151,6 +154,19 @@ Session-start recall (no query needed):
   "name": "agenr_recall",
   "arguments": {
     "context": "session-start",
+    "limit": 20
+  }
+}
+```
+
+Browse recall (no query needed):
+
+```json
+{
+  "name": "agenr_recall",
+  "arguments": {
+    "context": "browse",
+    "since": "1d",
     "limit": 20
   }
 }

--- a/docs/usage/recall.md
+++ b/docs/usage/recall.md
@@ -1,0 +1,46 @@
+# Recall Usage
+
+## Browse Mode
+
+Use browse mode when you want a timeline view of stored memory by importance and date instead of semantic similarity.
+
+- Enable with `--browse`
+- Query text is optional and ignored in browse mode
+- Browse mode uses a SQL-only path with zero OpenAI API calls
+
+### CLI examples
+
+Browse entries from the last day:
+
+```bash
+agenr recall --browse --since 1d
+```
+
+Browse entries inside a date window:
+
+```bash
+agenr recall --browse --since 14d --until 2026-02-09T00:00:00.000Z
+```
+
+Browse recent entries with default limits:
+
+```bash
+agenr recall --browse
+```
+
+### MCP example
+
+Use `context="browse"` and an optional time filter:
+
+```json
+{
+  "name": "agenr_recall",
+  "arguments": {
+    "context": "browse",
+    "since": "1d",
+    "limit": 20
+  }
+}
+```
+
+In browse mode, no query string is required and no embedding/API call is made.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -515,6 +515,7 @@ export function createProgram(): Command {
     .option("--budget <tokens>", "Approximate token budget", parseIntOption)
     .option("--context <mode>", "Context mode: default|session-start|topic:<query>", "default")
     .option("--scope <level>", "Visibility scope: private|personal|public", "private")
+    .option("--browse", "Skip semantic search and return entries sorted by importance and date", false)
     .option("--no-boost", "Disable scoring boosts and use raw vector similarity", false)
     .option("--no-update", "Do not increment recall metadata", false)
     .action(async (query: string | undefined, opts: Record<string, unknown>) => {
@@ -535,6 +536,7 @@ export function createProgram(): Command {
         budget: opts.budget as number | undefined,
         context: opts.context as string | undefined,
         scope: opts.scope as string | undefined,
+        browse: opts.browse === true,
         noBoost: opts.noBoost === true,
         noUpdate: opts.noUpdate === true,
       });

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -664,6 +664,10 @@ async function fetchBrowseCandidates(
         suppressed_contexts
       FROM entries
       ${whereClause}
+      -- SQL pre-sort is a best-effort approximation only.
+      -- Final order is determined by scoreBrowseEntry() (importance * recency decay)
+      -- which re-sorts post-fetch. The over-fetch buffer (limit*3, min 50)
+      -- ensures the final top-N are present in the candidate pool.
       ORDER BY importance DESC, created_at DESC
       LIMIT ?
     `,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -825,7 +825,7 @@ export function createMcpServer(
 
     const query = typeof args.query === "string" ? args.query.trim() : "";
     if (!query && context === "default") {
-      throw new RpcError(JSON_RPC_INVALID_PARAMS, "query is required unless context is session-start");
+      throw new RpcError(JSON_RPC_INVALID_PARAMS, "query is required unless context is session-start or browse");
     }
 
     const limit = parsePositiveInt(args.limit, 10, "limit");
@@ -899,6 +899,7 @@ export function createMcpServer(
           platform: platform ?? undefined,
           project,
           projectStrict: projectStrict ? true : undefined,
+          scope: "private",
           noUpdate: true,
         },
         "",

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -281,6 +281,32 @@ describe("openclaw plugin tool runners", () => {
     expect(capturedArgs[limitIdx + 1]).toBe("0");
   });
 
+  it("runRecallTool passes --browse and omits query text for context=browse", async () => {
+    let capturedArgs: string[] = [];
+    spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      return createMockChild({ stdout: JSON.stringify({ query: "[browse]", results: [] }) });
+    });
+
+    await runRecallTool("/path/to/agenr", { context: "browse", query: "ignored text" });
+
+    expect(capturedArgs).toContain("--browse");
+    expect(capturedArgs).not.toContain("ignored text");
+  });
+
+  it("runRecallTool does not pass --context browse to CLI", async () => {
+    let capturedArgs: string[] = [];
+    spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      return createMockChild({ stdout: JSON.stringify({ query: "[browse]", results: [] }) });
+    });
+
+    await runRecallTool("/path/to/agenr", { context: "browse" });
+
+    expect(capturedArgs).not.toContain("--context");
+    expect(capturedArgs).toContain("--browse");
+  });
+
   it("runRecallTool uses default project when params.project is omitted", async () => {
     let capturedArgs: string[] = [];
     spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -285,8 +285,11 @@ const plugin = {
             query: Type.Optional(Type.String({ description: "What to search for." })),
             context: Type.Optional(
               Type.Union(
-                [Type.Literal("default"), Type.Literal("session-start")],
-                { description: "Use session-start for fast bootstrap without embedding." },
+                [Type.Literal("default"), Type.Literal("session-start"), Type.Literal("browse")],
+                {
+                  description:
+                    "Use session-start for fast bootstrap without embedding. Use browse for temporal browsing (date+importance, no query needed, no semantic search).",
+                },
               ),
             ),
             limit: Type.Optional(Type.Number({ description: "Max results (default: 10)." })),

--- a/src/openclaw-plugin/tools.ts
+++ b/src/openclaw-plugin/tools.ts
@@ -156,6 +156,7 @@ export async function runRecallTool(
   const args = ["recall", "--json"];
   const query = asString(params.query);
   const context = asString(params.context);
+  const isBrowse = context === "browse";
   const limit = asNumber(params.limit);
   const types = asString(params.types);
   const since = asString(params.since);
@@ -163,10 +164,12 @@ export async function runRecallTool(
   const platform = asString(params.platform);
   const project = asString(params.project) || defaultProject;
 
-  if (query) {
+  if (isBrowse) {
+    args.push("--browse");
+  } else if (query) {
     args.push(query);
   }
-  if (context) {
+  if (context && !isBrowse) {
     args.push("--context", context);
   }
   if (limit !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,7 @@ export interface RecallQuery {
   project?: string | string[];
   excludeProject?: string | string[];
   projectStrict?: boolean;
+  browse?: boolean;
 }
 
 export interface RecallCommandResult extends RecallResult {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -683,7 +683,7 @@ describe("mcp server", () => {
       id: 32,
       error: {
         code: -32602,
-        message: "query is required unless context is session-start",
+        message: "query is required unless context is session-start or browse",
       },
     });
   });
@@ -737,7 +737,8 @@ describe("mcp server", () => {
     );
 
     const result = responses[0]?.result as { content?: Array<{ text?: string }> };
-    expect(result.content?.[0]?.text).toMatch(/browse mode|Found 0 entries/);
+    expect(result.content?.[0]?.text).toContain("browse mode");
+    expect(result.content?.[0]?.text).toMatch(/Found \d+ entries/);
   });
 
   it("passes since filter through context=browse recall", async () => {
@@ -845,7 +846,7 @@ describe("mcp server", () => {
       id: 3305,
       error: {
         code: -32602,
-        message: "query is required unless context is session-start",
+        message: "query is required unless context is session-start or browse",
       },
     });
   });


### PR DESCRIPTION
## Summary

Implements temporal browse mode for `agenr recall`. Browse mode skips vector search entirely, returns entries sorted by importance + date proximity, and makes zero OpenAI API calls.

## What's new

- `--browse` flag on the CLI: `agenr recall --browse --since 1d`
- `context="browse"` on the MCP/plugin tool interface
- `fetchBrowseCandidates()`: pure SQL path, no vector index touched
- `scoreBrowseEntry()`: importance * exponential recency decay (30-day half-life)
- Browse mode never updates `recall_count` or `last_recalled_at` (orientation, not targeted recall)
- New `browse?: boolean` field on `RecallQuery`
- `docs/usage/recall.md` with CLI + MCP examples

## Why

Every existing recall query requires a topic string embedded via OpenAI. When the caller doesn't know the topic - "what did we work on today?" - they have to guess, and wrong guesses silently miss entries. Browse mode flips the model: pull everything from a time window sorted by importance, let the agent reason over it.

## Acceptance criteria

- [x] `agenr recall --browse --since 1d` returns all entries from last 24h sorted by importance, no query required, no embed call
- [x] `agenr recall --browse --since 3w` returns entries from ~3 weeks ago, no topic required
- [x] Zero OpenAI API calls in browse mode (embed spy test in suite)
- [x] Available via CLI (`--browse`) and MCP (`context="browse"`)
- [x] Single browse call reconstructs a complete day's timeline without keyword misses
- [x] 1078 tests passing (up from 1045 on master, +33 total including 14 browse-specific DB tests)

## Related

Closes #190
Unblocks #177 (session-start cold-start - agents can now use `context="browse", since="1d"` instead of topic-guessing)
Complementary to #189 (soft recency bias for hybrid topic+time queries)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.8.16

* **New Features**
  * Added temporal browse mode for the recall command. Browse entries by date and importance without requiring a query; zero API calls made in this mode.

* **Documentation**
  * Added comprehensive recall usage documentation with CLI and MCP examples for the new browse mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->