### PR TITLE
feat: rename CLI command daemon -> watcher (v0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.1 (2026-02-26)
+
+### Changed
+- Renamed `agenr daemon` CLI command to `agenr watcher` - "watcher" better describes what it does
+- `agenr daemon` still works as a hidden compatibility command
+- Updated user-facing command output to say "watcher" instead of "daemon"
+
+### Internal
+- Renamed `src/commands/daemon.ts` to `src/commands/watcher.ts`
+- Renamed daemon command interfaces and exports from `Daemon*`/`runDaemon*` to `Watcher*`/`runWatcher*`
+
 ## 0.9.0 (2026-02-25)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -2144,7 +2144,7 @@ describe("runInitWizard", () => {
     ).toBe(false);
   });
 
-  it("wizard stops daemon before db reset during re-ingest", async () => {
+  it("wizard stops watcher before db reset during re-ingest", async () => {
     await withMockedPlatform("darwin", async () => {
       const dir = await createWizardProjectDir({
         project: "my-project",
@@ -2363,7 +2363,7 @@ describe("runInitWizard", () => {
     );
   });
 
-  it("wizard installs daemon with force:true on macOS and corrected sessionsDir", async () => {
+  it("wizard installs watcher with force:true on macOS and corrected sessionsDir", async () => {
     await withMockedPlatform("darwin", async () => {
       const dir = await createWizardProjectDir();
       const watcherSpy = vi.spyOn(initWizardRuntime, "runWatcherInstallCommand");

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -232,8 +232,8 @@ beforeEach(async () => {
     results: [],
   });
   vi.spyOn(initWizardRuntime, "runConsolidateCommand").mockResolvedValue({ exitCode: 0 });
-  vi.spyOn(initWizardRuntime, "runDaemonInstallCommand").mockResolvedValue({ exitCode: 0 });
-  vi.spyOn(initWizardRuntime, "runDaemonStopCommand").mockResolvedValue({ exitCode: 0 });
+  vi.spyOn(initWizardRuntime, "runWatcherInstallCommand").mockResolvedValue({ exitCode: 0 });
+  vi.spyOn(initWizardRuntime, "runWatcherStopCommand").mockResolvedValue({ exitCode: 0 });
   vi.spyOn(initWizardRuntime, "runDbResetCommand").mockResolvedValue({ exitCode: 0 });
 });
 
@@ -2150,7 +2150,7 @@ describe("runInitWizard", () => {
         project: "my-project",
         platform: "openclaw",
       });
-      const stopSpy = vi.spyOn(initWizardRuntime, "runDaemonStopCommand").mockResolvedValue({ exitCode: 0 });
+      const stopSpy = vi.spyOn(initWizardRuntime, "runWatcherStopCommand").mockResolvedValue({ exitCode: 0 });
       const resetSpy = vi.spyOn(initWizardRuntime, "runDbResetCommand").mockResolvedValue({ exitCode: 0 });
       readConfigMock.mockReturnValue({
         auth: "openai-api-key",
@@ -2366,7 +2366,7 @@ describe("runInitWizard", () => {
   it("wizard installs daemon with force:true on macOS and corrected sessionsDir", async () => {
     await withMockedPlatform("darwin", async () => {
       const dir = await createWizardProjectDir();
-      const daemonSpy = vi.spyOn(initWizardRuntime, "runDaemonInstallCommand");
+      const watcherSpy = vi.spyOn(initWizardRuntime, "runWatcherInstallCommand");
       readConfigMock.mockReturnValue(null);
       runSetupCoreMock.mockResolvedValue(mockSetupResult());
       vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platformList(true, false));
@@ -2375,7 +2375,7 @@ describe("runInitWizard", () => {
 
       await runInitWizard({ isInteractive: true, path: dir });
 
-      expect(daemonSpy).toHaveBeenCalledWith({
+      expect(watcherSpy).toHaveBeenCalledWith({
         force: true,
         interval: 120,
         dir: path.join(resolveDefaultOpenClawConfigDir(), "agents", "main", "sessions"),
@@ -2471,7 +2471,7 @@ describe("runInitWizard", () => {
   it("OpenClaw directory confirmation sets sessionsDir to agents/main/sessions", async () => {
     await withMockedPlatform("darwin", async () => {
       const dir = await createWizardProjectDir();
-      const daemonSpy = vi.spyOn(initWizardRuntime, "runDaemonInstallCommand");
+      const watcherSpy = vi.spyOn(initWizardRuntime, "runWatcherInstallCommand");
       readConfigMock.mockReturnValue(null);
       runSetupCoreMock.mockResolvedValue(mockSetupResult());
       vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platformList(false, false));
@@ -2482,7 +2482,7 @@ describe("runInitWizard", () => {
 
       await runInitWizard({ isInteractive: true, path: dir });
 
-      expect(daemonSpy).toHaveBeenCalledWith(
+      expect(watcherSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           dir: path.join("/tmp/custom-openclaw-dir", ".openclaw", "agents", "main", "sessions"),
         }),

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import * as clack from "@clack/prompts";
 import { describeAuth, readConfig, resolveConfigPath, resolveProjectFromGlobalConfig, writeConfig } from "../config.js";
 import { runConsolidateCommand } from "./consolidate.js";
-import { runDaemonInstallCommand, runDaemonStopCommand } from "./daemon.js";
+import { runWatcherInstallCommand, runWatcherStopCommand } from "./watcher.js";
 import { runDbResetCommand } from "./db.js";
 import { runIngestCommand, type IngestCommandResult } from "./ingest.js";
 import { resolveEmbeddingApiKey } from "../embeddings/client.js";
@@ -1062,8 +1062,8 @@ export const initWizardRuntime = {
   scanSessionFiles,
   runIngestCommand,
   runConsolidateCommand,
-  runDaemonInstallCommand,
-  runDaemonStopCommand,
+  runWatcherInstallCommand,
+  runWatcherStopCommand,
   runDbResetCommand,
 };
 
@@ -1592,7 +1592,7 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
       if (process.platform === "darwin") {
         spinner.start("Stopping watcher...");
         try {
-          await initWizardRuntime.runDaemonStopCommand({});
+          await initWizardRuntime.runWatcherStopCommand({});
         } catch {
           // Daemon might not be running.
         }
@@ -1771,14 +1771,14 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
       spinner.start("Installing watcher daemon...");
 
       try {
-        const daemonResult = await initWizardRuntime.runDaemonInstallCommand({
+        const watcherResult = await initWizardRuntime.runWatcherInstallCommand({
           force: true,
           interval: 120,
           dir: selectedPlatform.sessionsDir,
           platform: selectedPlatform.id,
         });
 
-        if (daemonResult.exitCode === 0) {
+        if (watcherResult.exitCode === 0) {
           spinner.stop("Watcher daemon installed and running (120s interval)");
           watcherStatus = "Running (120s interval)";
         } else {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1594,7 +1594,7 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
         try {
           await initWizardRuntime.runWatcherStopCommand({});
         } catch {
-          // Daemon might not be running.
+          // Watcher might not be running.
         }
         spinner.stop("Watcher stopped");
       }
@@ -1768,7 +1768,7 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
 
     if (setupWatcher) {
       const spinner = clack.spinner();
-      spinner.start("Installing watcher daemon...");
+      spinner.start("Installing watcher...");
 
       try {
         const watcherResult = await initWizardRuntime.runWatcherInstallCommand({
@@ -1779,11 +1779,11 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
         });
 
         if (watcherResult.exitCode === 0) {
-          spinner.stop("Watcher daemon installed and running (120s interval)");
+          spinner.stop("Watcher installed and running (120s interval)");
           watcherStatus = "Running (120s interval)";
         } else {
           spinner.stop(
-            "Daemon install failed. Run manually:\n" +
+            "Watcher install failed. Run manually:\n" +
               `  agenr watch --dir ${selectedPlatform.sessionsDir} ` +
               `--platform ${selectedPlatform.id}`,
           );
@@ -1791,7 +1791,7 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        spinner.stop(`Daemon install failed: ${message}`);
+        spinner.stop(`Watcher install failed: ${message}`);
         watcherStatus = "Failed";
       }
     } else {

--- a/src/commands/reset.test.ts
+++ b/src/commands/reset.test.ts
@@ -73,7 +73,7 @@ describe("runResetCommand", () => {
 
     const stdoutLines = (deps.stdoutLine as ReturnType<typeof vi.fn>).mock.calls.map((call) => String(call[0]));
     expect(stdoutLines).toContain(
-      "WARNING: If the agenr watcher daemon is running, stop it before proceeding. Reset will not abort if the daemon is running.",
+      "WARNING: If the agenr watcher is running, stop it before proceeding. Reset will not abort if the watcher is running.",
     );
     expect(stdoutLines).toContain("Backup created: /tmp/knowledge.db.backup-pre-reset-2026-02-19T10-00-00-000Z");
     expect(stdoutLines).toContain("Reset complete.");

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -113,7 +113,7 @@ export async function runResetCommand(
   }
 
   resolvedDeps.stdoutLine(
-    "WARNING: If the agenr watcher daemon is running, stop it before proceeding. Reset will not abort if the daemon is running.",
+    "WARNING: If the agenr watcher is running, stop it before proceeding. Reset will not abort if the watcher is running.",
   );
 
   let backupPath: string;

--- a/src/commands/watcher.ts
+++ b/src/commands/watcher.ts
@@ -26,11 +26,11 @@ export interface WatcherUninstallOptions {
   yes?: boolean;
 }
 
-export interface WatcherStartOptions {}
+export type WatcherStartOptions = Record<string, never>;
 
-export interface WatcherStopOptions {}
+export type WatcherStopOptions = Record<string, never>;
 
-export interface WatcherRestartOptions {}
+export type WatcherRestartOptions = Record<string, never>;
 
 export interface WatcherStatusOptions {
   lines?: number | string;
@@ -646,8 +646,8 @@ export async function runWatcherStatusCommand(
   const logTail = await readLastLines(resolvedDeps.readFileFn, logPath, lineCount);
   const nowMs = resolvedDeps.nowFn();
 
-  const daemonLines = [
-    "-- Watcher --",
+  const serviceLines = [
+    "-- Service --",
     `Loaded: ${loaded ? "yes" : "no"}`,
     `Running: ${running ? "yes" : "no"}`,
     `Current file: ${currentFile ?? "(none)"}`,
@@ -673,7 +673,7 @@ export async function runWatcherStatusCommand(
       ]
     : ["-- Watcher --", "Heartbeat: no data"];
 
-  resolvedDeps.noteFn([...daemonLines, "", ...watcherLines].join("\n"), "Status");
+  resolvedDeps.noteFn([...serviceLines, "", ...watcherLines].join("\n"), "Status");
 
   if (logTail.length > 0) {
     clack.log.info(`Last ${logTail.length} log lines:`);


### PR DESCRIPTION
## Summary

Renames `agenr daemon` CLI command to `agenr watcher`. The word "watcher" better describes what the command does. `agenr daemon` remains as a hidden backward-compatibility alias.

### Changes
- Renamed `src/commands/daemon.ts` to `src/commands/watcher.ts`
- Renamed all exported interfaces: Daemon* -> Watcher*
- Renamed all exported functions: runDaemon* -> runWatcher*
- Updated all user-facing strings: "Daemon" -> "Watcher"
- `agenr watcher` registered as primary command with `.alias("daemon")` for backward compat
- Updated init.ts imports and references
- Updated init.test.ts spies and test descriptions
- Bumps version to 0.9.1

### What stays the same
- launchd label (`com.agenr.watch`) unchanged
- Internal helper function names unchanged
- `agenr daemon *` still works via alias

1320 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Renamed the CLI "daemon" command to "watcher"; user-facing output and messaging now reference "watcher"
  * The legacy "daemon" command remains available as a hidden compatibility alias
* **Chore**
  * Bumped release version to 0.9.1 and added a 0.9.1 changelog section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->