### PR TITLE
chore: bump to v0.8.20 (rebuild dist with browse cold-start + handoff)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Rebuilds dist and bumps version to 0.8.20.

## What's in this release (unpublished since 0.8.19)

- `feat(openclaw-plugin)`: browse cold-start recall + handoff auto-retire (#196)
- `chore(openclaw-plugin)`: address issue 196 review findings
- `feat(openclaw-plugin)`: enrich before-reset handoff exchange context
- `fix(openclaw-plugin)`: scope handoff store to configured project

The dist was not rebuilt before the 0.8.19 publish, so these changes never shipped. This PR rebuilds from current source and bumps the patch version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.8.20

<!-- end of auto-generated comment: release notes by coderabbit.ai -->