### PR TITLE
chore: bump to v0.8.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump for #201 fix - isThinPrompt bare-reset boilerplate detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.8.21

<!-- end of auto-generated comment: release notes by coderabbit.ai -->