### PR TITLE
fix(openclaw-plugin): use command hook as before_reset proxy for RPC-triggered /new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.8.28] - 2026-02-23
+
+### Fixed
+- command hook fires before_reset handoff logic for RPC-triggered /new (closes #210)
+  - before_reset hook only fires in the in-process auto-reply path; sessions.reset RPC
+    path only fires the command hook
+  - new command hook handler reads and parses the session JSONL directly, then runs
+    the same Phase 1 fallback store + Phase 2 LLM upgrade logic
+  - dedup guard (Set<sessionId>) prevents double-writes when both hooks fire in
+    auto-reply path
+
+### Added
+- [AGENR-PROBE] debug logging throughout command hook path for observability
+  (to be removed in a future cleanup pass)
+- readAndParseSessionJsonl() helper to parse JSONL session files line by line
+- runHandoffForSession() shared helper extracted from before_reset for reuse
+
+### Tests
+- 5 new tests for command hook handoff behavior in index.test.ts
+
 ## [0.8.27] - 2026-02-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.8.28] - 2026-02-23
+## [0.8.28] - 2026-02-24
 
 ### Fixed
 - command hook fires before_reset handoff logic for RPC-triggered /new (closes #210)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -755,7 +755,7 @@ async function runHandoffForSession(opts: {
   }
 
   if (!opts.sessionFile) {
-    opts.logger?.debug?.("[agenr] before_reset: no sessionFile in event, using fallback");
+    opts.logger?.debug?.(`[agenr] ${opts.source}: no sessionFile in event, using fallback`);
   }
 
   // Phase 1: store fallback immediately so the next session can always read it.
@@ -777,10 +777,10 @@ async function runHandoffForSession(opts: {
     };
     try {
       await runStoreTool(opts.agenrPath, fallbackEntry, opts.storeConfig, opts.defaultProject);
-      opts.logger?.debug?.("[agenr] before_reset: fallback handoff stored");
+      opts.logger?.debug?.(`[agenr] ${opts.source}: fallback handoff stored`);
     } catch (err) {
       opts.logger?.debug?.(
-        `[agenr] before_reset: fallback store failed: ${err instanceof Error ? err.message : String(err)}`,
+        `[agenr] ${opts.source}: fallback store failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       fallbackEntrySubject = null;
     }
@@ -832,16 +832,16 @@ async function runHandoffForSession(opts: {
 
         try {
           await runStoreTool(opts.agenrPath, llmEntry, opts.storeConfig, opts.defaultProject);
-          opts.logger?.debug?.("[agenr] before_reset: LLM handoff stored");
+          opts.logger?.debug?.(`[agenr] ${opts.source}: LLM handoff stored`);
         } catch (err) {
           opts.logger?.debug?.(
-            `[agenr] before_reset: LLM handoff store failed: ${err instanceof Error ? err.message : String(err)}`,
+            `[agenr] ${opts.source}: LLM handoff store failed: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
       })
       .catch((err) => {
         opts.logger?.debug?.(
-          `[agenr] before_reset: LLM handoff rejected: ${err instanceof Error ? err.message : String(err)}`,
+          `[agenr] ${opts.source}: LLM handoff rejected: ${err instanceof Error ? err.message : String(err)}`,
         );
       });
   }
@@ -1152,7 +1152,7 @@ const plugin = {
             return;
           }
 
-          const agentId = ctx.agentId?.trim() || sessionKey.split(":")[0] || "main";
+          const agentId = ctx.agentId?.trim() || "main";
           const sessionsDir =
             config?.sessionsDir ?? path.join(os.homedir(), `.openclaw/agents/${agentId}/sessions`);
           const agenrPath = resolveAgenrPath(config);


### PR DESCRIPTION
## Problem

OpenClaw's `sessions.reset` RPC (used by webchat and any client calling the RPC directly) does NOT call `runBeforeReset`. The `before_reset` hook only fires in the in-process auto-reply path. This means no handoff entry was ever written to the DB for RPC-triggered /new commands.

Closes #210. Closes #216.

## Solution

Register a `command` hook handler that fires in both paths (RPC and auto-reply). It:
1. Filters to `action === "new" | "reset"`
2. Reads and parses the session JSONL file directly (command hook does not pre-parse messages)
3. Runs the same Phase 1 (fallback store) + Phase 2 (LLM upgrade) handoff logic via shared `runHandoffForSession()`
4. Uses a dedup guard (`Set<sessionId>` with 60s TTL eviction) to prevent double-writes when both hooks fire in the auto-reply path

## Changes

- `readAndParseSessionJsonl()` - new helper to read/parse JSONL line by line
- `runHandoffForSession()` - shared helper extracted from `before_reset` for reuse by both hooks
- `command` hook handler registered with full `[AGENR-PROBE]` debug logging at every decision point
- All `opts.logger` strings in shared helper use `opts.source` (not hardcoded `before_reset`)
- `before_reset` hook unchanged and stays in place as belt-and-suspenders for auto-reply path

## Tests

5 new tests: fires for new, skips stop, skips empty JSONL, dedup same sessionId, dedup cross-hook.
1107 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command hook handoff logic to prevent duplicate writes in RPC-triggered scenarios.
  * Improved session handling consistency across different execution paths.

* **Improvements**
  * Enhanced debugging observability for command hook operations and session file processing.

* **Tests**
  * Added new test coverage for command hook handoff behavior and deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->