### PR TITLE
fix(openclaw-plugin): fix session_start cast and logger type errors in 0.8.27 probes

### DIFF
--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -843,7 +843,7 @@ const plugin = {
     );
     process.stderr.write(`[AGENR-PROBE] before_prompt_build hook registered\n`);
 
-    api.on("session_start", async (_event: unknown, ctx: PluginHookAgentContext): Promise<void> => {
+    (api as unknown as { on: (hook: string, handler: (event: unknown, ctx: PluginHookAgentContext) => Promise<void>) => void }).on("session_start", async (_event: unknown, ctx: PluginHookAgentContext): Promise<void> => {
       process.stderr.write(
         `[AGENR-PROBE] session_start FIRED sessionKey=${(ctx as { sessionKey?: string }).sessionKey ?? "none"}\n`,
       );
@@ -854,9 +854,7 @@ const plugin = {
         process.stderr.write(
           `[AGENR-PROBE] before_reset FIRED sessionKey=${ctx.sessionKey ?? "none"} msgs=${Array.isArray(event.messages) ? event.messages.length : "non-array"}\n`,
         );
-        api.logger.info(
-          `[agenr] before_reset: fired sessionKey=${ctx.sessionKey ?? "none"} agentId=${ctx.agentId ?? "none"} msgs=${Array.isArray(event.messages) ? event.messages.length : "non-array"} sessionFile=${event.sessionFile ?? "none"}`,
-        );
+        api.logger.info?.(`[agenr] before_reset: fired sessionKey=${ctx.sessionKey ?? "none"} agentId=${ctx.agentId ?? "none"} msgs=${Array.isArray(event.messages) ? event.messages.length : "non-array"} sessionFile=${event.sessionFile ?? "none"}`);
         const sessionKey = ctx.sessionKey;
         if (!sessionKey) {
           return;


### PR DESCRIPTION
Fixes two TS compile errors introduced in #214:
- Cast `api.on` properly for `session_start` (not in SDK overloads)
- Use optional chaining on `api.logger.info` in probe

No logic changes. Build and 1102 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session reset robustness with improved error handling to prevent potential crashes during logging operations.

* **Refactor**
  * Refined type safety in hook registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->