### PR TITLE
feat(openclaw-plugin): browse cold-start recall + session handoff auto-retire (Closes #196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.19] - 2026-02-23
+
+### Changed
+- feat(openclaw-plugin): `before_reset` handoff store content now uses a structured recent exchange summary (`U:`/`A:` turns) instead of user-only fragments, improving cross-session handoff clarity while keeping stash-based recall seeding unchanged (issue #196)
+- feat(openclaw-plugin): added `extractLastExchangeText(messages, maxTurns?)` in `src/openclaw-plugin/session-query.ts` to collect the last 5 user-turn windows with interleaved assistant context, per-turn truncation (200 chars), and chronological `U:`/`A:` formatting
+- chore(openclaw-plugin): exported `SESSION_QUERY_LOOKBACK` from `session-query.ts` for direct test assertions
+
+### Tests
+- test(openclaw-plugin): added `extractLastExchangeText` coverage for empty input, U/A formatting, per-message truncation, 5-user-turn collection window, and no-extractable-content behavior
+- test(openclaw-plugin): updated handoff-store integration assertion to verify stored content includes exchange context prefixes (`U:`/`A:`) rather than flattened user-only text
+
 ## [0.8.18] - 2026-02-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.8.18] - 2026-02-23
+
+### Changed
+- feat(openclaw-plugin): `before_prompt_build` now uses browse-mode recall (`--browse --since 1d`) for cold session starts where no stash/query seed is available, and keeps embed/query recall for substantive or stash-seeded starts (issue #196)
+- chore(openclaw-plugin): removed archived-session fallback query synthesis from session-start recall seeding, simplifying thin-prompt startup behavior to browse vs stash/embed paths only (issue #196)
+- feat(openclaw-plugin): `before_reset` now stores a fire-and-forget `event` memory entry (`session handoff ...`) with the latest user context to support next-session handoff continuity (issue #196)
+- feat(openclaw-plugin): session-start browse results now auto-retire surfaced handoff entries after context injection to avoid repeated carryover (`reason: consumed at session start`) (issue #196)
+- feat(openclaw-plugin): `runRecall` in `src/openclaw-plugin/recall.ts` now accepts an optional context options object and maps browse context to CLI browse args while preserving existing default/session-start call behavior for unchanged callers (issue #196)
+
+### Tests
+- test(openclaw-plugin): updated query-seeding coverage for new cold-start browse path and removed archive-fallback-specific expectations (issue #196)
+- test(openclaw-plugin): added regression coverage for before-reset handoff storage and session-start handoff auto-retire success, non-handoff skip, missing-id skip, and retire-failure resilience (issue #196)
+- test(openclaw-plugin): added plugin recall browse-args unit coverage to assert `runRecall` browse flag construction and query omission behavior (issue #196)
+
 ## [0.8.17] - 2026-02-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -827,7 +827,7 @@ describe("before_prompt_build query seeding", () => {
       { context: "browse", since: "1d" },
     );
     expect(debugLogger).toHaveBeenCalledWith(
-      "[agenr] session-start: agentId not provided, defaulting to 'main'",
+      "[agenr] cold-start: agentId not in ctx, defaulting to 'main'",
     );
   });
 

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -266,8 +266,9 @@ const plugin = {
         }
 
         const handoffText = extractLastExchangeText(messages);
-        if (handoffText.length > 0) {
+        if (handoffText) {
           const agenrPath = resolveAgenrPath(config);
+          const defaultProject = config?.project?.trim() || undefined;
           const timestamp = new Date().toISOString().slice(0, 16).replace("T", " ");
           const handoffEntry = {
             entries: [
@@ -284,7 +285,7 @@ const plugin = {
             ...(config as Record<string, unknown> | undefined),
             logger: api.logger,
           };
-          runStoreTool(agenrPath, handoffEntry, storeConfig).catch((err) => {
+          runStoreTool(agenrPath, handoffEntry, storeConfig, defaultProject).catch((err) => {
             api.logger.debug?.(
               `[agenr] before_reset: handoff store failed: ${err instanceof Error ? err.message : String(err)}`,
             );

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./recall.js";
 import {
   clearStash,
+  extractLastExchangeText,
   extractLastUserText,
   resolveSessionQuery,
   SESSION_TOPIC_TTL_MS,
@@ -264,7 +265,8 @@ const plugin = {
           stashSessionTopic(sessionKey, lastUserText);
         }
 
-        if (lastUserText && lastUserText.length > 0) {
+        const handoffText = extractLastExchangeText(messages);
+        if (handoffText.length > 0) {
           const agenrPath = resolveAgenrPath(config);
           const timestamp = new Date().toISOString().slice(0, 16).replace("T", " ");
           const handoffEntry = {
@@ -273,7 +275,7 @@ const plugin = {
                 type: "event",
                 importance: 10,
                 subject: `session handoff ${timestamp}`,
-                content: lastUserText,
+                content: handoffText,
                 tags: ["handoff", "session"],
               },
             ],

--- a/src/openclaw-plugin/recall.test.ts
+++ b/src/openclaw-plugin/recall.test.ts
@@ -99,3 +99,32 @@ describe("runRecall query args", () => {
     expect(positionalQuery).toBe("x".repeat(500));
   });
 });
+
+describe("runRecall browse mode args", () => {
+  it("uses browse flags and omits budget/context/query by default", async () => {
+    let capturedArgs: string[] = [];
+    spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      return createMockChild(JSON.stringify({ query: "[browse]", results: [] }));
+    });
+
+    await runRecall("/path/to/agenr", 1234, undefined, "ignored query", { context: "browse" });
+
+    expect(capturedArgs).toEqual(["recall", "--browse", "--since", "1d", "--json"]);
+  });
+
+  it("uses explicit browse since and keeps --project while omitting query", async () => {
+    let capturedArgs: string[] = [];
+    spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      return createMockChild(JSON.stringify({ query: "[browse]", results: [] }));
+    });
+
+    await runRecall("/path/to/agenr", 1234, "proj-x", "ignored query", {
+      context: "browse",
+      since: "7d",
+    });
+
+    expect(capturedArgs).toEqual(["recall", "--browse", "--since", "7d", "--json", "--project", "proj-x"]);
+  });
+});

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -27,6 +27,11 @@ export type RecallResult = {
   }>;
 };
 
+export type RunRecallOptions = {
+  context?: "session-start" | "browse";
+  since?: string;
+};
+
 export function resolveAgenrPath(config?: AgenrPluginConfig): string {
   return config?.agenrPath?.trim() || process.env["AGENR_BIN"]?.trim() || DEFAULT_AGENR_PATH;
 }
@@ -48,7 +53,7 @@ export async function runRecall(
   budget: number,
   project?: string,
   query?: string,
-  options?: { context?: "session-start" | "browse"; since?: string },
+  options?: RunRecallOptions,
 ): Promise<RecallResult | null> {
   return await new Promise((resolve) => {
     let stdout = "";


### PR DESCRIPTION
## Summary

Closes #196.

Replaces the fragile archive-file fallback with browse-mode recall for cold-start sessions, and adds session handoff entry creation/auto-retire for continuity across `/new`.

## Changes

### `src/openclaw-plugin/recall.ts`
- Added `RunRecallOptions` exported type (`context`, `since`)
- `runRecall` accepts optional 5th param; browse mode uses `--browse --since \<since\>`, omits `--budget` and query arg

### `src/openclaw-plugin/index.ts`
- **before_prompt_build**: thin-prompt cold-start (`resolveSessionQuery` returns `undefined`) now uses browse mode instead of archive file fallback; archive fallback removed
- **before_prompt_build**: after browse, auto-retires any surfaced entries whose subject starts with `session handoff` - seen once, then gone
- **before_reset**: fire-and-forget `runStoreTool` stores a type=event imp=10 handoff entry capturing last session activity; hook stays `void`
- `config` moved to outer `register()` scope; removed shadowed inner declaration
- `agentId` debug log scoped to cold-start path with corrected message text
- Debug logging added to silent `.catch()` on both retire and store

## Test Coverage
- 1083 tests passing (up from 1045 pre-#196)
- 38 new tests covering: browse cold-start path, substantive-prompt embed path, handoff store, handoff auto-retire, non-handoff entries not retired, retire failure silent, missing entry id skipped
- Archive fallback tests removed (path deleted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cold-start recall now uses browse-mode retrieval when session seed is missing.
  * Handoff storage saves a structured recent exchange summary (U:/A: turns) and a lightweight event entry to aid next-session continuity.
  * Consumed handoff entries are auto-retired at session start to avoid carryover.
  * Recall API accepts an explicit browse-mode invocation for browse-only queries.

* **Tests**
  * Expanded coverage for cold-start browse flow, handoff storage/retire behavior, exchange-summary extraction, and recall argument construction.

* **Chores**
  * Version bumped to 0.8.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->