### PR TITLE
chore: bump version to 0.8.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.8.39",
+  "version": "0.8.40",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump - code already published to npm as agenr@0.8.40.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.8.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->