### PR TITLE
feat(openclaw-plugin): trigger LLM handoff summarization from Phase 1A (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.8.29] - 2026-02-24
+
+### Added
+- Phase 1A now triggers LLM handoff summarization (fire-and-forget) when a
+  previous session file is found at session start. This is a reliable
+  fallback for the before_reset/command hook paths that do not fire in
+  current OpenClaw versions due to a dispatch gap (openclaw/openclaw#25074).
+  The existing before_reset and command hook paths are unchanged.
+
+### Changed
+- runHandoffForSession source type now includes "session_start"
+
+### Tests
+- 5 new tests in session-handoff.test.ts covering the Phase 1A handoff
+  trigger path
+
 ## [0.8.28] - 2026-02-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -241,7 +241,7 @@ function getBaseSessionPath(filePath: string): string {
 function deriveSessionIdFromSessionFile(sessionFile: string): string {
   const baseSessionPath = getBaseSessionPath(sessionFile);
   const baseName = path.basename(baseSessionPath, ".jsonl").trim();
-  return baseName || sessionFile;
+  return baseName || "";
 }
 
 async function readSessionsJson(sessionsDir: string): Promise<Record<string, unknown>> {
@@ -938,7 +938,6 @@ const plugin = {
               }
 
               if (Array.isArray(messages) && messages.length > 0) {
-                const previousSessionId = deriveSessionIdFromSessionFile(previousSessionFile);
                 process.stderr.write(
                   `[AGENR-PROBE] session_start: triggering handoff for prev file=${previousSessionFile} msgs=${messages.length}\n`,
                 );
@@ -946,13 +945,18 @@ const plugin = {
                   .runHandoffForSession({
                     messages,
                     sessionFile: previousSessionFile,
-                    sessionId: previousSessionId,
+                    sessionId:
+                      deriveSessionIdFromSessionFile(previousSessionFile) ||
+                      (ctx.sessionId ?? ctx.sessionKey ?? ""),
                     sessionKey: ctx.sessionKey ?? "",
                     agentId,
                     agenrPath,
                     budget,
                     defaultProject: project,
-                    storeConfig: {},
+                    storeConfig: {
+                      ...(config as Record<string, unknown> | undefined),
+                      logger: api.logger,
+                    },
                     sessionsDir,
                     logger: api.logger,
                     source: "session_start",


### PR DESCRIPTION
## Summary

Phase 1A (`before_prompt_build`) now triggers `runHandoffForSession()` fire-and-forget when a previous session file is found. This is a reliable fallback for `before_reset`/`command` hooks that never fire due to an OpenClaw dispatch gap (openclaw/openclaw#25074).

## How it works

1. Phase 1A already finds and reads the previous session JSONL
2. After resolving the file, `readAndParseSessionJsonl()` is awaited
3. `runHandoffForSession()` fires as void fire-and-forget with `source: "session_start"`
4. Inside `runHandoffForSession` (unchanged):
   - Phase 1 (fallback): stores last 5 user turns at importance:9 immediately
   - Phase 2 (LLM): fires-and-forgets `summarizeSessionForHandoff()` with up to 50 messages, stores at importance:10
   - If LLM comes back, retires the fallback entry before storing - LLM always wins
5. Existing dedup guard (`handoffSeenSessionIds`) prevents double-fire if `before_reset` ever starts working

## Changes

- `src/openclaw-plugin/index.ts`: Phase 1A handoff trigger; source type union extended to include `"session_start"`; `retireFallbackHandoffEntries` now accepts source param (fixes hardcoded `"before_reset"` in log strings); debug probe writes added
- `src/openclaw-plugin/session-handoff.test.ts`: 5 new tests
- Version bump to 0.8.29

## Not changed

`before_reset` and `command` hook handlers are untouched - they stay in place for when OpenClaw fixes the dispatch gap.

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic Phase 1A handoff summarization triggers when resuming a previous session at startup.
  * Enhanced session management to detect and process prior session data during initialization.

* **Tests**
  * Added comprehensive test coverage for session-start handoff trigger scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->