### PR TITLE
fix(init): OpenClaw plugin install reliability (#170 Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
 
 ### Fixed
 - Test isolation: init wizard tests use isolated config path via `AGENR_CONFIG_PATH`
+- fix(init): `installOpenClawPlugin` now passes `OPENCLAW_HOME` env to all
+  OpenClaw CLI calls, preventing production config overwrites when targeting
+  a non-default directory (e.g. sandbox)
 
 ## [0.8.40] - 2026-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 - fix(init): `installOpenClawPlugin` now passes `OPENCLAW_HOME` env to all
   OpenClaw CLI calls, preventing production config overwrites when targeting
   a non-default directory (e.g. sandbox)
+- fix(init): wizard now adds `"agenr"` to `plugins.allow` in the target
+  OpenClaw config, ensuring the plugin is explicitly trusted and suppressing
+  the auto-load warning
 
 ## [0.8.40] - 2026-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@
 - Current config display shows all registered projects with directories and DB isolation status
 - `resolveProjectFromGlobalConfig()` helper for O(1) project lookup by directory
 - Shared DB warning when same project slug and same database across instances
+- Fix: OpenClaw sessionsDir correctly resolves to agents/main/sessions
+- OpenClaw plugin auto-install with gateway restart during wizard
+- Isolated DB path auto-written to OpenClaw plugin config (no manual editing)
+- Session file scanner with recursive discovery, mtime filtering, size totals
+- Cost estimation before ingest using model pricing from @mariozechner/pi-ai
+- "Recent" ingest passes only last-7-day file paths; "full" uses directory glob
+- Bulk ingest integration (--workers 10 --concurrency 1 --whole-file)
+- Post-ingest consolidation prompt (merges near-duplicates from bulk ingest)
+- Watcher daemon setup on macOS with launchd (120s interval)
+- Re-ingest flow on model/auth change: stops watcher, resets DB, re-ingests
+- Expanded setup summary with plugin/ingest/consolidate/watcher status
+- Next steps section for skipped or failed wizard steps
 
 ### Changed
 - Refactored setup.ts: extracted `runSetupCore()` for programmatic use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,9 @@
 
 ### Fixed
 - Test isolation: init wizard tests use isolated config path via `AGENR_CONFIG_PATH`
-- fix(init): `installOpenClawPlugin` now passes `OPENCLAW_HOME` env to all
-  OpenClaw CLI calls, preventing production config overwrites when targeting
-  a non-default directory (e.g. sandbox)
+- fix(init): `installOpenClawPlugin` no longer forces the `OPENCLAW_HOME`
+  environment variable on OpenClaw CLI calls, preventing production config
+  overwrites when targeting a non-default directory (e.g. sandbox)
 - fix(init): wizard now adds `"agenr"` to `plugins.allow` in the target
   OpenClaw config, ensuring the plugin is explicitly trusted and suppressing
   the auto-load warning

--- a/scripts/setup-test-openclaw.sh
+++ b/scripts/setup-test-openclaw.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Creates a clean OpenClaw test instance that mimics a normal user setup.
 # OPENCLAW_HOME=~/.openclaw-testenv
 # Config at ~/.openclaw-testenv/.openclaw/openclaw.json (OpenClaw's standard layout)
@@ -7,6 +8,8 @@
 
 TEST_HOME="$HOME/.openclaw-testenv"
 PORT=18791
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 case "${1:-start}" in
   start)
@@ -41,7 +44,7 @@ EOF
     echo "  OPENCLAW_HOME=$TEST_HOME openclaw gateway"
     echo ""
     echo "Terminal 2 - Run wizard:"
-    echo "  cd ~/Code/agenr && node dist/cli.js init"
+    echo "  cd $REPO_ROOT && node dist/cli.js init"
     echo ""
     echo "When the wizard asks for OpenClaw directory, enter:"
     echo "  $TEST_HOME"

