### PR TITLE
fix(openclaw-plugin): handoff debug logging + fallback retirement fragility (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.8.31] - 2026-02-24
+
+### Fixed
+- plugin: LLM handoff now logs transcript size, model, and summary length before/after the LLM call for observability (#221)
+- plugin: fallback handoff retirement now matches by subject+importance+tag only, dropping fragile content equality check that left stale fallback entries alongside LLM summaries (#221)
+
 ## [0.8.30] - 2026-02-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Closes #221

## Changes

### Fix 1 - Debug logging in summarizeSessionForHandoff
- Replaces the single opaque 'calling LLM for session summary...' log with a rich pre-call log: model, transcript chars, current+prior message counts
- Adds 'LLM summary received chars=N' log on success
- Adds labeled skip-reason debug log at every null-return path (short transcript, too few messages, LLM client init failed, LLM error stop, empty summary text)

### Fix 2 - Fallback retirement drops fragile content equality check
- Removes the `entryContent !== normalizedFallbackText` guard from `retireFallbackHandoffEntries`
- Match is now subject + importance:9 + tag:handoff - sufficient since subject is a timestamped unique string
- Removes `fallbackText` param from function signature and all call sites
- Fixes production bug where fallback (raw transcript, imp:9) and LLM summary (imp:10) both remained in DB after a successful LLM run

## Tests
- 1114 passing (up from 1112, 2 new)
- New: retirement fires even when browse content differs from original fallback text
- New: debug log emitted with model + char count before LLM call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging for LLM handoff interactions with detailed transcript and model metrics for improved observability
  * Resolved issue where stale fallback handoff entries would persist alongside newly generated LLM summaries

* **Tests**
  * Added test coverage for LLM handoff logging and fallback retirement behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->