### PR TITLE
feat(openclaw-plugin): three-phase cross-session context injection (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.8.22] - 2026-02-23
+
+### Changed
+- feat(openclaw-plugin): replace thin-prompt/stash session-start recall with three-phase
+  cross-session context injection (issue #205)
+  - Phase 1A (always): reads last 7 user+assistant turns from most recently modified
+    session JSONL file in ~/.openclaw/agents/<agentId>/sessions/
+  - Phase 1B (always): runs agenr recall --browse --since 1d --limit 20, picks up
+    importance:10 handoff entry written at /new time
+  - Phase 2 (conditional): semantic recall seeded from Phase 1A turns + first user
+    message if >= 5 words; results deduplicated against Phase 1B by entry id
+  - Handoff entries retired after first use (one-time read)
+- feat(openclaw-plugin): added findPreviousSessionFile, extractRecentTurns,
+  buildSemanticSeed to src/openclaw-plugin/session-query.ts
+- feat(openclaw-plugin): findPreviousSessionFile uses parallel stat() calls for
+  performance on large sessions dirs
+- feat(openclaw-plugin): sessionsDir configurable via AgenrPluginConfig.sessionsDir;
+  defaults to ~/.openclaw/agents/<agentId>/sessions using ctx.agentId with "main"
+  fallback
+- feat(openclaw-plugin): RunRecallOptions extended with limit?: number to support
+  --limit flag in browse recall
+- refactor(openclaw-plugin): removed isThinPrompt, resolveSessionQuery,
+  sessionTopicStash, stashSessionTopic, shouldStashTopic, sweepInterval, clearStash,
+  readLatestArchivedUserMessages
+
+### Tests
+- test(openclaw-plugin): added unit tests for findPreviousSessionFile, extractRecentTurns,
+  buildSemanticSeed in session-query.test.ts
+- test(openclaw-plugin): added integration tests for three-phase before_prompt_build flow,
+  Phase 2 deduplication, and isFirstInSession guard in index.test.ts
+- test(openclaw-plugin): added second-message guard test (isFirstInSession prevents
+  re-injection on subsequent messages in same session)
+
 ## [0.8.19] - 2026-02-23
 
 ### Changed

--- a/docs/OPENCLAW.md
+++ b/docs/OPENCLAW.md
@@ -60,30 +60,16 @@ That's the wiring. Now the important part.
 
 ## Session-Start Recall
 
-When a new session begins, agenr automatically seeds recall with a query so that
-relevant memory surfaces before the first response. The query source depends on
-how the session started:
+On the first message of each new session, agenr injects three context blocks:
 
-**Normal session (daily reset or gateway restart):**
-The user's first message is used directly as the recall query. Entries relevant
-to what the user actually asked rank higher than generic recency-based results.
+- Recent session: last 7 turns from the previous session (any surface - Telegram,
+  webchat, Codex)
+- Recent memory: top 20 importance-ranked entries from the last 24 hours
+  (includes the session handoff entry written at /new time)
+- Relevant memory: semantic recall seeded from previous session context plus the
+  first user message (if >= 5 words)
 
-**After /new (no topic):**
-When the user sends /new alone, the opening prompt is low-signal. agenr captures
-the last few substantive user messages from the ending session before it resets
-and uses that content as the recall seed for the new session. This means recall
-surfaces what you were working on -- not just whatever was most recently stored.
-
-A message is only eligible for stashing if the combined recent content is at least
-40 characters and 5 words. Short conversational closers ("thanks", "sounds good",
-"see you on the other side") are filtered out.
-
-**After /new with a topic (e.g., /new let's pick up the migration work):**
-The topic portion is used as the recall query directly. The stash from the
-ending session is consumed and discarded.
-
-**Cold boot (no prior session):**
-Recall falls back to recency-based ranking with no query.
+This fires unconditionally - short messages like "hey" still get full context injection.
 
 ## Seed Your Agent's Memory
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -400,8 +400,8 @@ describe("before_prompt_build cross-session context injection", () => {
     expect(result?.prependContext).toContain("## Recent memory");
   });
 
-  it("does not inject recall on second message in the same session", async () => {
-    vi.spyOn(pluginRecall, "runRecall").mockResolvedValue({
+  it("second message in same session does not inject context again", async () => {
+    const runRecallMock = vi.spyOn(pluginRecall, "runRecall").mockResolvedValue({
       query: "[browse]",
       results: [
         {
@@ -415,6 +415,7 @@ describe("before_prompt_build cross-session context injection", () => {
         },
       ],
     });
+    const findPreviousSessionFileMock = vi.spyOn(sessionQuery, "findPreviousSessionFile");
     const api = makeApi({ pluginConfig: { signalsEnabled: false } });
     plugin.register(api);
     const handler = getBeforePromptBuildHandler(api);
@@ -430,6 +431,8 @@ describe("before_prompt_build cross-session context injection", () => {
 
     expect(first?.prependContext).toContain("## Recent memory");
     expect(second).toBeUndefined();
+    expect(runRecallMock).toHaveBeenCalledTimes(1);
+    expect(findPreviousSessionFileMock).toHaveBeenCalledTimes(1);
   });
 
   it("Phase 2 deduplicates entries already present in Phase 1B by id", async () => {

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -158,7 +158,7 @@ const plugin = {
               config?.sessionsDir ?? path.join(os.homedir(), `.openclaw/agents/${agentId}/sessions`);
 
             const [previousTurns, browseResult] = await Promise.all([
-              findPreviousSessionFile(sessionsDir, ctx.sessionId).then((file) =>
+              findPreviousSessionFile(sessionsDir, ctx.sessionId, api.logger).then((file) =>
                 file ? extractRecentTurns(file) : Promise.resolve(""),
               ),
               runRecall(agenrPath, budget, project, undefined, {

--- a/src/openclaw-plugin/recall.test.ts
+++ b/src/openclaw-plugin/recall.test.ts
@@ -127,4 +127,19 @@ describe("runRecall browse mode args", () => {
 
     expect(capturedArgs).toEqual(["recall", "--browse", "--since", "7d", "--json", "--project", "proj-x"]);
   });
+
+  it("passes --limit when browse limit is provided", async () => {
+    let capturedArgs: string[] = [];
+    spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      return createMockChild(JSON.stringify({ query: "[browse]", results: [] }));
+    });
+
+    await runRecall("/path/to/agenr", 1234, undefined, undefined, {
+      context: "browse",
+      limit: 20,
+    });
+
+    expect(capturedArgs).toEqual(["recall", "--browse", "--since", "1d", "--json", "--limit", "20"]);
+  });
 });

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -30,6 +30,7 @@ export type RecallResult = {
 export type RunRecallOptions = {
   context?: "session-start" | "browse";
   since?: string;
+  limit?: number;
 };
 
 export function resolveAgenrPath(config?: AgenrPluginConfig): string {
@@ -72,6 +73,9 @@ export async function runRecall(
     const args = isBrowse
       ? ["recall", "--browse", "--since", options?.since ?? "1d", "--json"]
       : ["recall", "--context", "session-start", "--budget", String(budget), "--json"];
+    if (isBrowse && options?.limit) {
+      args.push("--limit", String(options.limit));
+    }
     if (project) {
       args.push("--project", project);
     }

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -73,7 +73,7 @@ export async function runRecall(
     const args = isBrowse
       ? ["recall", "--browse", "--since", options?.since ?? "1d", "--json"]
       : ["recall", "--context", "session-start", "--budget", String(budget), "--json"];
-    if (isBrowse && options?.limit) {
+    if (isBrowse && options?.limit !== undefined) {
       args.push("--limit", String(options.limit));
     }
     if (project) {

--- a/src/openclaw-plugin/session-query.test.ts
+++ b/src/openclaw-plugin/session-query.test.ts
@@ -1,15 +1,12 @@
 import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
-  clearStash,
+  buildSemanticSeed,
   extractLastExchangeText,
-  isThinPrompt,
-  readLatestArchivedUserMessages,
-  resolveSessionQuery,
-  SESSION_QUERY_LOOKBACK,
-  stashSessionTopic,
+  extractRecentTurns,
+  findPreviousSessionFile,
   stripPromptMetadata,
 } from "./session-query.js";
 
@@ -24,12 +21,14 @@ async function createTempDir(): Promise<string> {
 async function writeJsonlFile(
   filePath: string,
   entries: unknown[],
-  mtimeMs: number,
+  mtimeMs?: number,
 ): Promise<void> {
   const content = entries.map((entry) => JSON.stringify(entry)).join("\n");
   await writeFile(filePath, content, "utf8");
-  const mtime = new Date(mtimeMs);
-  await utimes(filePath, mtime, mtime);
+  if (typeof mtimeMs === "number") {
+    const mtime = new Date(mtimeMs);
+    await utimes(filePath, mtime, mtime);
+  }
 }
 
 afterEach(async () => {
@@ -58,98 +57,9 @@ describe("stripPromptMetadata", () => {
       "what should we work on next?",
     );
   });
-
-  it("returns empty string for empty input", () => {
-    expect(stripPromptMetadata("")).toBe("");
-  });
-
-  it("strips at the last timestamp-like pattern", () => {
-    const input =
-      "I said [Mon 2026-01-01 09:00 CST] something\n[Tue 2026-01-02 10:00 CST] actual message";
-
-    expect(stripPromptMetadata(input)).toBe("actual message");
-  });
-
-  it("returns empty string when timestamp has no trailing content", () => {
-    expect(stripPromptMetadata("[Sun 2026-02-22 21:08 CST] ")).toBe("");
-  });
-});
-
-describe("isThinPrompt", () => {
-  it("returns true for empty string", () => {
-    expect(isThinPrompt("")).toBe(true);
-  });
-
-  it("returns true for /new", () => {
-    expect(isThinPrompt("/new")).toBe(true);
-  });
-
-  it("returns true for /reset", () => {
-    expect(isThinPrompt("/reset")).toBe(true);
-  });
-
-  it("returns true for full OpenClaw bare-reset boilerplate", () => {
-    const prompt =
-      "A new session was started via /new or /reset. Greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
-
-    expect(isThinPrompt(prompt)).toBe(true);
-  });
-
-  it("returns true for bare-reset prefix only", () => {
-    expect(isThinPrompt("A new session was started via /new")).toBe(true);
-  });
-
-  it("returns true for uppercase bare-reset text", () => {
-    expect(isThinPrompt("A NEW SESSION WAS STARTED VIA /NEW OR /RESET")).toBe(true);
-  });
-
-  it("returns false for a real user message", () => {
-    expect(isThinPrompt("what should we work on today?")).toBe(false);
-  });
-
-  it("returns false for /new with real content", () => {
-    expect(isThinPrompt("/new let's keep working on agenr")).toBe(false);
-  });
-
-  it("returns false for another real user message", () => {
-    expect(isThinPrompt("deploy the agenr plugin")).toBe(false);
-  });
-});
-
-describe("resolveSessionQuery - bare reset prompt", () => {
-  const BARE_RESET_PROMPT =
-    "A new session was started via /new or /reset. Greet the user in your configured " +
-    "persona, if one is provided. Be yourself - use your defined voice, mannerisms, and " +
-    "mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model " +
-    "differs from default_model in the system prompt, mention the default model. Do not " +
-    "mention internal steps, files, tools, or reasoning.";
-
-  beforeEach(() => {
-    clearStash();
-  });
-
-  afterAll(() => {
-    clearStash();
-  });
-
-  it("returns undefined when bare-reset prompt has no stash", () => {
-    expect(resolveSessionQuery(BARE_RESET_PROMPT)).toBeUndefined();
-  });
-
-  it("returns stash text when bare-reset prompt has stash", () => {
-    const key = "agent:main:tui";
-    const stashText = "working on agenr session recall improvements for bare new sessions";
-    stashSessionTopic(key, stashText);
-
-    expect(resolveSessionQuery(BARE_RESET_PROMPT, key)).toBe(stashText);
-  });
 });
 
 describe("extractLastExchangeText", () => {
-  it("returns empty string for empty messages array", () => {
-    expect(extractLastExchangeText([])).toBe("");
-  });
-
   it("formats last user and assistant turns with U:/A: prefixes", () => {
     const result = extractLastExchangeText([
       { role: "user", content: "hello" },
@@ -168,196 +78,200 @@ describe("extractLastExchangeText", () => {
     expect(result).toBe(expected);
     expect(result).not.toContain("x".repeat(201));
   });
+});
 
-  it("collects up to 5 user turns worth of context", () => {
-    const result = extractLastExchangeText([
-      { role: "user", content: "u1" },
-      { role: "assistant", content: "a1" },
-      { role: "user", content: "u2" },
-      { role: "assistant", content: "a2" },
-      { role: "user", content: "u3" },
-      { role: "assistant", content: "a3" },
-      { role: "user", content: "u4" },
-      { role: "assistant", content: "a4" },
-      { role: "user", content: "u5" },
-      { role: "assistant", content: "a5" },
-      { role: "user", content: "u6" },
-    ]);
+describe("findPreviousSessionFile", () => {
+  it("returns most recent *.jsonl file by mtime (not deleted, not current session)", async () => {
+    const dir = await createTempDir();
+    const now = Date.now();
+    await writeJsonlFile(path.join(dir, "older.jsonl"), [], now - 10_000);
+    await writeJsonlFile(path.join(dir, "latest.reset.jsonl"), [], now - 100);
 
-    expect(result).toBe("U: u2 | A: a2 | U: u3 | A: a3 | U: u4 | A: a4 | U: u5 | A: a5 | U: u6");
+    await expect(findPreviousSessionFile(dir, "current-session-id")).resolves.toBe(
+      path.join(dir, "latest.reset.jsonl"),
+    );
   });
 
-  it("returns empty string when no extractable text exists", () => {
-    const result = extractLastExchangeText([
-      { role: "user", content: [{ type: "image", source: "img" }] },
-      { role: "assistant", content: [{ type: "tool_result", text: "ignored" }] },
-      { role: "assistant", content: null },
-    ]);
+  it("skips files containing .deleted. in name", async () => {
+    const dir = await createTempDir();
+    const now = Date.now();
+    await writeJsonlFile(path.join(dir, "new.deleted.session.jsonl"), [], now - 10);
+    await writeJsonlFile(path.join(dir, "active.jsonl"), [], now - 100);
 
-    expect(result).toBe("");
+    await expect(findPreviousSessionFile(dir, "current-session-id")).resolves.toBe(
+      path.join(dir, "active.jsonl"),
+    );
+  });
+
+  it("skips file whose name equals currentSessionId + .jsonl", async () => {
+    const dir = await createTempDir();
+    const now = Date.now();
+    await writeJsonlFile(path.join(dir, "current-session.jsonl"), [], now - 10);
+    await writeJsonlFile(path.join(dir, "previous-session.jsonl"), [], now - 100);
+
+    await expect(findPreviousSessionFile(dir, "current-session")).resolves.toBe(
+      path.join(dir, "previous-session.jsonl"),
+    );
+  });
+
+  it("returns null when directory is empty", async () => {
+    const dir = await createTempDir();
+    await expect(findPreviousSessionFile(dir, "current")).resolves.toBeNull();
+  });
+
+  it("returns null when only deleted files exist", async () => {
+    const dir = await createTempDir();
+    await writeJsonlFile(path.join(dir, "one.deleted.two.jsonl"), []);
+
+    await expect(findPreviousSessionFile(dir, "current")).resolves.toBeNull();
+  });
+
+  it("returns null when only current session file exists", async () => {
+    const dir = await createTempDir();
+    await writeJsonlFile(path.join(dir, "current.jsonl"), []);
+
+    await expect(findPreviousSessionFile(dir, "current")).resolves.toBeNull();
+  });
+
+  it("does not skip current-like file when currentSessionId is undefined", async () => {
+    const dir = await createTempDir();
+    const now = Date.now();
+    await writeJsonlFile(path.join(dir, "current.jsonl"), [], now - 10);
+    await writeJsonlFile(path.join(dir, "older.jsonl"), [], now - 1000);
+
+    await expect(findPreviousSessionFile(dir, undefined)).resolves.toBe(
+      path.join(dir, "current.jsonl"),
+    );
   });
 });
 
-describe("readLatestArchivedUserMessages", () => {
-  it("returns [] when dir does not exist", async () => {
-    const missingDir = path.join(os.tmpdir(), `agenr-missing-${Date.now()}`);
-    await expect(readLatestArchivedUserMessages(missingDir)).resolves.toEqual([]);
+describe("extractRecentTurns", () => {
+  it("returns last 7 turns formatted as U: text | A: text", async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, "session.jsonl");
+    const entries = [
+      { type: "message", message: { role: "user", content: "u1" } },
+      { type: "message", message: { role: "assistant", content: "a1" } },
+      { type: "message", message: { role: "user", content: "u2" } },
+      { type: "message", message: { role: "assistant", content: "a2" } },
+      { type: "message", message: { role: "user", content: "u3" } },
+      { type: "message", message: { role: "assistant", content: "a3" } },
+      { type: "message", message: { role: "user", content: "u4" } },
+      { type: "message", message: { role: "assistant", content: "a4" } },
+    ];
+    await writeJsonlFile(filePath, entries);
+
+    await expect(extractRecentTurns(filePath)).resolves.toBe(
+      "A: a1 | U: u2 | A: a2 | U: u3 | A: a3 | U: u4 | A: a4",
+    );
   });
 
-  it("returns [] when no .reset.* files exist", async () => {
+  it("truncates each turn to 150 chars", async () => {
     const dir = await createTempDir();
-    await writeFile(path.join(dir, "active-session.jsonl"), "", "utf8");
-
-    await expect(readLatestArchivedUserMessages(dir)).resolves.toEqual([]);
-  });
-
-  it("returns [] when only old .reset.* files are outside maxAgeMs", async () => {
-    const dir = await createTempDir();
-    const now = Date.now();
-    await writeJsonlFile(
-      path.join(dir, "a.jsonl.reset.2026-02-23T01:00:00.000Z"),
-      [
-        {
-          type: "message",
-          message: { role: "user", content: "keep this out due to age" },
-        },
-      ],
-      now - 10_000,
-    );
-
-    await expect(readLatestArchivedUserMessages(dir, 1_000)).resolves.toEqual([]);
-  });
-
-  it("returns last 3 user messages from the most recent .reset.* file", async () => {
-    const dir = await createTempDir();
-    const now = Date.now();
-
-    await writeJsonlFile(
-      path.join(dir, "older.jsonl.reset.2026-02-23T00:00:00.000Z"),
-      [
-        {
-          type: "message",
-          message: { role: "user", content: "older session text that should not be read" },
-        },
-      ],
-      now - 2_000,
-    );
-
-    await writeJsonlFile(
-      path.join(dir, "newer.jsonl.reset.2026-02-23T00:10:00.000Z"),
-      [
-        { type: "message", message: { role: "user", content: "first user message" } },
-        { type: "message", message: { role: "user", content: "second user message" } },
-        { type: "message", message: { role: "user", content: "third user message" } },
-        { type: "message", message: { role: "user", content: "fourth user message" } },
-      ],
-      now - 200,
-    );
-
-    const result = await readLatestArchivedUserMessages(dir, 60_000);
-    expect(result).toEqual(["second user message", "third user message", "fourth user message"]);
-    expect(result).toHaveLength(SESSION_QUERY_LOOKBACK);
-  });
-
-  it("skips non-user messages and tool results", async () => {
-    const dir = await createTempDir();
-    const now = Date.now();
-    await writeJsonlFile(
-      path.join(dir, "mixed.jsonl.reset.2026-02-23T00:20:00.000Z"),
-      [
-        { type: "tool_result", content: "ignore tool result lines" },
-        { type: "message", message: { role: "assistant", content: "assistant text" } },
-        {
-          type: "message",
-          message: {
-            role: "user",
-            content: [
-              { type: "text", text: "first user text chunk" },
-              { type: "image", url: "ignore image parts" },
-              { type: "text", text: "second chunk" },
-            ],
-          },
-        },
-        { type: "message", message: { role: "user", content: "plain user text" } },
-      ],
-      now - 100,
-    );
-
-    await expect(readLatestArchivedUserMessages(dir, 60_000)).resolves.toEqual([
-      "first user text chunk second chunk",
-      "plain user text",
+    const filePath = path.join(dir, "session.jsonl");
+    const longText = "x".repeat(200);
+    await writeJsonlFile(filePath, [
+      { type: "message", message: { role: "user", content: longText } },
     ]);
+
+    const result = await extractRecentTurns(filePath);
+    expect(result).toBe(`U: ${"x".repeat(150)}`);
   });
 
-  it("returns [] when newest archived file has no user messages", async () => {
+  it("skips non-message JSONL records", async () => {
     const dir = await createTempDir();
-    const now = Date.now();
-    await writeJsonlFile(
-      path.join(dir, "no-user.jsonl.reset.2026-02-23T00:25:00.000Z"),
-      [
-        { type: "tool_result", content: "tool output" },
-        { type: "message", message: { role: "assistant", content: "assistant-only content" } },
-      ],
-      now - 100,
-    );
-
-    await expect(readLatestArchivedUserMessages(dir, 60_000)).resolves.toEqual([]);
-  });
-
-  it("falls back to second-most-recent file when newest has no user messages", async () => {
-    const dir = await createTempDir();
-    const now = Date.now();
-
-    await writeJsonlFile(
-      path.join(dir, "older-with-user.jsonl.reset.2026-02-23T00:20:00.000Z"),
-      [
-        { type: "message", message: { role: "user", content: "older user one" } },
-        { type: "message", message: { role: "user", content: "older user two" } },
-      ],
-      now - 2_000,
-    );
-
-    await writeJsonlFile(
-      path.join(dir, "newer-no-user.jsonl.reset.2026-02-23T00:30:00.000Z"),
-      [
-        { type: "tool_result", content: "tool output only" },
-        { type: "message", message: { role: "assistant", content: "assistant only" } },
-      ],
-      now - 100,
-    );
-
-    await expect(readLatestArchivedUserMessages(dir, 60_000)).resolves.toEqual([
-      "older user one",
-      "older user two",
+    const filePath = path.join(dir, "session.jsonl");
+    await writeJsonlFile(filePath, [
+      { type: "event", detail: "ignored" },
+      { type: "message", message: { role: "user", content: "kept" } },
     ]);
+
+    await expect(extractRecentTurns(filePath)).resolves.toBe("U: kept");
   });
 
-  it("skips malformed json lines and keeps valid user messages", async () => {
+  it("returns empty string when file not found", async () => {
     const dir = await createTempDir();
-    const now = Date.now();
-    const filePath = path.join(dir, "mixed-valid-malformed.jsonl.reset.2026-02-23T00:30:00.000Z");
-    const raw = [
-      JSON.stringify({
-        type: "message",
-        message: { role: "user", content: "first valid user message" },
-      }),
-      "{ this is not valid json",
-      JSON.stringify({
-        type: "message",
-        message: { role: "assistant", content: "assistant message to ignore" },
-      }),
-      JSON.stringify({
-        type: "message",
-        message: { role: "user", content: "second valid user message" },
-      }),
-    ].join("\n");
-    await writeFile(filePath, raw, "utf8");
-    const mtime = new Date(now - 50);
-    await utimes(filePath, mtime, mtime);
+    const filePath = path.join(dir, "missing.jsonl");
 
-    await expect(readLatestArchivedUserMessages(dir, 60_000)).resolves.toEqual([
-      "first valid user message",
-      "second valid user message",
+    await expect(extractRecentTurns(filePath)).resolves.toBe("");
+  });
+
+  it("returns empty string for empty file", async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, "empty.jsonl");
+    await writeFile(filePath, "", "utf8");
+
+    await expect(extractRecentTurns(filePath)).resolves.toBe("");
+  });
+
+  it("skips assistant turns with empty text (tool-only turns)", async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, "session.jsonl");
+    await writeJsonlFile(filePath, [
+      { type: "message", message: { role: "user", content: "keep this" } },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", name: "search" }],
+        },
+      },
+      { type: "message", message: { role: "assistant", content: "assistant text" } },
     ]);
+
+    await expect(extractRecentTurns(filePath)).resolves.toBe("U: keep this | A: assistant text");
+  });
+});
+
+describe("buildSemanticSeed", () => {
+  it("returns previous turns plus message when message has >= 5 words", () => {
+    const result = buildSemanticSeed("U: previous context", "fix the session recall bug now");
+    expect(result).toBe("U: previous context fix the session recall bug now");
+  });
+
+  it("returns previous turns only when message has < 5 words", () => {
+    const result = buildSemanticSeed("U: previous context", "hey");
+    expect(result).toBe("U: previous context");
+
+    expect(buildSemanticSeed("U: previous context", "fix it")).toBe("U: previous context");
+    expect(buildSemanticSeed("U: previous context", "on the other side")).toBe("U: previous context");
+  });
+
+  it("returns combined seed when message has exactly 5 words", () => {
+    const result = buildSemanticSeed("U: previous context", "fix the session recall bug");
+    expect(result).toBe("U: previous context fix the session recall bug");
+  });
+
+  it("returns previous turns only when message has exactly 4 words", () => {
+    const result = buildSemanticSeed("U: previous context", "how does recall work");
+    expect(result).toBe("U: previous context");
+  });
+
+  it("returns message only when previous turns are empty and message has >= 5 words", () => {
+    const result = buildSemanticSeed("", "fix the session recall bug");
+    expect(result).toBe("fix the session recall bug");
+  });
+
+  it("returns undefined when previous turns are empty and message has < 5 words", () => {
+    expect(buildSemanticSeed("", "hey")).toBeUndefined();
+    expect(buildSemanticSeed("", "fix it")).toBeUndefined();
+    expect(buildSemanticSeed("", "how does recall work")).toBeUndefined();
+  });
+
+  it("returns previous turns when message is missing", () => {
+    const result = buildSemanticSeed("U: previous context", "");
+    expect(result).toBe("U: previous context");
+  });
+
+  it("returns truncated previous turns when message is missing", () => {
+    const previousTurns = "x".repeat(450);
+    const result = buildSemanticSeed(previousTurns, "");
+    expect(result).toBe("x".repeat(400));
+  });
+
+  it("truncates previous turns to 400 chars in seed", () => {
+    const previousTurns = "x".repeat(450);
+    const result = buildSemanticSeed(previousTurns, "hello");
+    expect(result).toBe("x".repeat(400));
   });
 });

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -98,6 +98,8 @@ export type PluginApi = {
 export type AgenrPluginConfig = {
   /** Path to agenr CLI entry point (dist/cli.js). Defaults to AGENR_BIN env or bundled dist/cli.js */
   agenrPath?: string;
+  /** Path to OpenClaw sessions directory. Defaults to ~/.openclaw/agents/<agentId>/sessions */
+  sessionsDir?: string;
   /** Token budget for recall (default: 2000) */
   budget?: number;
   /** Active project scope. When set, recall and store calls are scoped to this project. */


### PR DESCRIPTION
## Summary

Closes #205

Replaces the fragile thin-prompt/stash session-start recall architecture with a reliable three-phase design. After 5 previous attempts (metadata stripping, archive fallback, stash blending, bare-reset patch), this redesign eliminates the root cause: conditional recall gating based on prompt signal quality.

## The Flow

### On `/new` (before_reset)
- Writes an importance:10 `session handoff` entry to agenr DB via `extractLastExchangeText`
- Removes old stash logic (`extractLastUserText`, `stashSessionTopic`)

### On first message of new session (before_prompt_build)

**Phase 1A (always):** Finds most recently modified session file in `~/.openclaw/agents/<agentId>/sessions/`, skips `.deleted.` files and the current session file. Extracts last 7 user+assistant turns via `extractRecentTurns`. Injects as `## Recent session` block.

**Phase 1B (always):** Runs `agenr recall --browse --since 1d --limit 20`. The importance:10 handoff entry from before_reset floats to the top. Injects as `## Recent memory` block. Runs in parallel with Phase 1A via `Promise.all`.

**Phase 2 (conditional):** Builds semantic seed from Phase 1A turns (first 400 chars) + first user message if >= 5 words. Deduplicates results against Phase 1B by entry id. Injects as `## Relevant memory` block.

**Handoff auto-retire:** After Phase 1B, retires any `session handoff` entries found in browse results. One-time read - won't clutter future sessions.

## What's Removed
- `isThinPrompt` - gone entirely
- `resolveSessionQuery` - replaced by `buildSemanticSeed`
- `sessionTopicStash` + `stashSessionTopic` + TTL sweep - gone
- `readLatestArchivedUserMessages` - replaced by `findPreviousSessionFile` + `extractRecentTurns`
- `shouldStashTopic` - gone
- Stash lines from `before_reset` - gone

## What's Added
- `findPreviousSessionFile(sessionsDir, currentSessionId, logger)` - finds most recent prior session JSONL by mtime, parallel stat calls, debug logs on dir failure
- `extractRecentTurns(filePath, maxTurns)` - reads last N turns from JSONL, correctly passes `record.message` to extract functions
- `buildSemanticSeed(previousTurns, firstUserMessage)` - >= 5 word threshold replaces fragile greeting list
- `RunRecallOptions.limit` - supports `--limit` flag for browse recall
- `AgenrPluginConfig.sessionsDir` - configurable sessions dir path

## Why This Time Is Different

Every prior attempt tried to decide at runtime whether the first message was "good enough" to use as a recall seed. This approach removes that decision entirely - Phase 1 always fires regardless of what the user says. "hey" and "fix the recall bug" both get the same Phase 1 treatment. Phase 2 is purely additive.

See #205 for full design documentation including the complete flow, token budget breakdown, and history of previous attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three-phase cross-session context injection on first message of a session.
  * Configurable sessions directory.
  * Handoff auto-retire via CLI and browse recall --limit support.

* **Improvements**
  * Entry deduplication across recall sources and refined multi-phase semantic recall.
  * Prependable "Recent session", "Recent memory", and "Relevant memory" sections with session-cap/cooldown guards; one-time per-session injection.

* **Tests**
  * Expanded unit and integration tests covering recall flows, deduplication, retire behavior, and limit propagation.

* **Chores**
  * Documentation and version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->