--- a/scripts/setup-test-openclaw.sh
+++ b/scripts/setup-test-openclaw.sh
@@ -59,7 +59,7 @@ EOF
       exit 0
     fi
 
-    PID=$(lsof -ti :$PORT 2>/dev/null)
+    PID=$(lsof -ti :$PORT 2>/dev/null || true)
     if [ -n "$PID" ]; then
       echo "Stopping gateway (PID $PID)..."
       kill "$PID" 2>/dev/null

--- a/scripts/setup-test-openclaw.sh
+++ b/scripts/setup-test-openclaw.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Creates a clean OpenClaw test instance that mimics a normal user setup.
+# OPENCLAW_HOME=~/.openclaw-testenv
+# Config at ~/.openclaw-testenv/.openclaw/openclaw.json (OpenClaw's standard layout)
+# Sessions at ~/.openclaw-testenv/.openclaw/agents/main/sessions
+# Usage: ./setup-test-openclaw.sh [start|clean]
+
+TEST_HOME="$HOME/.openclaw-testenv"
+PORT=18791
+
+case "${1:-start}" in
+  start)
+    if [ -d "$TEST_HOME" ]; then
+      echo "Test instance already exists at $TEST_HOME"
+      echo "Run: $0 clean   to remove it first"
+      exit 1
+    fi
+
+    mkdir -p "$TEST_HOME/.openclaw/agents/main/sessions"
+    cat > "$TEST_HOME/.openclaw/openclaw.json" << EOF
+{
+  "gateway": {
+    "port": $PORT,
+    "mode": "local",
+    "bind": "loopback",
+    "controlUi": {
+      "enabled": true,
+      "dangerouslyDisableDeviceAuth": true
+    },
+    "auth": {
+      "mode": "token",
+      "token": "$(openssl rand -hex 24)"
+    }
+  }
+}
+EOF
+
+    echo "Created test OpenClaw instance at $TEST_HOME"
+    echo ""
+    echo "Terminal 1 - Start gateway:"
+    echo "  OPENCLAW_HOME=$TEST_HOME openclaw gateway"
+    echo ""
+    echo "Terminal 2 - Run wizard:"
+    echo "  cd ~/Code/agenr && node dist/cli.js init"
+    echo ""
+    echo "When the wizard asks for OpenClaw directory, enter:"
+    echo "  $TEST_HOME"
+    echo ""
+    echo "Clean up when done:"
+    echo "  $0 clean"
+    ;;
+
+  clean)
+    if [ ! -d "$TEST_HOME" ]; then
+      echo "No test instance found at $TEST_HOME"
+      exit 0
+    fi
+
+    PID=$(lsof -ti :$PORT 2>/dev/null)
+    if [ -n "$PID" ]; then
+      echo "Stopping gateway (PID $PID)..."
+      kill "$PID" 2>/dev/null
+      sleep 1
+    fi
+
+    rm -rf "$TEST_HOME"
+    echo "Cleaned up $TEST_HOME"
+    ;;
+
+  *)
+    echo "Usage: $0 [start|clean]"
+    exit 1
+    ;;
+esac

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -2013,7 +2013,7 @@ describe("runInitWizard", () => {
     );
   });
 
