### PR TITLE
feat(init): interactive onboarding wizard (#170 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.9.2 (2026-02-25)
+
+### Added
+- Added embeddings API key connectivity check in setup via new `runEmbeddingConnectionTest` helper
+  - Sends a minimal embeddings request (`"connection test"`) and verifies a non-empty vector is returned
+  - Handles API and transport errors with user-facing messages
+
+### Changed
+- Setup now tests embeddings connectivity immediately after entering or updating the OpenAI embeddings key
+  - Applies to embeddings-only update flow and the main setup flow for non-OpenAI extraction auth
+  - Uses spinner + retry prompt and allows explicit skip with guidance to run `agenr auth status`
+- `agenr auth status` now includes a separate embeddings diagnostics line in addition to extraction auth status
+- Added regression coverage for embeddings connection helper and setup retry/skip/update flows
+
 ## 0.9.1 (2026-02-25)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.5 (2026-02-25)
+
+- Current config display now shows all registered projects with directories and database isolation status
+
 ## 0.9.4 (2026-02-25)
 
 - Refactor: global projects map keyed by directory path instead of project slug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.3 (2026-02-25)
+
+### Fixed
+- Test isolation hardening for init wizard coverage: `src/commands/init.test.ts` now forces `AGENR_CONFIG_PATH` to a per-test temp config path and restores it in teardown, preventing tests from reading or writing real `~/.agenr/config.json`
+- Updated global-config assertions in init tests to read the isolated config path, so tests no longer depend on home-directory config locations
+
 ## 0.9.2 (2026-02-25)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Auth setup shows API key links (platform.openai.com, console.anthropic.com)
 - Subscription auth methods moved to "Advanced options" submenu
 - Default recommended model changed to gpt-4.1-mini
+- Platform auto-detection for OpenClaw and Codex (macOS, Linux, Windows paths)
+- Project slug derivation with interactive edit
+- Reconfigure mode: re-run `agenr init` to change individual settings with "keep current" defaults
+- Change tracking for auth/model to enable re-ingest offers (Phase 3)
 
 ### Changed
 - Refactored setup.ts: extracted `runSetupCore()` for programmatic use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,34 @@
 # Changelog
 
-## 0.9.5 (2026-02-25)
-
-- Current config display now shows all registered projects with directories and database isolation status
-
-## 0.9.4 (2026-02-25)
-
-- Refactor: global projects map keyed by directory path instead of project slug
-- Multiple instances can now share the same project slug with isolated databases
-- Removed slug collision warning (no longer applicable)
-- `resolveProjectFromGlobalConfig` uses direct key lookup (O(1) instead of iteration)
-
-## 0.9.3 (2026-02-25)
-
-### Fixed
-- Test isolation hardening for init wizard coverage: `src/commands/init.test.ts` now forces `AGENR_CONFIG_PATH` to a per-test temp config path and restores it in teardown, preventing tests from reading or writing real `~/.agenr/config.json`
-- Updated global-config assertions in init tests to read the isolated config path, so tests no longer depend on home-directory config locations
-
-## 0.9.2 (2026-02-25)
-
-### Added
-- Added embeddings API key connectivity check in setup via new `runEmbeddingConnectionTest` helper
-  - Sends a minimal embeddings request (`"connection test"`) and verifies a non-empty vector is returned
-  - Handles API and transport errors with user-facing messages
-
-### Changed
-- Setup now tests embeddings connectivity immediately after entering or updating the OpenAI embeddings key
-  - Applies to embeddings-only update flow and the main setup flow for non-OpenAI extraction auth
-  - Uses spinner + retry prompt and allows explicit skip with guidance to run `agenr auth status`
-- `agenr auth status` now includes a separate embeddings diagnostics line in addition to extraction auth status
-- Added regression coverage for embeddings connection helper and setup retry/skip/update flows
-
-## 0.9.1 (2026-02-25)
-
-### Changed
-- `agenr init` now stores OpenClaw and Codex project settings in the global config at `~/.agenr/config.json` under a new `projects` map instead of writing `<projectDir>/.agenr/config.json` for those global platforms
-- Reconfigure flow now checks the global `projects` map first (matched by `projectDir`) and falls back to per-repo `.agenr/config.json`, so existing per-repo platforms continue to work unchanged
-- Wizard summary now prints the resolved config path so global platforms show `~/.agenr/config.json` and per-repo platforms show `.agenr/config.json` under the project directory
-
-### Added
-- `AgenrConfig.projects` type and config normalization for global project entries (`platform`, `projectDir`, optional `dbPath`, optional `dependencies`)
-- `resolveProjectFromGlobalConfig(projectDir)` helper in `src/config.ts` for resolving global project metadata by directory
-- OpenClaw DB isolation follow-up integration in init flow: selected isolated DB path is now persisted as `projects.<slug>.dbPath`
-
 ## 0.9.0 (2026-02-25)
 
 ### Features
-- Interactive onboarding wizard foundation for `agenr init` (#170 Phase 1)
-- Auth setup shows API key links (platform.openai.com, console.anthropic.com)
-- Subscription auth methods moved to "Advanced options" submenu
-- Default recommended model changed to gpt-4.1-mini
-- Platform auto-detection for OpenClaw and Codex (macOS, Linux, Windows paths)
-- Project slug derivation with interactive edit
-- Reconfigure mode: re-run `agenr init` to change individual settings with "keep current" defaults
-- Change tracking for auth/model to enable re-ingest offers (Phase 3)
+- Interactive onboarding wizard for `agenr init` (#170)
+  - Auth setup with API key links and connection testing
+  - Embeddings API key connectivity check during setup
+  - Platform auto-detection for OpenClaw and Codex (macOS, Linux, Windows)
+  - OpenClaw directory confirmation with custom path support
+  - DB isolation prompt for non-default OpenClaw paths (shared vs isolated)
+  - Project slug derivation with interactive edit
+  - Reconfigure mode with "keep current" defaults
+  - Change tracking for auth, model, embeddings, directory, and DB path
+- Global projects map in `~/.agenr/config.json` for OpenClaw and Codex
+  - Keyed by directory path (multiple instances can share the same project slug)
+  - Stores platform, project slug, and optional dbPath per instance
+  - Per-repo platforms (Cursor, Claude Code, Windsurf) unchanged
+- Current config display shows all registered projects with directories and DB isolation status
+- `resolveProjectFromGlobalConfig()` helper for O(1) project lookup by directory
+- Shared DB warning when same project slug and same database across instances
 
 ### Changed
 - Refactored setup.ts: extracted `runSetupCore()` for programmatic use
+- Subscription auth methods moved to "Advanced options" submenu
+- Default recommended model changed to gpt-4.1-mini
 - Non-interactive init behavior preserved when CLI flags are provided
-- Version bumped to 0.9.0
+- Skip .gitignore writes for OpenClaw and Codex (not git repos)
+
+### Fixed
+- Test isolation: init wizard tests use isolated config path via `AGENR_CONFIG_PATH`
 
 ## [0.8.39] - 2025-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.9.1 (2026-02-25)
+
+### Changed
+- `agenr init` now stores OpenClaw and Codex project settings in the global config at `~/.agenr/config.json` under a new `projects` map instead of writing `<projectDir>/.agenr/config.json` for those global platforms
+- Reconfigure flow now checks the global `projects` map first (matched by `projectDir`) and falls back to per-repo `.agenr/config.json`, so existing per-repo platforms continue to work unchanged
+- Wizard summary now prints the resolved config path so global platforms show `~/.agenr/config.json` and per-repo platforms show `.agenr/config.json` under the project directory
+
+### Added
+- `AgenrConfig.projects` type and config normalization for global project entries (`platform`, `projectDir`, optional `dbPath`, optional `dependencies`)
+- `resolveProjectFromGlobalConfig(projectDir)` helper in `src/config.ts` for resolving global project metadata by directory
+- OpenClaw DB isolation follow-up integration in init flow: selected isolated DB path is now persisted as `projects.<slug>.dbPath`
+
 ## 0.9.0 (2026-02-25)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.4 (2026-02-25)
+
+- Refactor: global projects map keyed by directory path instead of project slug
+- Multiple instances can now share the same project slug with isolated databases
+- Removed slug collision warning (no longer applicable)
+- `resolveProjectFromGlobalConfig` uses direct key lookup (O(1) instead of iteration)
+
 ## 0.9.3 (2026-02-25)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,17 +30,6 @@
 ### Fixed
 - Test isolation: init wizard tests use isolated config path via `AGENR_CONFIG_PATH`
 
-## [0.8.39] - 2025-02-25
-
-### Features
-- **ingest:** Add LLM debug logging via `--log-dir`, `--log-all`, and `--sample-rate` flags (#238)
-  - Captures raw LLM prompt input and response output per chunk
-  - Logs dedup before/after entry lists
-  - Best-effort writes, never blocks extraction
-  - Sampling defaults to 1-in-10 files; use `--log-all` for full capture
-
-### Tests
-- Add tests for ingest debug logging: file creation, sampling, dedup logs, graceful failure on bad logDir
 ## [0.8.40] - 2026-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.5",
+  "version": "0.9.0",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/auth-status.ts
+++ b/src/auth-status.ts
@@ -1,5 +1,6 @@
 import type { Context } from "@mariozechner/pi-ai";
 import { describeAuth, isCompleteConfig, readConfig } from "./config.js";
+import { embed, resolveEmbeddingApiKey } from "./embeddings/client.js";
 import { probeCredentials } from "./llm/credentials.js";
 import { resolveModel } from "./llm/models.js";
 import { runSimpleStream, type StreamSimpleFn } from "./llm/stream.js";
@@ -13,6 +14,9 @@ export interface AuthStatusResult {
   credentialAvailable: boolean;
   credentialSource?: string;
   authenticated?: boolean;
+  embeddingsConfigured?: boolean;
+  embeddingsAuthenticated?: boolean;
+  embeddingsError?: string;
   guidance: string;
   error?: string;
 }
@@ -30,9 +34,15 @@ export interface ConnectionTestResult {
   error?: string;
 }
 
+export interface EmbeddingTestResult {
+  ok: boolean;
+  error?: string;
+}
+
 export interface StatusDeps {
   config?: AgenrConfig | null;
   connectionTestFn?: (input: ConnectionTestInput) => Promise<ConnectionTestResult>;
+  embeddingConnectionTestFn?: (apiKey: string) => Promise<EmbeddingTestResult>;
 }
 
 function buildAuthTestContext(): Context {
@@ -75,6 +85,59 @@ export async function runConnectionTest(input: ConnectionTestInput): Promise<Con
     return {
       ok: false,
       error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function runEmbeddingConnectionTest(apiKey: string): Promise<EmbeddingTestResult> {
+  try {
+    const vectors = await embed(["connection test"], apiKey);
+    if (vectors.length === 1 && vectors[0] && vectors[0].length > 0) {
+      return { ok: true };
+    }
+    return { ok: false, error: "Unexpected response: empty embedding vector" };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function runEmbeddingStatusCheck(
+  config: AgenrConfig | null | undefined,
+  env: NodeJS.ProcessEnv,
+  testFn: (apiKey: string) => Promise<EmbeddingTestResult>,
+): Promise<Pick<AuthStatusResult, "embeddingsConfigured" | "embeddingsAuthenticated" | "embeddingsError">> {
+  let embeddingApiKey: string;
+  try {
+    embeddingApiKey = resolveEmbeddingApiKey(config, env);
+  } catch {
+    return {
+      embeddingsConfigured: false,
+      embeddingsAuthenticated: false,
+    };
+  }
+
+  try {
+    const embeddingTest = await testFn(embeddingApiKey);
+    if (embeddingTest.ok) {
+      return {
+        embeddingsConfigured: true,
+        embeddingsAuthenticated: true,
+      };
+    }
+
+    return {
+      embeddingsConfigured: true,
+      embeddingsAuthenticated: false,
+      embeddingsError: embeddingTest.error,
+    };
+  } catch (error) {
+    return {
+      embeddingsConfigured: true,
+      embeddingsAuthenticated: false,
+      embeddingsError: error instanceof Error ? error.message : String(error),
     };
   }
 }
@@ -195,10 +258,16 @@ export async function getAuthStatus(
     model: quick.model,
     credentials: probe.credentials,
   });
+  const embeddings = await runEmbeddingStatusCheck(
+    loadedConfig,
+    env,
+    deps?.embeddingConnectionTestFn ?? runEmbeddingConnectionTest,
+  );
 
   if (!test.ok) {
     return {
       ...quick,
+      ...embeddings,
       authenticated: false,
       guidance: `Not authenticated. ${probe.guidance}`,
       error: test.error,
@@ -207,6 +276,7 @@ export async function getAuthStatus(
 
   return {
     ...quick,
+    ...embeddings,
     authenticated: true,
     guidance: "Authenticated.",
   };

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1115,6 +1115,16 @@ export function createProgram(): Command {
           formatLabel("Auth", status.auth ? formatAuthSummary(status.auth) : "(not set)"),
           formatLabel("Model", status.model ?? "(not set)"),
           formatLabel("Credential", status.credentialSource ?? "not found"),
+          formatLabel(
+            "Embeddings",
+            status.embeddingsConfigured === false
+              ? ui.warn("not configured")
+              : status.embeddingsAuthenticated === true
+                ? ui.success("Connected")
+                : status.embeddingsAuthenticated === false
+                  ? ui.error(status.embeddingsError ?? "Connection failed")
+                  : "(not checked)",
+          ),
           "",
           status.authenticated ? ui.success("Ready to extract") : ui.error(status.error ?? status.guidance),
         ].join("\n"),

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -82,6 +82,7 @@ vi.mock("../embeddings/client.js", () => ({
 
 import {
   buildMcpEntry,
+  formatPathForDisplay,
   formatWizardChanges,
   formatInitSummary,
   initWizardRuntime,
@@ -1889,6 +1890,18 @@ describe("buildMcpEntry", () => {
         AGENR_PROJECT_DIR: projectDir,
       },
     });
+  });
+});
+
+describe("formatPathForDisplay", () => {
+  it("does not replace sibling-prefix paths", () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/Users/al");
+    expect(formatPathForDisplay("/Users/alex/foo")).toBe("/Users/alex/foo");
+  });
+
+  it("returns ~ for exact home directory", () => {
+    vi.spyOn(os, "homedir").mockReturnValue("/Users/al");
+    expect(formatPathForDisplay("/Users/al")).toBe("~");
   });
 });
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1066,14 +1066,18 @@ describe("runInitWizard", () => {
     readConfigMock.mockReturnValue(null);
     runSetupCoreMock.mockResolvedValue(mockSetupResult());
     vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platforms);
-    vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
+    const runInitCommandSpy = vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
     clackSelectMock.mockResolvedValueOnce("openclaw").mockResolvedValueOnce("shared");
     clackTextMock.mockResolvedValueOnce("/tmp/custom-openclaw").mockResolvedValueOnce("agenr");
 
     await runInitWizard({ isInteractive: true, path: dir });
 
-    expect(platforms[0]?.configDir).toBe(path.resolve("/tmp/custom-openclaw"));
-    expect(platforms[0]?.sessionsDir).toBe(path.join(path.resolve("/tmp/custom-openclaw"), "sessions"));
+    // The wizard spreads into a new object, so verify via runInitCommand args
+    expect(runInitCommandSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: path.resolve("/tmp/custom-openclaw"),
+      }),
+    );
   });
 
   it("wizard uses OpenClaw configDir as projectDir", async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -855,13 +855,15 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
   if (hasExistingConfig) {
     const summaryLines: string[] = [];
     if (existingConfig) {
-      summaryLines.push(initWizardRuntime.formatExistingConfig(existingConfig));
-    }
-    if (existingProjectSettings.platform) {
-      summaryLines.push(`Platform: ${formatPlatformLabel(existingProjectSettings.platform)}`);
-    }
-    if (existingProjectSettings.project) {
-      summaryLines.push(`Project: ${existingProjectSettings.project}`);
+      const sharedDbPath = resolveSharedKnowledgeDbPath();
+      summaryLines.push(initWizardRuntime.formatExistingConfig(existingConfig, sharedDbPath));
+    } else {
+      if (existingProjectSettings.platform) {
+        summaryLines.push(`Platform: ${formatPlatformLabel(existingProjectSettings.platform)}`);
+      }
+      if (existingProjectSettings.project) {
+        summaryLines.push(`Project: ${existingProjectSettings.project}`);
+      }
     }
     if (summaryLines.length > 0) {
       clack.note(summaryLines.join("\n"), "Current config");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1143,18 +1143,11 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
               "  2. Use an isolated database instead of shared",
           );
 
-          const proceed = await clack.confirm({
-            message: "Continue with shared database and same project name?",
-            initialValue: false,
-          });
-          if (clack.isCancel(proceed)) {
-            clack.cancel("Setup cancelled.");
-            return;
-          }
-          if (!proceed) {
-            projectSlug = null;
-            continue;
-          }
+          projectSlug = null;
+          clack.log.info(
+            "Choose a different project name, or restart and select an isolated database for this instance.",
+          );
+          continue;
         } else if (otherSharedDiffSlug.length > 0) {
           const others = otherSharedDiffSlug
             .map(([dirPath, entry]) => `  - ${entry.project} (${formatPathForDisplay(dirPath)})`)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -536,9 +536,13 @@ export function formatInitSummary(result: InitCommandResult): string[] {
   return lines;
 }
 
-function formatPathForDisplay(filePath: string): string {
+export function formatPathForDisplay(filePath: string): string {
   const home = os.homedir();
-  return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+  if (filePath === home) {
+    return "~";
+  }
+  const homePrefix = `${home}${path.sep}`;
+  return filePath.startsWith(homePrefix) ? `~${filePath.slice(home.length)}` : filePath;
 }
 
 function resolveInputPath(value: string): string {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -566,6 +566,34 @@ function formatWizardSummary(result: WizardSummary): string {
   ].join("\n");
 }
 
+export function formatWizardChanges(changes: WizardChanges): string {
+  const items: string[] = [];
+
+  if (changes.authChanged) {
+    items.push("Auth method updated");
+  }
+  if (changes.modelChanged) {
+    const previousModel = changes.previousModel ?? "(not set)";
+    const newModel = changes.newModel ?? "(not set)";
+    items.push(`Model changed: ${previousModel} -> ${newModel}`);
+  }
+  if (changes.embeddingsKeyChanged) {
+    items.push("Embeddings API key updated");
+  }
+  if (changes.platformChanged) {
+    items.push("Platform changed");
+  }
+  if (changes.projectChanged) {
+    items.push("Project slug changed");
+  }
+
+  if (items.length === 0) {
+    return "No changes detected.";
+  }
+
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
 export async function runInitCommand(options: InitCommandOptions): Promise<InitCommandResult> {
   const projectDir = path.resolve(options.path?.trim() || process.cwd());
   if (projectDir === os.homedir()) {
@@ -881,6 +909,8 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
     "Setup summary",
   );
 
-  clack.log.info(`Wizard changes: ${JSON.stringify(wizardChanges)}`);
+  if (hasExistingConfig) {
+    clack.note(formatWizardChanges(wizardChanges), "Changes");
+  }
   clack.outro("Setup complete.");
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -799,15 +799,18 @@ export async function runInitCommand(options: InitCommandOptions): Promise<InitC
     await upsertPromptBlock(instructionsPath, buildSystemPromptBlock(project));
   }
   const { mcpPath, skipped: mcpSkipped } = await writeMcpConfig(projectDir, resolvedPlatform);
-  const gitignoreEntries = [".agenr/knowledge.db"];
-  if (resolvedPlatform === "cursor") {
-    gitignoreEntries.push(".cursor/rules/agenr.mdc");
-    if (instructionsPath !== null && isPathInsideProject(projectDir, instructionsPath)) {
-      const relativeInstructionsPath = path.relative(projectDir, instructionsPath).split(path.sep).join("/");
-      gitignoreEntries.push(relativeInstructionsPath);
+  let gitignoreUpdated = false;
+  if (resolvedPlatform !== "openclaw" && resolvedPlatform !== "codex") {
+    const gitignoreEntries = [".agenr/knowledge.db"];
+    if (resolvedPlatform === "cursor") {
+      gitignoreEntries.push(".cursor/rules/agenr.mdc");
+      if (instructionsPath !== null && isPathInsideProject(projectDir, instructionsPath)) {
+        const relativeInstructionsPath = path.relative(projectDir, instructionsPath).split(path.sep).join("/");
+        gitignoreEntries.push(relativeInstructionsPath);
+      }
     }
+    gitignoreUpdated = await addGitignoreEntries(projectDir, gitignoreEntries);
   }
-  const gitignoreUpdated = await addGitignoreEntries(projectDir, gitignoreEntries);
 
   return {
     platform: resolvedPlatform,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -488,6 +488,13 @@ function formatPlatformLabel(platform: InitPlatform | DetectedPlatform["id"]): s
   return platform;
 }
 
+export function resolveWizardProjectSlug(projectDir: string, platformId: string): string {
+  if (platformId === "openclaw" || platformId === "codex") {
+    return platformId;
+  }
+  return resolveProjectSlug(projectDir);
+}
+
 async function readExistingProjectSettings(projectDir: string): Promise<ExistingProjectSettings> {
   const configPath = path.join(projectDir, ".agenr", "config.json");
   const config = await readJsonRecord(configPath);
@@ -810,7 +817,7 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
     ? existingProjectSettings.platform !== selectedPlatform.id
     : false;
 
-  const derivedSlug = resolveProjectSlug(projectDir);
+  const derivedSlug = resolveWizardProjectSlug(projectDir, selectedPlatform.id);
   let projectSlug: string | null = null;
 
   if (existingProjectSettings.project) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -105,7 +105,6 @@ type JsonRecord = Record<string, unknown>;
 type GlobalProjectEntry = {
   project: string;
   platform: string;
-  projectDir: string;
   dbPath?: string;
   dependencies?: string[];
 };
@@ -694,7 +693,6 @@ function getGlobalProjectMap(config: AgenrConfig | null | undefined): Record<str
     out[dirKey] = {
       project: entry.project,
       platform: entry.platform,
-      projectDir: dirKey,
       ...(entry.dbPath ? { dbPath: entry.dbPath } : {}),
       ...(entry.dependencies ? { dependencies: entry.dependencies } : {}),
     };
@@ -1028,8 +1026,11 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
       return;
     }
 
-    selectedPlatform.configDir = resolveInputPath(openclawDir.trim());
-    selectedPlatform.sessionsDir = path.join(selectedPlatform.configDir, "sessions");
+    selectedPlatform = {
+      ...selectedPlatform,
+      configDir: resolveInputPath(openclawDir.trim()),
+      sessionsDir: path.join(resolveInputPath(openclawDir.trim()), "sessions"),
+    };
   }
 
   projectDir = resolveWizardProjectDir(projectDir, selectedPlatform.id, selectedPlatform.configDir);
@@ -1120,51 +1121,51 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
     if (isWizardPlatformId(selectedPlatform.id)) {
       const globalProjects = getGlobalProjectMap(readConfig(env));
 
-        if (!selectedOpenclawDbPath) {
-          const resolvedDir = path.resolve(projectDir);
-          const otherSharedEntries = Object.entries(globalProjects)
-            .filter(([dirKey, entry]) => dirKey !== resolvedDir && !entry.dbPath);
-          const otherSharedSameSlug = otherSharedEntries
-            .filter(([, entry]) => entry.project === projectSlug);
-          const otherSharedDiffSlug = otherSharedEntries
-            .filter(([, entry]) => entry.project !== projectSlug);
+      if (!selectedOpenclawDbPath) {
+        const resolvedDir = path.resolve(projectDir);
+        const otherSharedEntries = Object.entries(globalProjects)
+          .filter(([dirKey, entry]) => dirKey !== resolvedDir && !entry.dbPath);
+        const otherSharedSameSlug = otherSharedEntries
+          .filter(([, entry]) => entry.project === projectSlug);
+        const otherSharedDiffSlug = otherSharedEntries
+          .filter(([, entry]) => entry.project !== projectSlug);
 
-          if (otherSharedSameSlug.length > 0) {
-            const conflicting = otherSharedSameSlug
-              .map(([, entry]) => `  - ${formatPathForDisplay(entry.projectDir)}`)
-              .join("\n");
-            clack.log.warn(
-              `WARNING: This project uses the same name ("${projectSlug}") and the same database as:\n${conflicting}\n\n` +
-                "Entries from these instances will be completely indistinguishable.\n" +
-                "There is no way to isolate one instance's data from the other.\n\n" +
-                "To fix this, either:\n" +
-                "  1. Use a different project name for this instance\n" +
-                "  2. Use an isolated database instead of shared",
-            );
+        if (otherSharedSameSlug.length > 0) {
+          const conflicting = otherSharedSameSlug
+            .map(([dirPath]) => `  - ${formatPathForDisplay(dirPath)}`)
+            .join("\n");
+          clack.log.warn(
+            `WARNING: This project uses the same name ("${projectSlug}") and the same database as:\n${conflicting}\n\n` +
+              "Entries from these instances will be completely indistinguishable.\n" +
+              "There is no way to isolate one instance's data from the other.\n\n" +
+              "To fix this, either:\n" +
+              "  1. Use a different project name for this instance\n" +
+              "  2. Use an isolated database instead of shared",
+          );
 
-            const proceed = await clack.confirm({
-              message: "Continue with shared database and same project name?",
-              initialValue: false,
-            });
-            if (clack.isCancel(proceed)) {
-              clack.cancel("Setup cancelled.");
-              return;
-            }
-            if (!proceed) {
-              projectSlug = null;
-              continue;
-            }
-          } else if (otherSharedDiffSlug.length > 0) {
-            const others = otherSharedDiffSlug
-              .map(([, entry]) => `  - ${entry.project} (${formatPathForDisplay(entry.projectDir)})`)
-              .join("\n");
-            clack.log.info(
-              `This project shares the knowledge database with:\n${others}\n` +
-                "All projects using the shared database can see each other's knowledge.\n" +
-                "Data is separated by project tag in recall queries.",
-            );
+          const proceed = await clack.confirm({
+            message: "Continue with shared database and same project name?",
+            initialValue: false,
+          });
+          if (clack.isCancel(proceed)) {
+            clack.cancel("Setup cancelled.");
+            return;
           }
+          if (!proceed) {
+            projectSlug = null;
+            continue;
+          }
+        } else if (otherSharedDiffSlug.length > 0) {
+          const others = otherSharedDiffSlug
+            .map(([dirPath, entry]) => `  - ${entry.project} (${formatPathForDisplay(dirPath)})`)
+            .join("\n");
+          clack.log.info(
+            `This project shares the knowledge database with:\n${others}\n` +
+              "All projects using the shared database can see each other's knowledge.\n" +
+              "Data is separated by project tag in recall queries.",
+          );
         }
+      }
     }
 
     break;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -783,6 +783,29 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
     return;
   }
 
+  if (selectedPlatform.id === "openclaw") {
+    const openclawDir = await clack.text({
+      message: "OpenClaw directory:",
+      initialValue: selectedPlatform.configDir,
+      placeholder: selectedPlatform.configDir,
+      validate: (value) => {
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return "Path is required";
+        }
+        return undefined;
+      },
+    });
+
+    if (clack.isCancel(openclawDir)) {
+      clack.cancel("Setup cancelled.");
+      return;
+    }
+
+    selectedPlatform.configDir = path.resolve(openclawDir.trim());
+    selectedPlatform.sessionsDir = path.join(selectedPlatform.configDir, "sessions");
+  }
+
   wizardChanges.platformChanged = existingProjectSettings.platform
     ? existingProjectSettings.platform !== selectedPlatform.id
     : false;

--- a/src/commands/init/platform-detector.test.ts
+++ b/src/commands/init/platform-detector.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { detectPlatforms, isOnPath } from "./platform-detector.js";
+import {
+  detectPlatforms,
+  isDefaultOpenClawPath,
+  isOnPath,
+  resolveDefaultCodexConfigDir,
+  resolveDefaultOpenClawConfigDir,
+} from "./platform-detector.js";
 
 const tempDirs: string[] = [];
 
@@ -69,5 +75,35 @@ describe("isOnPath", () => {
 
   it("isOnPath returns false for nonexistent command", () => {
     expect(isOnPath("definitely-not-a-real-command-agenr")).toBe(false);
+  });
+});
+
+describe("default path helpers", () => {
+  it("resolveDefaultOpenClawConfigDir resolves from home directory", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    expect(resolveDefaultOpenClawConfigDir()).toBe(path.join(homeDir, ".openclaw"));
+  });
+
+  it("resolveDefaultCodexConfigDir resolves from home directory", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    expect(resolveDefaultCodexConfigDir()).toBe(path.join(homeDir, ".codex"));
+  });
+
+  it("isDefaultOpenClawPath returns true for default path", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    expect(isDefaultOpenClawPath(path.join(homeDir, ".openclaw"))).toBe(true);
+  });
+
+  it("isDefaultOpenClawPath returns false for custom path", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    expect(isDefaultOpenClawPath(path.join(homeDir, ".openclaw-sandbox"))).toBe(false);
   });
 });

--- a/src/commands/init/platform-detector.test.ts
+++ b/src/commands/init/platform-detector.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { detectPlatforms, isOnPath } from "./platform-detector.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(prefix = "agenr-platform-detector-"): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("detectPlatforms", () => {
+  it("detectPlatforms finds openclaw when config dir exists", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+    await fs.mkdir(path.join(homeDir, ".openclaw"), { recursive: true });
+
+    const platforms = detectPlatforms(() => false);
+    const openclaw = platforms.find((platform) => platform.id === "openclaw");
+    expect(openclaw?.detected).toBe(true);
+  });
+
+  it("detectPlatforms finds codex when config dir exists", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+    await fs.mkdir(path.join(homeDir, ".codex"), { recursive: true });
+
+    const platforms = detectPlatforms(() => false);
+    const codex = platforms.find((platform) => platform.id === "codex");
+    expect(codex?.detected).toBe(true);
+  });
+
+  it("detectPlatforms returns detected=false for missing dirs", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    const platforms = detectPlatforms(() => false);
+    expect(platforms.every((platform) => !platform.detected)).toBe(true);
+  });
+
+  it("detectPlatforms returns both openclaw and codex entries", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    const platforms = detectPlatforms(() => false);
+    expect(platforms).toHaveLength(2);
+    expect(platforms.map((platform) => platform.id)).toEqual(["openclaw", "codex"]);
+  });
+});
+
+describe("isOnPath", () => {
+  it("isOnPath returns true for node", () => {
+    expect(isOnPath("node")).toBe(true);
+  });
+
+  it("isOnPath returns false for nonexistent command", () => {
+    expect(isOnPath("definitely-not-a-real-command-agenr")).toBe(false);
+  });
+});

