### PR TITLE
fix: rebuild dist for 0.8.30 - Phase 1A handoff trigger missing from 0.8.29 artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.8.30] - 2026-02-24
+
+### Fixed
+- Rebuild dist to include Phase 1A handoff trigger missing from 0.8.29.
+  The dist/ artifact in 0.8.29 was stale - runHandoffForSession() call added
+  in the 0.8.29 source (commit e3222c5) was not present in the published
+  package. No logic changes. Build-only fix.
+
 ## [0.8.29] - 2026-02-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
## Problem

0.8.29 was published with a stale dist/. The Phase 1A handoff trigger (runHandoffForSession with source: "session_start") was written in src/openclaw-plugin/index.ts but dist/ was not rebuilt before publish, so the published npm package was missing the feature entirely.

Evidence: grep for "session_start: triggering handoff" in the 0.8.29 npm package dist returns nothing. Same grep on the freshly built dist returns line 1630.

## Fix

Build-only. No source changes.

1. pnpm build (rebuilt dist/)
2. Verified trigger present in new dist
3. pnpm test - 1112/1112 passing
4. Version bump + CHANGELOG

## Changes

- package.json: 0.8.29 -> 0.8.30
- CHANGELOG.md: 0.8.30 entry
- dist/: rebuilt (gitignored, not committed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing Phase 1A handoff trigger functionality. Although this feature was completed in v0.8.29, the distributed package was not properly updated to include it. Version 0.8.30 resolves this issue by including the complete functionality in the distribution, restoring full access to the handoff trigger for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->