### PR TITLE
fix: rebuild dist for 0.8.34 - --force flag missing from 0.8.33 artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.34] - 2026-02-24
+
+### Fixed
+- rebuild dist - --force flag missing from 0.8.33 artifact (stale build)
+
 ## [0.8.33] - 2026-02-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
0.8.33 was published with a stale dist/ - the --force flag from #225 was not in the artifact. This bumps to 0.8.34 with a fresh build.