--- a/src/commands/init/platform-detector.test.ts
+++ b/src/commands/init/platform-detector.test.ts
@@ -69,8 +69,9 @@ describe("detectPlatforms", () => {
 });
 
 describe("isOnPath", () => {
-  it("isOnPath returns true for node", () => {
-    expect(isOnPath("node")).toBe(true);
+  it("isOnPath returns true for sh (POSIX-guaranteed)", () => {
+    if (process.platform === "win32") return;
+    expect(isOnPath("sh")).toBe(true);
   });
 
   it("isOnPath returns false for nonexistent command", () => {

--- a/src/commands/init/platform-detector.ts
+++ b/src/commands/init/platform-detector.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface DetectedPlatform {
+  id: "openclaw" | "codex";
+  label: string;
+  detected: boolean;
+  configDir: string;
+  sessionsDir: string;
+}
+
+export function detectPlatforms(pathLookup: (command: string) => boolean = isOnPath): DetectedPlatform[] {
+  const home = os.homedir();
+  const isWindows = process.platform === "win32";
+
+  const platforms: DetectedPlatform[] = [
+    {
+      id: "openclaw",
+      label: "OpenClaw",
+      detected: false,
+      configDir: isWindows
+        ? path.join(process.env.APPDATA ?? path.join(home, "AppData", "Roaming"), "openclaw")
+        : path.join(home, ".openclaw"),
+      sessionsDir: "",
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      detected: false,
+      configDir: path.join(home, ".codex"),
+      sessionsDir: "",
+    },
+  ];
+
+  for (const platform of platforms) {
+    platform.sessionsDir = path.join(platform.configDir, "sessions");
+    platform.detected = existsSync(platform.configDir) || pathLookup(platform.id);
+  }
+
+  return platforms;
+}
+
+export function isOnPath(command: string): boolean {
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    execFileSync(cmd, [command], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/commands/init/platform-detector.ts
+++ b/src/commands/init/platform-detector.ts
@@ -11,25 +11,41 @@ export interface DetectedPlatform {
   sessionsDir: string;
 }
 
-export function detectPlatforms(pathLookup: (command: string) => boolean = isOnPath): DetectedPlatform[] {
+export function resolveDefaultOpenClawConfigDir(): string {
   const home = os.homedir();
   const isWindows = process.platform === "win32";
+  return isWindows
+    ? path.join(process.env.APPDATA ?? path.join(home, "AppData", "Roaming"), "openclaw")
+    : path.join(home, ".openclaw");
+}
 
+export function resolveDefaultCodexConfigDir(): string {
+  return path.join(os.homedir(), ".codex");
+}
+
+export function isDefaultOpenClawPath(configDir: string): boolean {
+  const expected = path.resolve(resolveDefaultOpenClawConfigDir());
+  const actual = path.resolve(configDir);
+  if (process.platform === "win32") {
+    return expected.toLowerCase() === actual.toLowerCase();
+  }
+  return expected === actual;
+}
+
+export function detectPlatforms(pathLookup: (command: string) => boolean = isOnPath): DetectedPlatform[] {
   const platforms: DetectedPlatform[] = [
     {
       id: "openclaw",
       label: "OpenClaw",
       detected: false,
-      configDir: isWindows
-        ? path.join(process.env.APPDATA ?? path.join(home, "AppData", "Roaming"), "openclaw")
-        : path.join(home, ".openclaw"),
+      configDir: resolveDefaultOpenClawConfigDir(),
       sessionsDir: "",
     },
     {
       id: "codex",
       label: "Codex",
       detected: false,
-      configDir: path.join(home, ".codex"),
+      configDir: resolveDefaultCodexConfigDir(),
       sessionsDir: "",
     },
   ];

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,7 +74,7 @@ function resolveUserPath(inputPath: string): string {
   return path.join(os.homedir(), inputPath.slice(1));
 }
 
-function resolveDefaultKnowledgeDbPath(): string {
+export function resolveDefaultKnowledgeDbPath(): string {
   return path.join(os.homedir(), ".agenr", "knowledge.db");
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,7 @@ export const AUTH_METHOD_DEFINITIONS: readonly AuthMethodDefinition[] = [
     id: "openai-api-key",
     provider: "openai",
     title: "OpenAI -- API key",
-    setupDescription: "Standard API key from platform.openai.com. Pay per token.",
+    setupDescription: "Standard API key from https://platform.openai.com/api-keys. Pay per token.",
     preferredModels: ["gpt-4.1-nano", "gpt-4.1-mini", "gpt-5-nano"],
   },
 ] as const;

--- a/src/llm/credentials.ts
+++ b/src/llm/credentials.ts
@@ -283,7 +283,7 @@ export function credentialSetupGuidance(auth: AgenrAuthMethod): string {
 
   return [
     "No OpenAI API key found.",
-    "Get a key from platform.openai.com",
+    "Get a key from https://platform.openai.com/api-keys",
     "Then store it: agenr config set-key openai <key>",
   ].join(" ");
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -315,13 +315,13 @@ export async function runSetupCore(options: SetupCoreOptions): Promise<SetupResu
 
     const normalizedKey = (embeddingKey ?? "").trim();
     if (normalizedKey && options.existingConfig) {
-      const updated = setStoredCredential(options.existingConfig, "openai", normalizedKey);
-      writeConfig(updated, options.env);
-      clack.log.info("Embedding API key updated.");
       const embeddingTestResult = await runEmbeddingConnectionTestWithRetry(normalizedKey);
       if (embeddingTestResult === null) {
         return null;
       }
+      const updated = setStoredCredential(options.existingConfig, "openai", normalizedKey);
+      writeConfig(updated, options.env);
+      clack.log.info("Embedding API key updated.");
 
       let embeddingStatus: string;
       try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,15 @@ export interface AgenrConfig {
   provider?: AgenrProvider;
   model?: string;
   labelProjectMap?: Record<string, string>;
+  projects?: Record<
+    string,
+    {
+      platform: string;
+      projectDir: string;
+      dbPath?: string;
+      dependencies?: string[];
+    }
+  >;
   forgetting?: {
     protect?: string[];
     scoreThreshold?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,8 +49,8 @@ export interface AgenrConfig {
   projects?: Record<
     string,
     {
+      project: string;
       platform: string;
-      projectDir: string;
       dbPath?: string;
       dependencies?: string[];
     }

--- a/tests/auth-status.test.ts
+++ b/tests/auth-status.test.ts
@@ -1,8 +1,54 @@
-import { describe, expect, it } from "vitest";
-import { getAuthStatus } from "../src/auth-status.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { embedMock } = vi.hoisted(() => ({
+  embedMock: vi.fn(),
+}));
+
+vi.mock("../src/embeddings/client.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/embeddings/client.js")>("../src/embeddings/client.js");
+  return {
+    ...actual,
+    embed: embedMock,
+  };
+});
+
+import { getAuthStatus, runEmbeddingConnectionTest } from "../src/auth-status.js";
 import type { AgenrConfig } from "../src/types.js";
 
 describe("auth status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runEmbeddingConnectionTest returns ok:true with valid key", async () => {
+    embedMock.mockResolvedValueOnce([[0.1, 0.2, 0.3]]);
+
+    const result = await runEmbeddingConnectionTest("sk-valid");
+
+    expect(result).toEqual({ ok: true });
+    expect(embedMock).toHaveBeenCalledWith(["connection test"], "sk-valid");
+  });
+
+  it("runEmbeddingConnectionTest returns ok:false with invalid key", async () => {
+    embedMock.mockRejectedValueOnce(new Error("OpenAI embeddings request failed (401): invalid API key"));
+
+    const result = await runEmbeddingConnectionTest("sk-invalid");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("401");
+  });
+
+  it("runEmbeddingConnectionTest returns ok:false on empty vector", async () => {
+    embedMock.mockResolvedValueOnce([[]]);
+
+    const result = await runEmbeddingConnectionTest("sk-empty");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Unexpected response: empty embedding vector",
+    });
+  });
+
   it("returns not configured when config is missing", async () => {
     const status = await getAuthStatus(process.env, {
       config: null,
@@ -47,11 +93,14 @@ describe("auth status", () => {
     const status = await getAuthStatus(process.env, {
       config,
       connectionTestFn: async () => ({ ok: true }),
+      embeddingConnectionTestFn: async () => ({ ok: true }),
     });
 
     expect(status.configured).toBe(true);
     expect(status.credentialAvailable).toBe(true);
     expect(status.authenticated).toBe(true);
+    expect(status.embeddingsConfigured).toBe(true);
+    expect(status.embeddingsAuthenticated).toBe(true);
   });
 
   it("returns not authenticated when live test fails", async () => {
@@ -67,9 +116,12 @@ describe("auth status", () => {
     const status = await getAuthStatus(process.env, {
       config,
       connectionTestFn: async () => ({ ok: false, error: "invalid key" }),
+      embeddingConnectionTestFn: async () => ({ ok: true }),
     });
 
     expect(status.authenticated).toBe(false);
     expect(status.error).toContain("invalid key");
+    expect(status.embeddingsConfigured).toBe(true);
+    expect(status.embeddingsAuthenticated).toBe(true);
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -226,13 +226,13 @@ describe("config", () => {
   it("normalizeConfig preserves valid projects map", () => {
     const normalized = normalizeConfig({
       projects: {
-        openclaw: {
+        "/Users/jmartin/.openclaw": {
+          project: "openclaw",
           platform: "openclaw",
-          projectDir: "/Users/jmartin/.openclaw",
         },
-        "openclaw-sandbox": {
+        "/Users/jmartin/.openclaw-sandbox": {
+          project: "openclaw",
           platform: "openclaw",
-          projectDir: "/Users/jmartin/.openclaw-sandbox",
           dbPath: "/Users/jmartin/.openclaw-sandbox/agenr-data/knowledge.db",
           dependencies: ["shared-brain", "workspace-x"],
         },
@@ -240,13 +240,13 @@ describe("config", () => {
     });
 
     expect(normalized.projects).toEqual({
-      openclaw: {
+      "/Users/jmartin/.openclaw": {
+        project: "openclaw",
         platform: "openclaw",
-        projectDir: "/Users/jmartin/.openclaw",
       },
-      "openclaw-sandbox": {
+      "/Users/jmartin/.openclaw-sandbox": {
+        project: "openclaw",
         platform: "openclaw",
-        projectDir: "/Users/jmartin/.openclaw-sandbox",
         dbPath: "/Users/jmartin/.openclaw-sandbox/agenr-data/knowledge.db",
         dependencies: ["shared-brain", "workspace-x"],
       },
@@ -256,23 +256,53 @@ describe("config", () => {
   it("normalizeConfig drops malformed project entries", () => {
     const normalized = normalizeConfig({
       projects: {
-        valid: {
+        "/Users/jmartin/.openclaw": {
+          project: "openclaw",
           platform: "openclaw",
-          projectDir: "/Users/jmartin/.openclaw",
         },
-        missingPlatform: {
-          projectDir: "/Users/jmartin/.openclaw-sandbox",
+        "/Users/jmartin/.missing-platform": {
+          project: "openclaw-sandbox",
         },
-        missingProjectDir: {
+        "/Users/jmartin/.missing-project": {
           platform: "openclaw",
         },
       },
     });
 
     expect(normalized.projects).toEqual({
-      valid: {
+      "/Users/jmartin/.openclaw": {
+        project: "openclaw",
         platform: "openclaw",
-        projectDir: "/Users/jmartin/.openclaw",
+      },
+    });
+  });
+
+  it("normalizeConfig validates project field in entries", () => {
+    const normalized = normalizeConfig({
+      projects: {
+        "/Users/jmartin/.openclaw": {
+          platform: "openclaw",
+        },
+      },
+    });
+
+    expect(normalized.projects).toBeUndefined();
+  });
+
+  it("normalizeConfig migrates legacy slug-keyed project entries", () => {
+    const normalized = normalizeConfig({
+      projects: {
+        openclaw: {
+          platform: "openclaw",
+          projectDir: "/Users/jmartin/.openclaw",
+        },
+      },
+    });
+
+    expect(normalized.projects).toEqual({
+      "/Users/jmartin/.openclaw": {
+        project: "openclaw",
+        platform: "openclaw",
       },
     });
   });
@@ -312,15 +342,15 @@ describe("normalizeConfig dedup", () => {
 });
 
 describe("resolveProjectFromGlobalConfig", () => {
-  it("returns matching entry", async () => {
+  it("does direct key lookup", async () => {
     const configPath = await makeTempConfigPath();
     const env = makeEnv(configPath);
     writeConfig(
       {
         projects: {
-          "openclaw-sandbox": {
+          "/Users/jmartin/.openclaw-sandbox": {
+            project: "openclaw",
             platform: "openclaw",
-            projectDir: "/Users/jmartin/.openclaw-sandbox",
             dbPath: "/Users/jmartin/.openclaw-sandbox/agenr-data/knowledge.db",
           },
         },
@@ -330,7 +360,7 @@ describe("resolveProjectFromGlobalConfig", () => {
 
     const resolved = resolveProjectFromGlobalConfig("/Users/jmartin/.openclaw-sandbox", env);
     expect(resolved).toEqual({
-      slug: "openclaw-sandbox",
+      slug: "openclaw",
       platform: "openclaw",
       dbPath: "/Users/jmartin/.openclaw-sandbox/agenr-data/knowledge.db",
     });
@@ -342,9 +372,9 @@ describe("resolveProjectFromGlobalConfig", () => {
     writeConfig(
       {
         projects: {
-          openclaw: {
+          "/Users/jmartin/.openclaw": {
+            project: "openclaw",
             platform: "openclaw",
-            projectDir: "/Users/jmartin/.openclaw",
           },
         },
       },

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -116,6 +116,99 @@ beforeEach(() => {
   current.runEmbeddingConnectionTestMock.mockResolvedValue({ ok: true });
 });
 
+describe("formatExistingConfig", () => {
+  it("shows projects when they exist", () => {
+    const sharedDbPath = path.join(os.homedir(), ".agenr", "knowledge.db");
+    const formatted = setupModule.formatExistingConfig(
+      {
+        auth: "openai-api-key",
+        provider: "openai",
+        model: "openai/gpt-4.1",
+        projects: {
+          [path.join(os.homedir(), ".openclaw")]: {
+            project: "openclaw",
+            platform: "openclaw",
+          },
+          [path.join(os.homedir(), ".openclaw-sandbox")]: {
+            project: "openclaw",
+            platform: "openclaw",
+            dbPath: path.join(os.homedir(), ".openclaw-sandbox", "agenr-data", "knowledge.db"),
+          },
+        },
+      },
+      sharedDbPath,
+    );
+
+    expect(formatted).toContain("Projects:");
+    expect(formatted).toContain("  openclaw");
+    expect(formatted).toContain("    Directory: ~/.openclaw");
+    expect(formatted).toContain("    Directory: ~/.openclaw-sandbox");
+  });
+
+  it("omits projects section when none exist", () => {
+    const formatted = setupModule.formatExistingConfig({
+      auth: "openai-api-key",
+      provider: "openai",
+      model: "openai/gpt-4.1",
+    });
+
+    expect(formatted).not.toContain("Projects:");
+  });
+
+  it("shows isolated and shared labels", () => {
+    const sharedDbPath = path.join(os.homedir(), ".agenr", "knowledge.db");
+    const formatted = setupModule.formatExistingConfig(
+      {
+        auth: "openai-api-key",
+        provider: "openai",
+        model: "openai/gpt-4.1",
+        projects: {
+          "/tmp/openclaw-main": {
+            project: "openclaw",
+            platform: "openclaw",
+          },
+          "/tmp/openclaw-sandbox": {
+            project: "openclaw",
+            platform: "openclaw",
+            dbPath: "/tmp/openclaw-sandbox/agenr-data/knowledge.db",
+          },
+        },
+      },
+      sharedDbPath,
+    );
+
+    expect(formatted).toContain("~/.agenr/knowledge.db (shared)");
+    expect(formatted).toContain("/tmp/openclaw-sandbox/agenr-data/knowledge.db (isolated)");
+  });
+
+  it("shows tilde paths for home directory", () => {
+    const sharedDbPath = path.join(os.homedir(), ".agenr", "knowledge.db");
+    const formatted = setupModule.formatExistingConfig(
+      {
+        auth: "openai-api-key",
+        provider: "openai",
+        model: "openai/gpt-4.1",
+        projects: {
+          [path.join(os.homedir(), ".openclaw")]: {
+            project: "openclaw",
+            platform: "openclaw",
+          },
+          [path.join(os.homedir(), ".openclaw-sandbox")]: {
+            project: "openclaw",
+            platform: "openclaw",
+            dbPath: path.join(os.homedir(), ".openclaw-sandbox", "agenr-data", "knowledge.db"),
+          },
+        },
+      },
+      sharedDbPath,
+    );
+
+    expect(formatted).toContain("Directory: ~/.openclaw-sandbox");
+    expect(formatted).toContain("Database:  ~/.openclaw-sandbox/agenr-data/knowledge.db (isolated)");
+    expect(formatted).toContain("~/.agenr/knowledge.db");
+  });
+});
+
 describe("runSetupCore", () => {
   it("returns SetupResult with auth, provider, model on success", async () => {
     const mocks = getMocks();


### PR DESCRIPTION
## Summary

Interactive onboarding wizard for `agenr init` - Phase 2 of #170.

### Features
- **Auth setup** with API key links and connection testing (extraction + embeddings)
- **Platform auto-detection** for OpenClaw and Codex (macOS, Linux, Windows)
- **OpenClaw directory confirmation** with custom path support
- **DB isolation prompt** for non-default OpenClaw paths (shared vs isolated)
- **Global projects map** in `~/.agenr/config.json` keyed by directory path
  - Multiple instances can share the same project slug with isolated databases
  - Per-repo platforms (Cursor, Claude Code, Windsurf) unchanged
- **Reconfigure mode** with change tracking for auth, model, embeddings, directory, and DB path
- **Current config display** shows all registered projects with directories and DB isolation status
- **Shared DB warning** when same project slug and same database across instances (blocking confirm)

### Changed
- Extracted `runSetupCore()` from setup.ts for programmatic use
- Subscription auth methods moved to "Advanced options" submenu
- Default recommended model changed to gpt-4.1-mini
- Skip .gitignore writes for OpenClaw and Codex (not git repos)

### Fixed
- Test isolation: init wizard tests use isolated config path via `AGENR_CONFIG_PATH`

### Stats
- 14 files changed, ~3000 lines added
- 1270 tests passing (95 test files)
- Version: 0.9.0

Closes phase 2 of #170. Phase 3 (plugin install, ingest, watcher, re-ingest) will follow as a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive onboarding wizard with platform auto-detection (OpenClaw/Codex), custom paths, project slug editing, DB isolation prompts, reconfigure mode, and a global projects map (~/.agenr/config.json) for multi-instance visibility
  * Embeddings connectivity checks surfaced in CLI status and during setup with retry/cancel support

* **Changes**
  * Default model updated to gpt-4.1-mini
  * Current-config display now lists registered project directories and DB isolation/shared status

* **Bug Fixes**
  * Improved test isolation and embedding test retry/validation handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->