### PR TITLE
fix(openclaw-plugin): raise summarizeSessionForHandoff logs from debug to console (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.32] - 2026-02-24
+
+### Fixed
+- summarizeSessionForHandoff: changed logger.debug to console.log for all skip-reason
+  and LLM call logging so output is visible in gateway.err.log at production log level
+  (closes #223)
+
 ## [0.8.31] - 2026-02-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -1319,6 +1319,23 @@ describe("before_reset handoff store", () => {
   });
 });
 
+describe("summarizeSessionForHandoff logging skip paths", () => {
+  it("returns null for short transcripts without throwing", async () => {
+    const api = makeApi();
+    const summaryPromise = __testing.summarizeSessionForHandoff(
+      [
+        { role: "user", content: "short one" },
+        { role: "assistant", content: "short two" },
+      ],
+      "/tmp/agenr-missing-sessions-dir",
+      "/tmp/current-session-short.jsonl",
+      api.logger,
+    );
+
+    await expect(summaryPromise).resolves.toBeNull();
+  });
+});
+
 describe("command hook handoff", () => {
   it("fires handoff for action=new with valid sessionFile", async () => {
     vi.spyOn(__testing, "summarizeSessionForHandoff").mockResolvedValue(null);

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -534,12 +534,12 @@ async function summarizeSessionForHandoff(
     let transcript = buildMergedTranscript(priorSlice, priorSurface, currentSlice, currentSurface);
     const nonHeaderLineCount = countTranscriptContentLines(transcript);
     if (nonHeaderLineCount < 3) {
-      logger.debug?.("[agenr] before_reset: skipping LLM summary - reason: short transcript");
+      console.log("[agenr] before_reset: skipping LLM summary - reason: short transcript");
       return null;
     }
 
     if (currentSlice.length < 5 && priorSlice.length === 0) {
-      logger.debug?.("[agenr] before_reset: skipping LLM summary - reason: too few messages");
+      console.log("[agenr] before_reset: skipping LLM summary - reason: too few messages");
       return null;
     }
 
@@ -557,7 +557,7 @@ async function summarizeSessionForHandoff(
     try {
       llmClient = createLlmClient({});
     } catch (err) {
-      logger.debug?.("[agenr] before_reset: skipping LLM summary - reason: LLM client init failed");
+      console.log("[agenr] before_reset: skipping LLM summary - reason: LLM client init failed");
       return null;
     }
 
@@ -565,7 +565,7 @@ async function summarizeSessionForHandoff(
     const credentials = llmClient.credentials;
     const apiKey = typeof credentials.apiKey === "string" ? credentials.apiKey.trim() : "";
     if (!apiKey) {
-      logger.debug?.("[agenr] before_reset: no apiKey available, skipping LLM summary");
+      console.log("[agenr] before_reset: no apiKey available, skipping LLM summary");
       return null;
     }
 
@@ -575,7 +575,7 @@ async function summarizeSessionForHandoff(
       tools: [],
     };
 
-    logger.debug?.(
+    console.log(
       `[agenr] before_reset: sending to LLM model=${resolvedModel.model} chars=${transcript.length} currentMsgs=${currentSlice.length} priorMsgs=${priorSlice.length}`,
     );
     const assistantMsg = await runSimpleStream({
@@ -587,19 +587,19 @@ async function summarizeSessionForHandoff(
     });
 
     if (assistantMsg.stopReason === "error") {
-      logger.debug?.("[agenr] before_reset: skipping LLM summary - reason: LLM error stop");
+      console.log("[agenr] before_reset: skipping LLM summary - reason: LLM error stop");
       return null;
     }
 
     const summaryText = extractAssistantSummaryText(assistantMsg);
     if (!summaryText) {
-      logger.debug?.("[agenr] before_reset: skipping LLM summary - reason: empty summary text");
+      console.log("[agenr] before_reset: skipping LLM summary - reason: empty summary text");
       return null;
     }
-    logger.debug?.(`[agenr] before_reset: LLM summary received chars=${summaryText.length}`);
+    console.log(`[agenr] before_reset: LLM summary received chars=${summaryText.length}`);
     return summaryText;
   } catch (err) {
-    logger.debug?.(
+    console.log(
       `[agenr] before_reset: summarize handoff failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;

--- a/src/openclaw-plugin/session-handoff.test.ts
+++ b/src/openclaw-plugin/session-handoff.test.ts
@@ -724,6 +724,7 @@ describe("summarizeSessionForHandoff", () => {
       },
     });
     const logger = makeLogger();
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const dir = await makeTempDir("agenr-handoff-summary-");
     const currentSessionFile = path.join(dir, "current-uuid.jsonl");
     await fs.writeFile(currentSessionFile, "", "utf8");
@@ -737,7 +738,7 @@ describe("summarizeSessionForHandoff", () => {
     );
 
     expect(summary).toBe("summary text");
-    expect(logger.debug).toHaveBeenCalledWith(
+    expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringMatching(
         /^\[agenr\] before_reset: sending to LLM model=gpt-4\.1-nano chars=\d+ currentMsgs=5 priorMsgs=0$/,
       ),
@@ -836,6 +837,7 @@ describe("summarizeSessionForHandoff", () => {
       throw new Error("Not configured. Run `agenr setup`.");
     });
     const logger = makeLogger();
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const dir = await makeTempDir("agenr-handoff-summary-");
     const currentSessionFile = path.join(dir, "current-uuid.jsonl");
     await fs.writeFile(currentSessionFile, "", "utf8");
@@ -849,10 +851,10 @@ describe("summarizeSessionForHandoff", () => {
     );
 
     expect(summary).toBeNull();
-    expect(logger.debug).toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalled();
   });
 
-  it("returns null and logs debug when credentials.apiKey is missing", async () => {
+  it("returns null and logs when credentials.apiKey is missing", async () => {
     vi.spyOn(llmClientModule, "createLlmClient").mockReturnValue({
       auth: "openai-api-key",
       resolvedModel: {
@@ -863,6 +865,7 @@ describe("summarizeSessionForHandoff", () => {
       credentials: {} as { apiKey?: string },
     });
     const logger = makeLogger();
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const dir = await makeTempDir("agenr-handoff-summary-");
     const currentSessionFile = path.join(dir, "current-uuid.jsonl");
     await fs.writeFile(currentSessionFile, "", "utf8");
@@ -876,7 +879,7 @@ describe("summarizeSessionForHandoff", () => {
     );
 
     expect(summary).toBeNull();
-    expect(logger.debug).toHaveBeenCalledWith(
+    expect(consoleLogSpy).toHaveBeenCalledWith(
       "[agenr] before_reset: no apiKey available, skipping LLM summary",
     );
   });


### PR DESCRIPTION
Closes #223

## Changes

- Changed all `logger.debug?.()` calls inside `summarizeSessionForHandoff` to `console.log()`
- Covers all 9 log points: 5 skip-reason null paths, pre-LLM-call metadata, LLM summary received, and catch block
- Consistent with existing PROBE pattern already using `console.log`

## Tests

1115 passing (1 new: short-transcript null path in summarizeSessionForHandoff)