### PR TITLE
fix(consolidate): prevent duplicate canonical merge outputs (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.2 (2026-02-26)
+
+### Fixed
+- fix(consolidate): fragmented clustering produced duplicate canonical entries instead of a single winner (#249)
+  - Phase 1 now over-fetches neighbors (3x) when type-filtered to preserve same-type neighborhood coverage
+  - Added a new Phase 3 post-merge dedup pass to merge near-duplicate canonical entries created in the same run
+  - Phase 3 disables idempotency and only processes clusters that include entries created during the current run
+
 ## 0.9.1 (2026-02-26)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -417,6 +417,16 @@ function renderTextReport(stats: ConsolidationOrchestratorReport, dryRun: boolea
     );
   }
 
+  if (stats.phase3) {
+    lines.push(
+      "|",
+      "|  Phase 3: Post-Merge Dedup",
+      `|  +- Clusters processed: ${formatNumber(stats.phase3.clustersProcessed)} / ${formatNumber(stats.phase3.clustersFound)}`,
+      `|  +- Clusters merged: ${formatNumber(stats.phase3.clustersMerged)}`,
+      `|  +- LLM calls: ${formatNumber(stats.phase3.llmCalls)}`,
+    );
+  }
+
   lines.push(
     "|",
     "|  Summary",

--- a/src/consolidate/cluster.ts
+++ b/src/consolidate/cluster.ts
@@ -194,7 +194,8 @@ export async function buildClusters(db: Client, options: ClusterOptions = {}): P
   }
 
   for (const entry of candidates) {
-    const neighbors = await findSimilar(db, entry.embedding, neighborLimit);
+    const fetchLimit = typeFilter ? neighborLimit * 3 : neighborLimit;
+    const neighbors = await findSimilar(db, entry.embedding, fetchLimit);
     for (const neighbor of neighbors) {
       const candidate = entryById.get(neighbor.entry.id);
       if (!candidate || candidate.id === entry.id) {

--- a/tests/commands/consolidate.test.ts
+++ b/tests/commands/consolidate.test.ts
@@ -48,6 +48,17 @@ function reportFixture(): ConsolidationOrchestratorReport {
       entriesConsolidatedFrom: 2,
       canonicalEntriesCreated: 1,
     },
+    phase3: {
+      entries: 3,
+      clustersFound: 1,
+      skippedByResume: 0,
+      clustersProcessed: 1,
+      clustersMerged: 1,
+      mergesFlagged: 0,
+      llmCalls: 1,
+      entriesConsolidatedFrom: 3,
+      canonicalEntriesCreated: 1,
+    },
     progress: {
       resumed: false,
       checkpointPath: "/tmp/checkpoint",
@@ -224,6 +235,7 @@ describe("consolidate command", () => {
     expect(warnSpy).not.toHaveBeenCalled();
     const output = stderrSpy.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("Knowledge Consolidation");
+    expect(output).toContain("Phase 3: Post-Merge Dedup");
     expect(output.includes("\u001b[")).toBe(false);
   });
 

--- a/tests/consolidate-cluster-overfetch.test.ts
+++ b/tests/consolidate-cluster-overfetch.test.ts
@@ -1,0 +1,106 @@
+import type { Client } from "@libsql/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { findSimilarMock } = vi.hoisted(() => ({
+  findSimilarMock: vi.fn(),
+}));
+
+vi.mock("../src/db/store.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/db/store.js")>("../src/db/store.js");
+  return {
+    ...actual,
+    findSimilar: findSimilarMock,
+  };
+});
+
+import { buildClusters } from "../src/consolidate/cluster.js";
+
+function makeEmbedding(seed: number): Float32Array {
+  const vector = new Float32Array(1024);
+  vector[0] = seed;
+  return vector;
+}
+
+function makeDbRows() {
+  return [
+    {
+      id: "fact-1",
+      type: "fact",
+      subject: "Diet",
+      content: "keto a",
+      project: "agenr",
+      importance: 5,
+      embedding: makeEmbedding(1),
+      confirmations: 0,
+      recall_count: 0,
+      created_at: "2026-02-26T00:00:00.000Z",
+      merged_from: 0,
+      consolidated_at: null,
+      tags_csv: "",
+    },
+    {
+      id: "fact-2",
+      type: "fact",
+      subject: "Diet",
+      content: "keto b",
+      project: "agenr",
+      importance: 5,
+      embedding: makeEmbedding(2),
+      confirmations: 0,
+      recall_count: 0,
+      created_at: "2026-02-26T00:00:00.000Z",
+      merged_from: 0,
+      consolidated_at: null,
+      tags_csv: "",
+    },
+    {
+      id: "preference-1",
+      type: "preference",
+      subject: "Diet",
+      content: "keto pref",
+      project: "agenr",
+      importance: 5,
+      embedding: makeEmbedding(3),
+      confirmations: 0,
+      recall_count: 0,
+      created_at: "2026-02-26T00:00:00.000Z",
+      merged_from: 0,
+      consolidated_at: null,
+      tags_csv: "",
+    },
+  ];
+}
+
+describe("consolidate cluster neighbor over-fetch", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("over-fetches neighbors by 3x when type filter is set", async () => {
+    findSimilarMock.mockResolvedValue([]);
+    const db = {
+      execute: vi.fn(async () => ({ rows: makeDbRows() })),
+    } as unknown as Client;
+
+    await buildClusters(db, { typeFilter: "fact", minCluster: 2, neighborLimit: 5 });
+
+    expect(findSimilarMock).toHaveBeenCalledTimes(2);
+    for (const call of findSimilarMock.mock.calls) {
+      expect(call[2]).toBe(15);
+    }
+  });
+
+  it("uses raw neighbor limit when type filter is not set", async () => {
+    findSimilarMock.mockResolvedValue([]);
+    const db = {
+      execute: vi.fn(async () => ({ rows: makeDbRows() })),
+    } as unknown as Client;
+
+    await buildClusters(db, { minCluster: 2, neighborLimit: 5 });
+
+    expect(findSimilarMock).toHaveBeenCalledTimes(3);
+    for (const call of findSimilarMock.mock.calls) {
+      expect(call[2]).toBe(5);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

When consolidate processes a cluster of similar entries, the LLM merge step sometimes produces multiple near-identical canonical entries instead of collapsing the cluster into a single winner. This means consolidate can actually increase duplication rather than reduce it.

Example: 5 keto diet preference entries went in, 5 slightly reworded keto diet entries came out - all with source `consolidate-merge`.

## Root Cause

Two issues:
1. **Neighborhood dilution:** `findSimilar` returns neighbors across all types, but type-filtered consolidation only uses same-type neighbors. With a 5-neighbor limit, a fact entry might get 3 preference neighbors and only 2 fact neighbors, fragmenting same-type clusters.
2. **No post-merge dedup:** When fragmented clusters each produce a canonical entry, those near-duplicate canonicals are protected by idempotency rules and never get merged together.

## Fix

### Phase 1 over-fetch (cluster.ts)
When a type filter is active, fetch 3x neighbors to compensate for cross-type dilution. Pragmatic heuristic - extra DB reads only, no correctness impact.

### Phase 3 post-merge dedup (orchestrate.ts)
After Phase 1/2 complete, if 2+ canonical entries were created:
- Re-cluster with idempotency disabled (`idempotencyDays: 0`)
- Only process clusters containing at least one entry created in the current run
- Merge near-duplicate canonicals into a single winner

Phase 3 is skipped when batch limit is already reached, and correctly accounts in all summary totals.

## Tests

- 5 new tests (1325 total, all passing)
- Over-fetch: confirms 3x with type filter, 1x without
- Phase 3: runs and merges new canonicals, skipped on flagged merge, skipped on batch limit
- Report rendering includes Phase 3 stats

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Phase 3 "Post-Merge Dedup" step to run an extra deduplication pass for entries created in the same run.
  * Neighbor discovery now fetches additional neighbors when consolidating by type to improve coverage.

* **Bug Fixes**
  * Prevents duplicate canonical entries by merging near-duplicates discovered after initial consolidation.

* **Documentation**
  * CHANGELOG updated for v0.9.2.

* **Tests**
  * Added unit and orchestrator tests covering the new Phase 3 flow and neighbor over-fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->