### PR TITLE
chore: bump to v0.8.17 (rebuild dist with browse mode CLI flag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.17] - 2026-02-23
+
+### Changed
+- chore: rebuild dist to include browse mode CLI flag inadvertently omitted from 0.8.16 publish
+
 ## [0.8.16] - 2026-02-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
## Summary

Rebuilds dist and bumps to v0.8.17.

The v0.8.16 publish went out with a stale dist - `pnpm build` was not run after the browse mode commits landed (PRs #190/#195). As a result, `agenr recall --browse` was missing from the CLI even though the source and tests were correct.

No source changes. Just rebuild + version bump.

## Changes
- `pnpm build` to regenerate dist/ with browse mode included
- `package.json` bumped to 0.8.17
- `CHANGELOG.md` entry for 0.8.17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the browse mode CLI flag that was unavailable in version 0.8.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->