### PR TITLE
fix(openclaw-plugin): handoff summarizer isolation + opt-in background context (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.8.38] - 2026-02-24
+
+### Fixed
+- Handoff summarizer no longer blends prior session messages into the LLM summary, preventing stale facts from being stored as current findings (#235)
+- Simplified handoff system prompt to single-session summarization
+- Added anti-hallucination guardrail to handoff prompt
+
+### Removed
+- All temporary [AGENR-PROBE] debug logging from openclaw-plugin (replaced with clean operational logs where needed)
+- Removed findPriorResetFile (no longer needed for summarization)
+- Removed capTranscriptLength (simplified without prior session merging)
+
 ## [0.8.37] - 2026-02-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,22 @@
   console.log for production visibility
 
 ### Added
+- Opt-in `handoff.includeBackground` config flag for handoff summarizer: when
+  enabled, prior session messages are included as background context with strong
+  section headers so the LLM can orient without blending stale facts into the
+  current session summary (#235)
+- New system prompt variant with anti-hallucination instructions for background
+  context mode ("BACKGROUND CONTEXT (DO NOT SUMMARIZE)" / "SUMMARIZE THIS
+  SESSION ONLY" section headers)
 - Optional `handoff.logDir` config: when set, writes the full LLM request
   transcript and response to files for prompt tuning and debugging (#235)
+
+### Changed
+- Default handoff behavior unchanged: current session only, no prior messages
+
+### Removed
+- All temporary [AGENR-PROBE] debug logging from openclaw-plugin (replaced with
+  clean operational logs where needed)
 
 ## [0.8.37] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,14 @@
 
 ## [0.8.38] - 2026-02-24
 
+### Fixed
+- Handoff log line now shows model ID string instead of [object Object]
+- Upgraded handoff retirement and browse debug logs from logger.debug to
+  console.log for production visibility
+
 ### Added
-- Opt-in `handoff.includeBackground` config flag for handoff summarizer: when
-  enabled, prior session messages are included as background context with strong
-  section headers so the LLM can orient without blending stale facts into the
-  current session summary (#235)
-- New system prompt variant with anti-hallucination instructions for background
-  context mode ("BACKGROUND CONTEXT (DO NOT SUMMARIZE)" / "SUMMARIZE THIS
-  SESSION ONLY" section headers)
-
-### Changed
-- Default handoff behavior unchanged: current session only, no prior messages
-
-### Removed
-- All temporary [AGENR-PROBE] debug logging from openclaw-plugin (replaced with
-  clean operational logs where needed)
+- Optional `handoff.logDir` config: when set, writes the full LLM request
+  transcript and response to files for prompt tuning and debugging (#235)
 
 ## [0.8.37] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Handoff log line now shows model ID string instead of [object Object]
 - Upgraded handoff retirement and browse debug logs from logger.debug to
   console.log for production visibility
+- Handoff transcript now strips OpenClaw/agenr injected context (memory
+  blocks, signals, conversation metadata, timestamp prefixes) before
+  sending to the LLM, preventing the summarizer from summarizing its own
+  metadata (#235)
 
 ### Added
 - Opt-in `handoff.includeBackground` config flag for handoff summarizer: when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,21 @@
 
 ## [0.8.38] - 2026-02-24
 
-### Fixed
-- Handoff summarizer no longer blends prior session messages into the LLM summary, preventing stale facts from being stored as current findings (#235)
-- Simplified handoff system prompt to single-session summarization
-- Added anti-hallucination guardrail to handoff prompt
+### Added
+- Opt-in `handoff.includeBackground` config flag for handoff summarizer: when
+  enabled, prior session messages are included as background context with strong
+  section headers so the LLM can orient without blending stale facts into the
+  current session summary (#235)
+- New system prompt variant with anti-hallucination instructions for background
+  context mode ("BACKGROUND CONTEXT (DO NOT SUMMARIZE)" / "SUMMARIZE THIS
+  SESSION ONLY" section headers)
+
+### Changed
+- Default handoff behavior unchanged: current session only, no prior messages
 
 ### Removed
-- All temporary [AGENR-PROBE] debug logging from openclaw-plugin (replaced with clean operational logs where needed)
-- Removed findPriorResetFile (no longer needed for summarization)
-- Removed capTranscriptLength (simplified without prior session merging)
+- All temporary [AGENR-PROBE] debug logging from openclaw-plugin (replaced with
+  clean operational logs where needed)
 
 ## [0.8.37] - 2026-02-24
 

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -83,7 +83,8 @@ Create `~/.openclaw-sandbox/.openclaw/openclaw.json`:
       "agenr": {
         "enabled": true,
         "config": {
-          "dbPath": "<ABSOLUTE_PATH>/.openclaw-sandbox/agenr-data/knowledge.db"
+          "dbPath": "<ABSOLUTE_PATH>/.openclaw-sandbox/agenr-data/knowledge.db",
+          "sessionsDir": "<ABSOLUTE_PATH>/.openclaw-sandbox/.openclaw/agents/main/sessions"
         }
       }
     }
@@ -245,11 +246,12 @@ No conflict - global and local coexist fine. They use different entry points and
 
 ## Gotchas
 
-- **Always use absolute paths** in the config for `workspace` and `dbPath`. Tilde paths can double-nest (`~/.openclaw-sandbox/.openclaw-sandbox/...`).
+- **Always use absolute paths** in the config for `workspace`, `dbPath`, and `sessionsDir`. Tilde paths can double-nest (`~/.openclaw-sandbox/.openclaw-sandbox/...`).
 - **Auth uses `auth-profiles.json`**, not `auth.json`. OpenClaw looks for the profiles format.
 - **Session JSONL carries context forward.** If you test with a dirty DB and then switch to a clean one, old context may persist in session files. Delete `*.jsonl` to fully reset.
 - **Port conflicts.** If the sandbox won't start, check for zombie processes: `lsof -i :18790` and `kill <pid>`. You can also force-kill with `sandbox-openclaw gateway stop` or just `kill <pid>`.
 - **The plugin reads the built `dist/` output.** Always run `pnpm build` before testing. Stale dist is the number one source of "but I changed it" confusion.
+- **`sessionsDir` must be set in plugin config.** The plugin defaults to `~/.openclaw/agents/main/sessions` (the production path), not the sandbox home. Without `sessionsDir` in the config, the handoff hooks will fail to find session files and silently skip.
 - **Sandbox shares the log file** at `/tmp/openclaw/openclaw-YYYY-MM-DD.log` with any other local OpenClaw instance. Filter by port or timestamps if needed.
 
 ## Running Tests (Unit)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -56,6 +56,17 @@
       "sessionsDir": {
         "type": "string",
         "description": "Path to OpenClaw sessions directory. Defaults to ~/.openclaw/agents/{agentId}/sessions."
+      },
+      "handoff": {
+        "type": "object",
+        "description": "Handoff summarizer options.",
+        "additionalProperties": false,
+        "properties": {
+          "includeBackground": {
+            "type": "boolean",
+            "description": "Include prior session as background context in handoff summary (default: false)."
+          }
+        }
       }
     }
   }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -65,6 +65,14 @@
           "includeBackground": {
             "type": "boolean",
             "description": "Include prior session as background context in handoff summary (default: false)."
+          },
+          "logEnabled": {
+            "type": "boolean",
+            "description": "Enable writing handoff LLM request/response logs to logDir (default: false)."
+          },
+          "logDir": {
+            "type": "string",
+            "description": "Directory to write handoff LLM request/response logs for debugging. Requires logEnabled: true."
           }
         }
       }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -52,6 +52,10 @@
       "dbPath": {
         "type": "string",
         "description": "Path to agenr DB. Defaults to AGENR_DB_PATH env or ~/.agenr/knowledge.db."
+      },
+      "sessionsDir": {
+        "type": "string",
+        "description": "Path to OpenClaw sessions directory. Defaults to ~/.openclaw/agents/{agentId}/sessions."
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -1344,6 +1344,7 @@ describe("summarizeSessionForHandoff logging skip paths", () => {
       "/tmp/agenr-missing-sessions-dir",
       "/tmp/current-session-short.jsonl",
       api.logger,
+      false,
     );
 
     await expect(summaryPromise).resolves.toBeNull();

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -1352,6 +1352,7 @@ describe("command hook handoff", () => {
       { role: "assistant", content: "Acknowledged, capturing handoff now." },
       { role: "user", content: "Focus on issue #210 command reset path." },
     ]);
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const runStoreMock = vi.spyOn(pluginTools, "runStoreTool").mockResolvedValue({
       content: [{ type: "text", text: "Stored 1 entries." }],
     });
@@ -1385,6 +1386,10 @@ describe("command hook handoff", () => {
     expect(payload.entries[0]?.type).toBe("event");
     expect(payload.entries[0]?.importance).toBe(9);
     expect(payload.entries[0]?.tags).toContain("handoff");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[agenr] command: triggered action=new sessionKey=agent:main:command-new",
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith("[agenr] command: handoff complete");
   });
 
   it("skips handoff for action=stop", async () => {
@@ -1452,6 +1457,7 @@ describe("command hook handoff", () => {
       { role: "user", content: "First handoff call should store." },
       { role: "assistant", content: "Second call should dedup skip." },
     ]);
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const runStoreMock = vi.spyOn(pluginTools, "runStoreTool").mockResolvedValue({
       content: [{ type: "text", text: "Stored 1 entries." }],
     });
@@ -1477,6 +1483,9 @@ describe("command hook handoff", () => {
     await handler(event, { sessionKey: "agent:main:command-dedup", agentId: "main" });
 
     expect(runStoreMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[agenr] command: dedup skip sessionId=session-210-cmd-dedup",
+    );
   });
 
   it("dedup: before_reset and command with same sessionId only write one entry", async () => {

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -277,6 +277,7 @@ describe("before_prompt_build recall behavior", () => {
       "plugin-scope",
       undefined,
       { context: "browse", since: "1d", limit: 20 },
+      undefined,
     );
     expect(runRecallMock).toHaveBeenNthCalledWith(
       2,
@@ -284,6 +285,8 @@ describe("before_prompt_build recall behavior", () => {
       expect.any(Number),
       "plugin-scope",
       prompt,
+      undefined,
+      undefined,
     );
   });
 });
@@ -307,6 +310,7 @@ describe("before_prompt_build cross-session context injection", () => {
       undefined,
       undefined,
       { context: "browse", since: "1d", limit: 20 },
+      undefined,
     );
   });
 
@@ -361,6 +365,8 @@ describe("before_prompt_build cross-session context injection", () => {
       expect.any(Number),
       undefined,
       "U: previous user | A: previous assistant",
+      undefined,
+      undefined,
     );
     expect(result?.prependContext).toContain("## Recent session");
     expect(result?.prependContext).toContain("## Recent memory");

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -268,12 +268,12 @@ function stripInjectedContext(text: string): string {
   // Strip large agenr-injected context blocks (## Recent session/memory/Relevant memory
   // and any ## agenr Memory Context sub-blocks that follow them).
   cleaned = cleaned.replace(
-    /(?:^|\n)## (?:Recent session|Recent memory|Relevant memory)\b[\s\S]*?(?=(?:^|\n)(?:Conversation info|\[(?:user|assistant)\]:|AGENR SIGNAL:|=== )|$)/g,
+    /(?:^|\n)## (?:Recent session|Recent memory|Relevant memory)\b[\s\S]*?(?=(?:^|\n)(?:## (?!Recent session|Recent memory|Relevant memory|agenr Memory Context)|Conversation info|\[(?:user|assistant)\]:|AGENR SIGNAL:|=== )|$)/g,
     "",
   );
   // Strip standalone ## agenr Memory Context blocks (if not already caught above).
   cleaned = cleaned.replace(
-    /(?:^|\n)## agenr Memory Context[\s\S]*?(?=(?:^|\n)(?:Conversation info|\[(?:user|assistant)\]:|AGENR SIGNAL:|=== )|$)/g,
+    /(?:^|\n)## agenr Memory Context[\s\S]*?(?=(?:^|\n)(?:## (?!agenr Memory Context)|Conversation info|\[(?:user|assistant)\]:|AGENR SIGNAL:|=== )|$)/g,
     "",
   );
   // Strip signal headline and following bullet entries.

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -983,6 +983,7 @@ async function runHandoffForSession(opts: {
           agenrPath: opts.agenrPath,
           budget: opts.budget,
           defaultProject: opts.defaultProject,
+          dbPath: opts.dbPath,
           fallbackSubject: fallbackEntrySubject,
           logger: opts.logger ?? {
             warn: () => undefined,

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -655,6 +655,13 @@ async function summarizeSessionForHandoff(
         currentSlice = currentSlice.slice(1);
         transcript = buildTranscript(currentSlice, currentSurface);
       }
+      if (transcript.length > HANDOFF_TRANSCRIPT_MAX_CHARS) {
+        transcript = transcript.slice(-HANDOFF_TRANSCRIPT_MAX_CHARS);
+        const firstNewline = transcript.indexOf("\n");
+        if (firstNewline > 0) {
+          transcript = transcript.slice(firstNewline + 1);
+        }
+      }
     }
 
     let llmClient;

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -90,9 +90,9 @@ export async function runRecall(
         args.push(truncatedQuery);
       }
     }
-    const child = spawn(spawnArgs.cmd, [...spawnArgs.args, ...args], {
+    const finalArgs = dbPath ? [...args, "--db", dbPath] : args;
+    const child = spawn(spawnArgs.cmd, [...spawnArgs.args, ...finalArgs], {
       stdio: ["ignore", "pipe", "ignore"],
-      env: dbPath ? { ...process.env, AGENR_DB_PATH: dbPath } : process.env,
     });
 
     const timer = setTimeout(() => {

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -55,6 +55,7 @@ export async function runRecall(
   project?: string,
   query?: string,
   options?: RunRecallOptions,
+  dbPath?: string,
 ): Promise<RecallResult | null> {
   return await new Promise((resolve) => {
     let stdout = "";
@@ -91,6 +92,7 @@ export async function runRecall(
     }
     const child = spawn(spawnArgs.cmd, [...spawnArgs.args, ...args], {
       stdio: ["ignore", "pipe", "ignore"],
+      env: dbPath ? { ...process.env, AGENR_DB_PATH: dbPath } : process.env,
     });
 
     const timer = setTimeout(() => {

--- a/src/openclaw-plugin/session-handoff.test.ts
+++ b/src/openclaw-plugin/session-handoff.test.ts
@@ -814,6 +814,7 @@ describe("summarizeSessionForHandoff", () => {
         { role: "assistant", content: "AGENR SIGNAL: signal\n- [fact] hidden", timestamp: "2026-02-24T10:03:00" },
         { role: "user", content: "cleaned two", timestamp: "2026-02-24T10:04:00" },
         { role: "assistant", content: "cleaned three", timestamp: "2026-02-24T10:05:00" },
+        { role: "user", content: "cleaned four", timestamp: "2026-02-24T10:06:00" },
       ],
       dir,
       currentSessionFile,
@@ -1025,6 +1026,7 @@ describe("summarizeSessionForHandoff", () => {
         { role: "assistant", content: "AGENR SIGNAL: signal\n- [fact] hidden", timestamp: "2026-02-24T10:03:00" },
         { role: "user", content: "cleaned two", timestamp: "2026-02-24T10:04:00" },
         { role: "assistant", content: "cleaned three", timestamp: "2026-02-24T10:05:00" },
+        { role: "user", content: "cleaned four", timestamp: "2026-02-24T10:06:00" },
       ],
       dir,
       currentSessionFile,
@@ -1045,10 +1047,11 @@ describe("summarizeSessionForHandoff", () => {
     const messageLines = transcript
       .split("\n")
       .filter((line) => line.startsWith("[user]:") || line.startsWith("[assistant]:"));
-    expect(messageLines).toHaveLength(3);
+    expect(messageLines).toHaveLength(4);
     expect(transcript).toContain("[assistant]: cleaned one");
     expect(transcript).toContain("[user]: cleaned two");
     expect(transcript).toContain("[assistant]: cleaned three");
+    expect(transcript).toContain("[user]: cleaned four");
     expect(transcript).not.toContain("## Recent session");
     expect(transcript).not.toContain("Conversation info (untrusted metadata):");
     expect(transcript).not.toContain("AGENR SIGNAL:");
@@ -1147,6 +1150,7 @@ describe("summarizeSessionForHandoff", () => {
         { role: "user", content: "hi", timestamp: "2026-02-24T10:00:00" },
         { role: "assistant", content: "hello", timestamp: "2026-02-24T10:01:00" },
         { role: "user", content: "thanks", timestamp: "2026-02-24T10:02:00" },
+        { role: "assistant", content: "bye", timestamp: "2026-02-24T10:03:00" },
       ],
       dir,
       currentSessionFile,

--- a/src/openclaw-plugin/session-handoff.test.ts
+++ b/src/openclaw-plugin/session-handoff.test.ts
@@ -780,6 +780,7 @@ describe("runHandoffForSession", () => {
       }),
       {},
       undefined,
+      undefined,
     );
     expect(llmStoreHappenedBeforeResolve).toBe(true);
   });
@@ -820,6 +821,7 @@ describe("runHandoffForSession", () => {
         ],
       }),
       {},
+      undefined,
       undefined,
     );
   });
@@ -880,7 +882,7 @@ describe("runHandoffForSession", () => {
     expect(runRetireMock).toHaveBeenCalledWith("/tmp/agenr", {
       entry_id: "fallback-entry-221",
       reason: "superseded by LLM handoff",
-    });
+    }, undefined);
   });
 });
 

--- a/src/openclaw-plugin/tools.ts
+++ b/src/openclaw-plugin/tools.ts
@@ -116,9 +116,9 @@ async function runAgenrCommand(
       resolve(result);
     };
 
-    const child = spawn(spawnArgs.cmd, [...spawnArgs.args, ...args], {
+    const finalArgs = dbPath ? [...args, "--db", dbPath] : args;
+    const child = spawn(spawnArgs.cmd, [...spawnArgs.args, ...finalArgs], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: dbPath ? { ...process.env, AGENR_DB_PATH: dbPath } : process.env,
     });
 
     const timer = setTimeout(() => {

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -112,6 +112,10 @@ export type AgenrPluginConfig = {
   handoff?: {
     /** Include prior session transcript as background-only context (default: false) */
     includeBackground?: boolean;
+    /** Enable writing handoff LLM request/response logs to logDir (default: false) */
+    logEnabled?: boolean;
+    /** Directory to write handoff LLM request/response logs for debugging */
+    logDir?: string;
   };
   /** Set to false to disable mid-session signals (default: true) */
   signalsEnabled?: boolean;

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -108,6 +108,11 @@ export type AgenrPluginConfig = {
   enabled?: boolean;
   /** Path to agenr DB. Defaults to AGENR_DB_PATH env or ~/.agenr/knowledge.db */
   dbPath?: string;
+  /** Handoff summarizer options */
+  handoff?: {
+    /** Include prior session transcript as background-only context (default: false) */
+    includeBackground?: boolean;
+  };
   /** Set to false to disable mid-session signals (default: true) */
   signalsEnabled?: boolean;
   /** Minimum importance for signal entries (default: 8) */


### PR DESCRIPTION
## Summary

Fixes #235 - handoff summarizer was blending prior session facts into current session summaries, poisoning the knowledge DB with stale information at importance 9.

## Changes

### Handoff summarizer isolation (default behavior)
- Summarizer now only processes current session messages by default
- Simplified system prompt for single-session summarization
- Anti-hallucination guardrails in the prompt

### Opt-in background context (`handoff.includeBackground`)
- New config flag to include prior session as read-only background
- Strong section headers: `=== BACKGROUND CONTEXT (DO NOT SUMMARIZE) ===` and `=== SUMMARIZE THIS SESSION ONLY ===`
- Dedicated system prompt variant with explicit instructions not to summarize background
- Prior messages trimmed first when transcript exceeds budget

### Metadata stripping
- `stripInjectedContext()` removes OpenClaw/agenr injected noise before LLM sees it:
  - `## Recent session/memory/Relevant memory` blocks
  - `## agenr Memory Context` blocks
  - `AGENR SIGNAL:` lines
  - `Conversation info (untrusted metadata):` JSON blocks
  - Timestamp prefixes
- Line-anchored regexes preserve inline backtick references

### Debug logging
- `handoff.logEnabled` + `handoff.logDir` config: writes full LLM request transcript and response to files for prompt tuning
- Retirement success/failure logs upgraded from debug to console.log
- Browse result count logged for handoff retirement visibility
- Fixed `model=[object Object]` in logs (now uses `resolvedModel.modelId`)

### Other fixes
- `findPriorResetFile` UUID extraction fixed for reset file paths
- Error check moved before summary extraction and log writing
- Minimum message threshold raised from 3 to 4
- dbPath threaded through all CLI tool spawns via --db flag
- sessionsDir added to plugin config schema
- All AGENR-PROBE debug logging removed

## Config

```json
{
  "agenr": {
    "enabled": true,
    "config": {
      "handoff": {
        "includeBackground": true,
        "logEnabled": true,
        "logDir": "/path/to/handoff-logs"
      }
    }
  }
}
```

## Tests

1135 passing, 0 failures. New tests for strip function, merged transcript, log file writing, background/no-background paths, prompt content verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in background context inclusion for session handoffs
  * Optional handoff transcript logging (enable + configurable logDir)
  * Anti-hallucination system prompt variant to improve handoff accuracy
  * New sessionsDir and handoff config options for finer control

* **Changed**
  * Default handoff behavior remains current-session only

* **Bug Fixes**
  * Fixed log formatting and production visibility issues
  * Improved transcript sanitization to strip injected context

* **Removed**
  * Temporary debug AGENR-PROBE logging removed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->