### PR TITLE
fix(openclaw-plugin): add 0.8.27 before_reset debug probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.8.27] - 2026-02-24
+
+### Changed
+- Add stderr debug probes to openclaw plugin to diagnose before_reset hook dispatch issue
+- Probes: register() entry, hook registrations, session_start handler, before_reset handler entry and guard points
+
 ## [0.8.26] - 2026-02-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -76,15 +76,20 @@ function createTimeoutChild(): MockChildProcess {
 }
 
 function makeApi(overrides?: Partial<PluginApi>): PluginApi {
+  const logger = {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    ...(overrides?.logger ?? {}),
+  };
+  const { logger: _ignoredLogger, ...restOverrides } = overrides ?? {};
   return {
     id: "agenr",
     name: "agenr memory context",
-    logger: {
-      warn: vi.fn(),
-      error: vi.fn(),
-    },
+    logger,
     on: vi.fn() as unknown as PluginApi["on"],
-    ...overrides,
+    ...restOverrides,
   };
 }
 


### PR DESCRIPTION
Debug instrumentation for issue #213.

Adds 7 `process.stderr.write` probes to diagnose why `before_reset` hook is not firing:

1. `register()` entry - confirms plugin init with pluginId
2. After `before_prompt_build` registration - confirms that api.on() completes
3. After `before_reset` registration - confirms THIS api.on() completes  
4. `session_start` handler - if this fires on /new but before_reset doesn't, OpenClaw isn't dispatching that event
5. `before_reset` handler entry - sessionKey + message count
6. After sessionKey guard - confirms it passed
7. After messages guard - confirms it passed

No logic changes. Probes only.

Closes #213 (once root cause identified and fixed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.8.27
  * Enhanced openclaw plugin with diagnostic logging to aid in troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->