### PR TITLE
chore: bump to v0.8.23 (rebuild dist with #205 three-phase flow)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
The 0.8.22 publish was made without running `pnpm build` first, so the tarball contained stale dist (old isThinPrompt/sessionTopicStash code). This bumps to 0.8.23 with a clean build - new three-phase flow (findPreviousSessionFile, extractRecentTurns, buildSemanticSeed) is now in dist.