### PR TITLE
chore(release): prepare 0.8.25 - fix extractRecentTurns (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.8.23] - 2026-02-23
+## [0.8.25] - 2026-02-23
 
 ### Changed
 - fix(openclaw-plugin): strip OpenClaw conversation metadata JSON blocks from

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.23",
+  "version": "0.8.25",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump and CHANGELOG update for v0.8.25. Published to npm. Closes the release for #208 fixes.