### PR TITLE
fix(openclaw-plugin): await session_start handoff - LLM summary dropped on webchat /new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.8.37] - 2026-02-24
+
+### Fixed
+- openclaw-plugin: await runHandoffForSession in session_start handler instead of void
+  fire-and-forget; webchat /new goes through sessions.reset RPC which does not trigger
+  before_reset, so session_start is the only hook that fires on that path - making it
+  void meant the LLM summary was always dropped (closes #232)
+
 ## [0.8.36] - 2026-02-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -932,8 +932,11 @@ const plugin = {
                 process.stderr.write(
                   `[AGENR-PROBE] session_start: triggering handoff for prev file=${previousSessionFile} msgs=${messages.length}\n`,
                 );
-                void testingApi
-                  .runHandoffForSession({
+                console.log(
+                  `[agenr] session_start: awaiting runHandoffForSession file=${previousSessionFile}`,
+                );
+                try {
+                  await testingApi.runHandoffForSession({
                     messages,
                     sessionFile: previousSessionFile,
                     sessionId:
@@ -951,12 +954,13 @@ const plugin = {
                     sessionsDir,
                     logger: api.logger,
                     source: "session_start",
-                  })
-                  .catch((err) => {
-                    api.logger.debug?.(
-                      `[agenr] session_start: handoff fire-and-forget failed: ${err instanceof Error ? err.message : String(err)}`,
-                    );
                   });
+                  console.log("[agenr] session_start: runHandoffForSession completed");
+                } catch (err) {
+                  api.logger.debug?.(
+                    `[agenr] session_start: handoff failed: ${err instanceof Error ? err.message : String(err)}`,
+                  );
+                }
               } else if (Array.isArray(messages)) {
                 process.stderr.write(
                   `[AGENR-PROBE] session_start: skipping handoff - no messages in prev file=${previousSessionFile}\n`,


### PR DESCRIPTION
## Problem

On webchat, `/new` goes through the `sessions.reset` RPC path, which does **not** trigger `before_reset`. Only `session_start` fires on this path.

The `session_start` handler called `runHandoffForSession` with `void` (fire-and-forget). The gateway did not wait for the detached promise, so the LLM summary was always dropped before it could complete. Only the fast Phase 1 CLI fallback sometimes landed; the LLM summary never did.

Confirmed via gateway.err.log - `[AGENR-PROBE] session_start: triggering handoff` logged, then silence. Zero `before_reset FIRED` lines across all webchat /new invocations.

## Fix

Change `void testingApi.runHandoffForSession(...)` to `await` inside a `try/catch`. The `session_start` handler is `async` and wired inside `before_prompt_build`, so the gateway awaits it before building the first prompt - the LLM call (~3s) completes cleanly.

## Changes

- `src/openclaw-plugin/index.ts`: `void` -> `await` with `try/catch` in `session_start` handler
- `src/openclaw-plugin/session-handoff.test.ts`: new test with 50ms delayed mock asserting handler awaits before resolving
- `CHANGELOG.md`: `[0.8.37]` entry

## Test Results

1121 passed, 0 failed

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where LLM summaries could be lost during session resets in webchat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->