-  it("wizard skips dbPath write for shared DB", async () => {
+  it("wizard calls writeOpenClawPluginDbPath with undefined dbPath for shared DB", async () => {
     const dir = await createWizardProjectDir();
     const customDir = "/tmp/.openclaw-shared";
     const writeSpy = vi.spyOn(initWizardRuntime, "writeOpenClawPluginDbPath");
@@ -2030,7 +2030,10 @@ describe("runInitWizard", () => {
 
     await runInitWizard({ isInteractive: true, path: dir });
 
-    expect(writeSpy).not.toHaveBeenCalled();
+    expect(writeSpy).toHaveBeenCalledWith(
+      path.resolve(customDir),
+      undefined,
+    );
   });
 
   it("wizard offers re-ingest when model changed", async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -806,6 +806,13 @@ async function writeOpenClawPluginDbPath(
     config.plugins = {};
   }
   const plugins = config.plugins as JsonRecord;
+  if (!Array.isArray(plugins.allow)) {
+    plugins.allow = [];
+  }
+  const allow = plugins.allow as string[];
+  if (!allow.includes("agenr")) {
+    allow.push("agenr");
+  }
   if (!isRecord(plugins.entries)) {
     plugins.entries = {};
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -702,8 +702,9 @@ function findBinaryPath(name: string): string | null {
 }
 
 async function installOpenClawPlugin(
-  _openclawConfigDir: string,
+  openclawConfigDir: string,
 ): Promise<PluginInstallResult> {
+  const env = { ...process.env, OPENCLAW_HOME: openclawConfigDir };
   const openclawBin = findBinaryPath("openclaw");
   if (!openclawBin) {
     return {
@@ -718,6 +719,7 @@ async function installOpenClawPlugin(
     const listOutput = execFileSync(openclawBin, ["plugins", "list"], {
       encoding: "utf8",
       timeout: 15000,
+      env,
     });
     if (listOutput.includes("agenr") && listOutput.includes("loaded")) {
       return { success: true, message: "agenr plugin already installed" };
@@ -730,6 +732,7 @@ async function installOpenClawPlugin(
     execFileSync(openclawBin, ["plugins", "install", "agenr"], {
       encoding: "utf8",
       timeout: 60000,
+      env,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -738,6 +741,7 @@ async function installOpenClawPlugin(
         execFileSync(openclawBin, ["plugins", "update", "agenr"], {
           encoding: "utf8",
           timeout: 60000,
+          env,
         });
       } catch {
         return {
@@ -759,6 +763,7 @@ async function installOpenClawPlugin(
     execFileSync(openclawBin, ["gateway", "restart"], {
       encoding: "utf8",
       timeout: 30000,
+      env,
     });
     return { success: true, message: "Plugin installed and gateway restarted" };
   } catch {
@@ -766,6 +771,7 @@ async function installOpenClawPlugin(
       execFileSync(openclawBin, ["gateway", "start"], {
         encoding: "utf8",
         timeout: 30000,
+        env,
       });
       return { success: true, message: "Plugin installed and gateway started" };
     } catch {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -787,7 +787,7 @@ async function installOpenClawPlugin(
 
 async function writeOpenClawPluginDbPath(
   openclawConfigDir: string,
-  dbPath: string,
+  dbPath: string | undefined,
 ): Promise<void> {
   const configPath = path.join(openclawConfigDir, "openclaw.json");
   let config: JsonRecord = {};
@@ -825,7 +825,9 @@ async function writeOpenClawPluginDbPath(
     agenr.config = {};
   }
   const agenrConfig = agenr.config as JsonRecord;
-  agenrConfig.dbPath = dbPath;
+  if (dbPath) {
+    agenrConfig.dbPath = dbPath;
+  }
 
   await fs.mkdir(openclawConfigDir, { recursive: true });
   await fs.writeFile(
@@ -1417,14 +1419,16 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
     spinner.stop(pluginResult.message);
     pluginStatus = pluginResult.message;
 
-    if (pluginResult.success && selectedOpenclawDbPath) {
+    if (pluginResult.success) {
       await initWizardRuntime.writeOpenClawPluginDbPath(
         selectedPlatform.configDir,
         selectedOpenclawDbPath,
       );
-      clack.log.info(
-        `Configured isolated database: ${formatPathForDisplay(selectedOpenclawDbPath)}`,
-      );
+      if (selectedOpenclawDbPath) {
+        clack.log.info(
+          `Configured isolated database: ${formatPathForDisplay(selectedOpenclawDbPath)}`,
+        );
+      }
     }
   }
 

--- a/src/commands/init/cost-estimator.test.ts
+++ b/src/commands/init/cost-estimator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateIngestCost,
+  formatCostUsd,
+  formatTokenCount,
+} from "./cost-estimator.js";
+
+describe("estimateIngestCost", () => {
+  it("estimateIngestCost calculates token count from bytes", () => {
+    const estimate = estimateIngestCost(4000, "gpt-4.1-mini", "openai");
+    expect(estimate.inputTokens).toBe(1000);
+  });
+
+  it("estimateIngestCost calculates output tokens at 10%", () => {
+    const estimate = estimateIngestCost(4000, "gpt-4.1-mini", "openai");
+    expect(estimate.outputTokens).toBe(100);
+  });
+
+  it("estimateIngestCost uses model cost data for gpt-4.1-mini", () => {
+    const estimate = estimateIngestCost(4000, "gpt-4.1-mini", "openai");
+    expect(estimate.inputCostUsd).toBeCloseTo(0.0004, 10);
+    expect(estimate.outputCostUsd).toBeCloseTo(0.00016, 10);
+    expect(estimate.totalCostUsd).toBeCloseTo(0.00056, 10);
+  });
+
+  it("estimateIngestCost strips provider prefix from model ID", () => {
+    const prefixed = estimateIngestCost(4000, "openai/gpt-4.1-mini", "openai");
+    const bare = estimateIngestCost(4000, "gpt-4.1-mini", "openai");
+    expect(prefixed.inputCostUsd).toBeCloseTo(bare.inputCostUsd, 10);
+    expect(prefixed.outputCostUsd).toBeCloseTo(bare.outputCostUsd, 10);
+    expect(prefixed.totalCostUsd).toBeCloseTo(bare.totalCostUsd, 10);
+  });
+
+  it("estimateIngestCost returns zero cost for unknown model", () => {
+    const estimate = estimateIngestCost(4000, "nonexistent-model", "openai");
+    expect(estimate.totalCostUsd).toBe(0);
+  });
+});
+
+describe("formatCostUsd", () => {
+  it("formatCostUsd returns <$0.01 for tiny amounts", () => {
+    expect(formatCostUsd(0.001)).toBe("<$0.01");
+  });
+
+  it("formatCostUsd formats dollars with 2 decimal places", () => {
+    expect(formatCostUsd(1.234)).toBe("~$1.23");
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("formatTokenCount formats thousands as K", () => {
+    expect(formatTokenCount(5000)).toBe("~5K");
+  });
+
+  it("formatTokenCount formats millions as M", () => {
+    expect(formatTokenCount(1_500_000)).toBe("~1.5M");
+  });
+
+  it("formatTokenCount returns raw number for small counts", () => {
+    expect(formatTokenCount(500)).toBe("500");
+  });
+});

--- a/src/commands/init/cost-estimator.test.ts
+++ b/src/commands/init/cost-estimator.test.ts
@@ -35,6 +35,15 @@ describe("estimateIngestCost", () => {
     const estimate = estimateIngestCost(4000, "nonexistent-model", "openai");
     expect(estimate.totalCostUsd).toBe(0);
   });
+
+  it("estimateIngestCost clamps invalid byte sizes to zero", () => {
+    for (const input of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const estimate = estimateIngestCost(input, "gpt-4.1-mini", "openai");
+      expect(estimate.inputTokens).toBe(0);
+      expect(estimate.outputTokens).toBe(0);
+      expect(estimate.totalCostUsd).toBe(0);
+    }
+  });
 });
 
 describe("formatCostUsd", () => {

--- a/src/commands/init/cost-estimator.ts
+++ b/src/commands/init/cost-estimator.ts
@@ -18,6 +18,7 @@ export function estimateIngestCost(
   modelId: string,
   provider: AgenrProvider,
 ): CostEstimate {
+  const safeTotalBytes = Number.isFinite(totalBytes) && totalBytes > 0 ? totalBytes : 0;
   const bareModelId = modelId.includes("/")
     ? modelId.slice(modelId.indexOf("/") + 1)
     : modelId;
@@ -28,7 +29,7 @@ export function estimateIngestCost(
   const inputCostPerMillion = model?.cost?.input ?? 0;
   const outputCostPerMillion = model?.cost?.output ?? 0;
 
-  const inputTokens = Math.ceil(totalBytes / CHARS_PER_TOKEN);
+  const inputTokens = Math.ceil(safeTotalBytes / CHARS_PER_TOKEN);
   const outputTokens = Math.ceil(inputTokens * OUTPUT_TOKEN_RATIO);
 
   const inputCostUsd = (inputTokens / 1_000_000) * inputCostPerMillion;

--- a/src/commands/init/cost-estimator.ts
+++ b/src/commands/init/cost-estimator.ts
@@ -1,0 +1,62 @@
+import { getModels } from "@mariozechner/pi-ai";
+import type { AgenrProvider } from "../../types.js";
+
+export interface CostEstimate {
+  inputTokens: number;
+  outputTokens: number;
+  inputCostUsd: number;
+  outputCostUsd: number;
+  totalCostUsd: number;
+  modelId: string;
+}
+
+const CHARS_PER_TOKEN = 4;
+const OUTPUT_TOKEN_RATIO = 0.1;
+
+export function estimateIngestCost(
+  totalBytes: number,
+  modelId: string,
+  provider: AgenrProvider,
+): CostEstimate {
+  const bareModelId = modelId.includes("/")
+    ? modelId.slice(modelId.indexOf("/") + 1)
+    : modelId;
+
+  const models = getModels(provider);
+  const model = models.find((entry) => entry.id === bareModelId);
+
+  const inputCostPerMillion = model?.cost?.input ?? 0;
+  const outputCostPerMillion = model?.cost?.output ?? 0;
+
+  const inputTokens = Math.ceil(totalBytes / CHARS_PER_TOKEN);
+  const outputTokens = Math.ceil(inputTokens * OUTPUT_TOKEN_RATIO);
+
+  const inputCostUsd = (inputTokens / 1_000_000) * inputCostPerMillion;
+  const outputCostUsd = (outputTokens / 1_000_000) * outputCostPerMillion;
+
+  return {
+    inputTokens,
+    outputTokens,
+    inputCostUsd,
+    outputCostUsd,
+    totalCostUsd: inputCostUsd + outputCostUsd,
+    modelId,
+  };
+}
+
+export function formatCostUsd(cost: number): string {
+  if (cost < 0.01) {
+    return "<$0.01";
+  }
+  return `~$${cost.toFixed(2)}`;
+}
+
+export function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) {
+    return `${tokens}`;
+  }
+  if (tokens < 1_000_000) {
+    return `~${Math.round(tokens / 1000)}K`;
+  }
+  return `~${(tokens / 1_000_000).toFixed(1)}M`;
+}

--- a/src/commands/init/platform-detector.test.ts
+++ b/src/commands/init/platform-detector.test.ts
@@ -66,6 +66,16 @@ describe("detectPlatforms", () => {
     expect(platforms).toHaveLength(2);
     expect(platforms.map((platform) => platform.id)).toEqual(["openclaw", "codex"]);
   });
+
+  it("OpenClaw platform sessionsDir includes agents/main/sessions", async () => {
+    const homeDir = await createTempDir();
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    const platforms = detectPlatforms(() => false);
+    const openclaw = platforms.find((platform) => platform.id === "openclaw");
+
+    expect(openclaw?.sessionsDir).toBe(path.join(homeDir, ".openclaw", "agents", "main", "sessions"));
+  });
 });
 
 describe("isOnPath", () => {

--- a/src/commands/init/platform-detector.ts
+++ b/src/commands/init/platform-detector.ts
@@ -51,7 +51,10 @@ export function detectPlatforms(pathLookup: (command: string) => boolean = isOnP
   ];
 
   for (const platform of platforms) {
-    platform.sessionsDir = path.join(platform.configDir, "sessions");
+    platform.sessionsDir =
+      platform.id === "openclaw"
+        ? path.join(platform.configDir, "agents", "main", "sessions")
+        : path.join(platform.configDir, "sessions");
     platform.detected = existsSync(platform.configDir) || pathLookup(platform.id);
   }
 

--- a/src/commands/init/session-scanner.test.ts
+++ b/src/commands/init/session-scanner.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { scanSessionFiles } from "./session-scanner.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(prefix = "agenr-session-scan-"): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeFileWithContent(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf8");
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("scanSessionFiles", () => {
+  it("scanSessionFiles finds .jsonl files in directory", async () => {
+    const sessionsDir = await createTempDir();
+    const fileA = path.join(sessionsDir, "a.jsonl");
+    const fileB = path.join(sessionsDir, "b.jsonl");
+    await writeFileWithContent(fileA, "a");
+    await writeFileWithContent(fileB, "b");
+
+    const result = await scanSessionFiles(sessionsDir);
+
+    expect(result.totalFiles).toBe(2);
+    expect([...result.allFiles].sort()).toEqual([fileA, fileB].sort());
+  });
+
+  it("scanSessionFiles finds .jsonl.gz files", async () => {
+    const sessionsDir = await createTempDir();
+    const gzFile = path.join(sessionsDir, "compressed.jsonl.gz");
+    await writeFileWithContent(gzFile, "gz-content");
+
+    const result = await scanSessionFiles(sessionsDir);
+
+    expect(result.totalFiles).toBe(1);
+    expect(result.allFiles).toEqual([gzFile]);
+  });
+
+  it("scanSessionFiles filters recent files by mtime", async () => {
+    const sessionsDir = await createTempDir();
+    const recentFile = path.join(sessionsDir, "recent.jsonl");
+    const oldFile = path.join(sessionsDir, "old.jsonl");
+    await writeFileWithContent(recentFile, "recent");
+    await writeFileWithContent(oldFile, "old");
+
+    const oldTime = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+    await fs.utimes(oldFile, oldTime, oldTime);
+
+    const result = await scanSessionFiles(sessionsDir, 7);
+
+    expect(result.totalFiles).toBe(2);
+    expect(result.recentFiles).toEqual([recentFile]);
+  });
+
+  it("scanSessionFiles returns empty result for missing directory", async () => {
+    const missingDir = path.join(os.tmpdir(), `agenr-missing-${Date.now()}-${Math.random()}`);
+    const result = await scanSessionFiles(missingDir);
+
+    expect(result.totalFiles).toBe(0);
+    expect(result.recentFiles).toEqual([]);
+    expect(result.allFiles).toEqual([]);
+    expect(result.totalSizeBytes).toBe(0);
+    expect(result.recentSizeBytes).toBe(0);
+  });
+
+  it("scanSessionFiles ignores non-jsonl files", async () => {
+    const sessionsDir = await createTempDir();
+    await writeFileWithContent(path.join(sessionsDir, "notes.txt"), "text");
+    await writeFileWithContent(path.join(sessionsDir, "data.json"), "{}");
+    await writeFileWithContent(path.join(sessionsDir, "valid.jsonl"), "ok");
+
+    const result = await scanSessionFiles(sessionsDir);
+
+    expect(result.totalFiles).toBe(1);
+    expect(result.allFiles).toEqual([path.join(sessionsDir, "valid.jsonl")]);
+  });
+
+  it("scanSessionFiles calculates total and recent size", async () => {
+    const sessionsDir = await createTempDir();
+    const recentFile = path.join(sessionsDir, "recent.jsonl");
+    const oldFile = path.join(sessionsDir, "old.jsonl");
+    await writeFileWithContent(recentFile, "12345");
+    await writeFileWithContent(oldFile, "1234567890");
+
+    const oldTime = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+    await fs.utimes(oldFile, oldTime, oldTime);
+
+    const result = await scanSessionFiles(sessionsDir, 7);
+
+    expect(result.totalSizeBytes).toBe(15);
+    expect(result.recentSizeBytes).toBe(5);
+  });
+
+  it("scanSessionFiles discovers files in nested subdirectories", async () => {
+    const sessionsDir = await createTempDir();
+    const nestedA = path.join(sessionsDir, "2026", "02", "one.jsonl");
+    const nestedB = path.join(sessionsDir, "2026", "03", "two.jsonl.gz");
+    await writeFileWithContent(nestedA, "one");
+    await writeFileWithContent(nestedB, "two");
+
+    const result = await scanSessionFiles(sessionsDir);
+
+    expect(result.totalFiles).toBe(2);
+    expect([...result.allFiles].sort()).toEqual([nestedA, nestedB].sort());
+  });
+});

--- a/src/commands/init/session-scanner.ts
+++ b/src/commands/init/session-scanner.ts
@@ -36,38 +36,50 @@ export async function scanSessionFiles(
     recentSizeBytes: 0,
   };
 
+  let entries: RecursiveDirent[];
   try {
-    const entries = (await fs.readdir(sessionsDir, {
+    entries = (await fs.readdir(sessionsDir, {
       withFileTypes: true,
       recursive: true,
     })) as RecursiveDirent[];
-    const cutoff = Date.now() - recentDays * 24 * 60 * 60 * 1000;
-
-    for (const entry of entries) {
-      if (!entry.isFile()) {
-        continue;
-      }
-      if (!entry.name.endsWith(".jsonl") && !entry.name.endsWith(".jsonl.gz")) {
-        continue;
-      }
-
-      const parentPath = resolveParentPath(entry, sessionsDir);
-      const filePath = path.join(parentPath, entry.name);
-      const stat = await fs.stat(filePath);
-
-      result.allFiles.push(filePath);
-      result.totalFiles += 1;
-      result.totalSizeBytes += stat.size;
-
-      if (stat.mtimeMs >= cutoff) {
-        result.recentFiles.push(filePath);
-        result.recentSizeBytes += stat.size;
-      }
-    }
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code !== "ENOENT") {
       throw error;
+    }
+    return result;
+  }
+
+  const cutoff = Date.now() - recentDays * 24 * 60 * 60 * 1000;
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (!entry.name.endsWith(".jsonl") && !entry.name.endsWith(".jsonl.gz")) {
+      continue;
+    }
+
+    const parentPath = resolveParentPath(entry, sessionsDir);
+    const filePath = path.join(parentPath, entry.name);
+
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stat = await fs.stat(filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+
+    result.allFiles.push(filePath);
+    result.totalFiles += 1;
+    result.totalSizeBytes += stat.size;
+
+    if (stat.mtimeMs >= cutoff) {
+      result.recentFiles.push(filePath);
+      result.recentSizeBytes += stat.size;
     }
   }
 

--- a/src/commands/init/session-scanner.ts
+++ b/src/commands/init/session-scanner.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface SessionScanResult {
+  totalFiles: number;
+  recentFiles: string[];
+  allFiles: string[];
+  totalSizeBytes: number;
+  recentSizeBytes: number;
+}
+
+type RecursiveDirent = Awaited<ReturnType<typeof fs.readdir>>[number] & {
+  parentPath?: string;
+  path?: string;
+};
+
+function resolveParentPath(entry: RecursiveDirent, fallback: string): string {
+  if (typeof entry.parentPath === "string") {
+    return entry.parentPath;
+  }
+  if (typeof entry.path === "string") {
+    return entry.path;
+  }
+  return fallback;
+}
+
+export async function scanSessionFiles(
+  sessionsDir: string,
+  recentDays: number = 7,
+): Promise<SessionScanResult> {
+  const result: SessionScanResult = {
+    totalFiles: 0,
+    recentFiles: [],
+    allFiles: [],
+    totalSizeBytes: 0,
+    recentSizeBytes: 0,
+  };
+
+  try {
+    const entries = (await fs.readdir(sessionsDir, {
+      withFileTypes: true,
+      recursive: true,
+    })) as RecursiveDirent[];
+    const cutoff = Date.now() - recentDays * 24 * 60 * 60 * 1000;
+
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!entry.name.endsWith(".jsonl") && !entry.name.endsWith(".jsonl.gz")) {
+        continue;
+      }
+
+      const parentPath = resolveParentPath(entry, sessionsDir);
+      const filePath = path.join(parentPath, entry.name);
+      const stat = await fs.stat(filePath);
+
+      result.allFiles.push(filePath);
+      result.totalFiles += 1;
+      result.totalSizeBytes += stat.size;
+
+      if (stat.mtimeMs >= cutoff) {
+        result.recentFiles.push(filePath);
+        result.recentSizeBytes += stat.size;
+      }
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  return result;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -321,7 +321,7 @@ function normalizeProjectsMap(input: unknown): AgenrConfig["projects"] | undefin
         entry.dependencies = dependencies;
       }
 
-      out[path.resolve(dirKey)] = entry;
+      out[path.resolve(resolveUserPath(dirKey))] = entry;
       continue;
     }
 
@@ -350,7 +350,7 @@ function normalizeProjectsMap(input: unknown): AgenrConfig["projects"] | undefin
       legacyEntry.dependencies = dependencies;
     }
 
-    out[path.resolve(value.projectDir.trim())] = legacyEntry;
+    out[path.resolve(resolveUserPath(value.projectDir.trim()))] = legacyEntry;
   }
 
   return Object.keys(out).length > 0 ? out : undefined;
@@ -466,7 +466,7 @@ export function resolveProjectFromGlobalConfig(
     return null;
   }
 
-  const resolvedDir = path.resolve(projectDir);
+  const resolvedDir = path.resolve(resolveUserPath(projectDir));
   const entry = config.projects[resolvedDir];
   if (!entry) {
     return null;


### PR DESCRIPTION
## Summary

Fixes multiple issues discovered during Phase 3 onboarding wizard testing for OpenClaw plugin installation.

## Changes

### Plugin Install Flow
- Reordered to: install plugin -> write config -> restart gateway (prevents config validation failures when config references a plugin that doesn't exist on disk yet)
- Removed OPENCLAW_HOME env override - let OpenClaw resolve its own paths
- Split gateway restart out of installOpenClawPlugin into the wizard for proper sequencing
- Check plugin files on disk (not config entries) for already-installed detection
- Skip npm install when local dev build detected via plugins.load.paths

### Path Resolution
- Added `resolveOpenClawConfigSubdir` helper to handle default (~/.openclaw) vs custom OPENCLAW_HOME layouts
- Fixed config file path to correctly resolve .openclaw subdir where needed
- Fixed sessions directory path construction
- `resolvedConfigDir` now flows back to `selectedPlatform.configDir` for downstream consistency

### UX Improvements
- Added user confirmation prompts for config file path and sessions directory
- Async `execAsync` helper so spinner animates during plugin install (execFileSync blocks event loop)
- Suppress stderr from OpenClaw CLI calls to keep wizard UI clean
- Safe null check on `findBinaryPath` in gateway restart block

### Tests
- Updated mocks for async execFile pattern
- Improved non-default directory test coverage
- Formatted clackTextMock for readability
- 115 init tests passing

### Other
- Added `scripts/setup-test-openclaw.sh` for creating clean test instances

Closes #170 (Phase 3 portion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cost estimation displayed before ingesting data to help plan token usage.
  * Session file scanner with filtering by recency and size totals.
  * Distinction between "Recent" and "Full" ingest paths with improved bulk processing.
  * OpenClaw plugin auto-installation and isolated database path management.
  * macOS daemon/watcher setup improvements.
  * Re-ingest flow triggered by model or authentication changes.

* **Improvements**
  * Expanded setup summary now displays status across plugin, ingest, consolidation, and watcher components.
  * Enhanced project lookup and path resolution utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->