### PR TITLE
fix: isThinPrompt detects OpenClaw bare-reset boilerplate (fixes #201)

### DIFF
--- a/src/openclaw-plugin/session-query.ts
+++ b/src/openclaw-plugin/session-query.ts
@@ -90,9 +90,18 @@ function truncateMessageText(text: string): string {
   return text.length > EXCHANGE_TEXT_MAX_CHARS ? text.slice(0, EXCHANGE_TEXT_MAX_CHARS) : text;
 }
 
+// Prefix of OpenClaw BARE_SESSION_RESET_PROMPT injected as event.prompt on bare /new or
+// /reset. Matched by prefix only to stay resilient to minor wording changes in OpenClaw.
+const OPENCLAW_BARE_RESET_PREFIX = "a new session was started via /new";
+
 export function isThinPrompt(prompt: string): boolean {
   const trimmed = prompt.trim().toLowerCase();
-  return trimmed === "" || trimmed === "/new" || trimmed === "/reset";
+  return (
+    trimmed === "" ||
+    trimmed === "/new" ||
+    trimmed === "/reset" ||
+    trimmed.startsWith(OPENCLAW_BARE_RESET_PREFIX)
+  );
 }
 
 export function stripPromptMetadata(raw: string): string {


### PR DESCRIPTION
## Summary

Fixes #201.

When a user sends a bare `/new` with no message, OpenClaw substitutes its internal `BARE_SESSION_RESET_PROMPT` boilerplate as `event.prompt`:

> "A new session was started via /new or /reset. Greet the user in your configured persona..."

`isThinPrompt` only checked for `""`, `"/new"`, and `"/reset"`, so the boilerplate triggered semantic recall against meaningless internal text instead of the browse cold-start path. This broke session-start recall on every bare `/new` in webchat.

## Changes

- Added `OPENCLAW_BARE_RESET_PREFIX` constant in `session-query.ts`
- Updated `isThinPrompt` to return `true` when the prompt starts with the bare-reset prefix (case-insensitive, prefix-only match for resilience to wording changes)
- Added `describe("isThinPrompt")` block with 9 test cases
- Added `describe("resolveSessionQuery - bare reset prompt")` block with 2 test cases including stash isolation via `beforeEach`/`afterAll`

## Tests

1100 passing (up from 1045).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for session query utilities, including reset prompt detection and state management scenarios

* **Improvements**
  * Enhanced reset prompt recognition to handle additional input variations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->