### PR TITLE
fix(openclaw-plugin): await LLM handoff upgrade in runHandoffForSession (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.8.36] - 2026-02-24
+
+### Fixed
+- openclaw-plugin: await LLM upgrade in runHandoffForSession instead of fire-and-forget; the gateway awaits before_reset so the LLM call can and should block until the summary is stored (closes #230)
+- openclaw-plugin: raise Phase 1 fallback store success/failure logs from logger.debug to console.log for production visibility (extends #223)
+
 ## [0.8.34] - 2026-02-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.34",
+  "version": "0.8.36",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
## Problem

The LLM upgrade in Phase 2 of `runHandoffForSession` was launched as a `void` fire-and-forget. The `before_reset` hook IS awaited by the gateway, but `runHandoffForSession` returned as soon as Phase 1 (fallback store) completed. The gateway then completed the reset, killing the in-flight LLM promise.

Confirmed in logs:
```
[agenr] before_reset: LLM summary received chars=1699
```
...then nothing. The 1699-char LLM summary was generated but never stored. The next session got fallback-only quality context.

## Fix

- Replace `void .then().catch()` with `const summary = await testingApi.summarizeSessionForHandoff(...)`
- Store the LLM entry synchronously after the await resolves
- The `before_reset` contract is `Promise<void>` - the gateway waits for it, so a ~3s LLM call is fine
- Raise Phase 1 fallback store success/failure logs from `opts.logger?.debug?.()` to `console.log()` (extends #223)

## Tests

- Added test: LLM handoff store is awaited before `runHandoffForSession` resolves
- Added test: fallback-only path works correctly when LLM returns null
- 1120 tests passing (up from 1118)

Closes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.8.36

* **Bug Fixes**
  * Improved session handoff reliability by ensuring operations complete in the correct sequence before reset
  * Enhanced production visibility by promoting handoff operation logs from debug-only to console output

* **Chores**
  * Version bump to 0.8.36

<!-- end of auto-generated comment: release notes by coderabbit.ai -->