### PR TITLE
chore: gitignore *.tgz pack artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ docs/internal/
 
 # Sandbox environment
 sandbox/
+
+# npm pack artifacts
+*.tgz


### PR DESCRIPTION
Adds *.tgz to .gitignore to prevent pnpm pack artifacts from being committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ignore npm package artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->