### PR TITLE
fix: init wizard model-only change, config set task models, swarm review fixes (#275, #276, #278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 - Contradiction detection: always run both subject-index and embedding search (removed hardcoded < 3 gate)
 - Contradiction detection: parallelize classifyConflict LLM calls via Promise.all
 - Contradiction detection: high-confidence supersession with lower importance now flags for review instead of silent coexist
+- Contradiction detection: lowered default similarity threshold from 0.72 to 0.55 (matches real contradiction scores)
+- Contradiction detection: entity hint injection from DB for consistent claim extraction across sessions
+- Contradiction detection: fuzzy attribute matching fallback in subject index
+- Contradiction detection: cross-entity lookup for same-attribute conflicts across entity aliases
 - Subject index rebuild is now atomic (swap instead of clear-then-populate)
 - Conflicts UI: request body size limit (64KB), auth token on POST endpoints, safe browser open
 - Extracted shared LLM helpers (clampConfidence, resolveModelForLlmClient, extractToolCallArgs) to src/db/llm-helpers.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.9.3 (2026-02-26)
 
 ### Added
+- feat: `config set` now supports per-task model overrides via dot-path keys (for example, `models.extraction`, `models.claimExtraction`) (#276)
+- Set value to `default` to remove an override and fall back to the global model
 - Schema: subject_entity, subject_attribute, subject_key, claim_predicate, claim_object, claim_confidence columns on entries table (#266)
 - Schema: conflict_log table for contradiction audit trail (#266)
 - Schema: idx_entries_subject_key partial index (#266)
@@ -35,6 +37,7 @@
 - Init wizard: per-task model selection for extraction, claim extraction, contradiction judge, and handoff summary (#266)
 
 ### Fixed
+- fix: setup and init wizards now write explicitly selected task models even when they match defaults (#275)
 - Critical: conflicts UI "keep-new"/"keep-old" resolution was retiring the wrong entry (swarm review)
 - Contradiction detection: cap subject-index candidates to maxCandidates, sort by recency
 - Contradiction detection: always run both subject-index and embedding search (removed hardcoded < 3 gate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Init wizard: per-task model selection for extraction, claim extraction, contradiction judge, and handoff summary (#266)
 
 ### Fixed
+- fix: CLI banner now displays the current agenr version (#278)
 - fix: setup and init wizards now write explicitly selected task models even when they match defaults (#275)
 - Critical: conflicts UI "keep-new"/"keep-old" resolution was retiring the wrong entry (swarm review)
 - Contradiction detection: cap subject-index candidates to maxCandidates, sort by recency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@
 ### Fixed
 - fix: CLI banner now displays the current agenr version (#278)
 - fix: setup and init wizards now write explicitly selected task models even when they match defaults (#275)
+- fix: resolveConflict now reads autoSupersedeConfidence from config instead of hardcoding 0.85 (#275)
+- fix: claim fields explicitly propagated through mutation pipeline (#275)
+- fix: supersede + insert wrapped in transaction for online-dedup path (#275)
+- fix: entity names with slashes sanitized during claim extraction (#275)
+- fix: LLM judge errors now logged via console.warn instead of silent fallback (#275)
+- fix: entity alias resolution no longer depends on single-entity heuristic (#275)
 - Critical: conflicts UI "keep-new"/"keep-old" resolution was retiring the wrong entry (swarm review)
 - Contradiction detection: cap subject-index candidates to maxCandidates, sort by recency
 - Contradiction detection: always run both subject-index and embedding search (removed hardcoded < 3 gate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Extracted shared LLM helpers (clampConfidence, resolveModelForLlmClient, extractToolCallArgs) to src/db/llm-helpers.ts
 - Removed unnecessary Float32Array conversions in contradiction detection pipeline
 - Replaced __pendingConflicts side-channel with scoped Map
+- Init wizard: change model without re-running auth setup (#275)
 
 ## 0.9.2 (2026-02-26)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -39,6 +39,7 @@ import { runStoreCommand } from "./commands/store.js";
 import { runTodoCommand } from "./commands/todo.js";
 import { runWatchCommand } from "./commands/watch.js";
 import { describeAuth, maskSecret, readConfig, setConfigKey, setStoredCredential, writeConfig } from "./config.js";
+import type { ConfigSetKey } from "./config.js";
 import { deduplicateEntries } from "./dedup.js";
 import { closeDb, getDb, initDb } from "./db/client.js";
 import { resolveEmbeddingApiKey } from "./embeddings/client.js";
@@ -1046,16 +1047,16 @@ export function createProgram(): Command {
 
   configCommand
     .command("set")
-    .description("Set one config value: provider, model, or auth")
-    .argument("<key>", "Config key: provider, model, auth")
+    .description("Set a config value (provider, model, auth, models.<task>)")
+    .argument("<key>", "Config key: provider, model, auth, models.<task>")
     .argument("<value>", "Config value")
     .action((key: string, value: string) => {
-      if (key !== "provider" && key !== "model" && key !== "auth") {
-        throw new Error('Invalid key. Expected one of: "provider", "model", "auth".');
+      if (key !== "provider" && key !== "model" && key !== "auth" && !key.startsWith("models.")) {
+        throw new Error('Invalid key. Expected one of: "provider", "model", "auth", or "models.<task>".');
       }
 
       const current = readConfig(process.env);
-      const result = setConfigKey(current, key, value);
+      const result = setConfigKey(current, key as ConfigSetKey, value);
       writeConfig(result.config, process.env);
       clack.log.success(formatLabel(`Updated ${key}`, value));
       for (const warning of result.warnings) {

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1584,10 +1584,11 @@ describe("runInitWizard", () => {
     expect(clackSelectMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        message: "Auth: OpenAI API key (current)",
+        message: "Auth: OpenAI API key | Model: gpt-4.1-mini (current)",
         options: [
-          expect.objectContaining({ label: "Keep current" }),
-          expect.objectContaining({ label: "Change..." }),
+          expect.objectContaining({ label: "Keep current auth and model" }),
+          expect.objectContaining({ label: "Change model only" }),
+          expect.objectContaining({ label: "Change auth and model..." }),
         ],
       }),
     );
@@ -1643,7 +1644,7 @@ describe("runInitWizard", () => {
     vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platformList(true, false));
     vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
     clackConfirmMock.mockResolvedValue(true);
-    clackSelectMock.mockResolvedValueOnce("change").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
+    clackSelectMock.mockResolvedValueOnce("change-auth").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
 
     await runInitWizard({ isInteractive: true, path: dir });
 
@@ -1666,7 +1667,7 @@ describe("runInitWizard", () => {
     vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platformList(true, false));
     vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
     clackConfirmMock.mockResolvedValue(true);
-    clackSelectMock.mockResolvedValueOnce("change").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
+    clackSelectMock.mockResolvedValueOnce("change-auth").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
 
     await runInitWizard({ isInteractive: true, path: dir });
 
@@ -1766,7 +1767,7 @@ describe("runInitWizard", () => {
     vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platformList(true, false));
     vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
     clackConfirmMock.mockResolvedValue(true);
-    clackSelectMock.mockResolvedValueOnce("change").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
+    clackSelectMock.mockResolvedValueOnce("change-auth").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
 
     await runInitWizard({ isInteractive: true, path: dir });
 
@@ -1790,7 +1791,7 @@ describe("runInitWizard", () => {
     vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platformList(true, false));
     vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
     clackConfirmMock.mockResolvedValue(true);
-    clackSelectMock.mockResolvedValueOnce("change").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
+    clackSelectMock.mockResolvedValueOnce("change-auth").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
 
     await runInitWizard({ isInteractive: true, path: dir });
 
@@ -1874,7 +1875,7 @@ describe("runInitWizard", () => {
     vi.spyOn(initWizardRuntime, "detectPlatforms").mockReturnValue(platformList(true, false));
     vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
     clackConfirmMock.mockResolvedValue(true);
-    clackSelectMock.mockResolvedValueOnce("change").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
+    clackSelectMock.mockResolvedValueOnce("change-auth").mockResolvedValueOnce("keep").mockResolvedValueOnce("keep");
 
     await runInitWizard({ isInteractive: true, path: dir });
 
@@ -2116,7 +2117,7 @@ describe("runInitWizard", () => {
     vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
     clackConfirmMock.mockResolvedValue(true);
     clackSelectMock
-      .mockResolvedValueOnce("change")
+      .mockResolvedValueOnce("change-auth")
       .mockResolvedValueOnce("keep")
       .mockResolvedValueOnce("keep")
       .mockResolvedValueOnce("keep");
@@ -2185,7 +2186,7 @@ describe("runInitWizard", () => {
       vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
       clackConfirmMock.mockResolvedValue(true);
       clackSelectMock
-        .mockResolvedValueOnce("change")
+        .mockResolvedValueOnce("change-auth")
         .mockResolvedValueOnce("keep")
         .mockResolvedValueOnce("keep")
         .mockResolvedValueOnce("reingest");
@@ -2221,7 +2222,7 @@ describe("runInitWizard", () => {
       vi.spyOn(initWizardRuntime, "runInitCommand").mockResolvedValue(mockInitResult());
       clackConfirmMock.mockResolvedValue(true);
       clackSelectMock
-        .mockResolvedValueOnce("change")
+        .mockResolvedValueOnce("change-auth")
         .mockResolvedValueOnce("keep")
         .mockResolvedValueOnce("isolated")
         .mockResolvedValueOnce("keep")

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -963,14 +963,10 @@ function taskModelsEqual(a: AgenrConfig["models"], b: AgenrConfig["models"]): bo
   return true;
 }
 
-function toTaskModelOverrides(baseModel: string | undefined, selected: TaskModelRecord): AgenrConfig["models"] {
-  const defaults = resolveTaskModelDefaults(baseModel);
+function toTaskModelOverrides(_baseModel: string | undefined, selected: TaskModelRecord): AgenrConfig["models"] {
   const overrides: NonNullable<AgenrConfig["models"]> = {};
   for (const task of TASK_MODEL_DEFINITIONS) {
-    const value = selected[task.key].trim();
-    if (value !== defaults[task.key]) {
-      overrides[task.key] = value;
-    }
+    overrides[task.key] = selected[task.key].trim();
   }
   return Object.keys(overrides).length > 0 ? overrides : undefined;
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1439,12 +1439,10 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
       }
 
       selectedModel = newModel;
-      const nextConfig: AgenrConfig = {
+      workingConfig = {
         ...existingConfig,
         model: newModel,
       };
-      writeConfig(nextConfig, env);
-      workingConfig = initWizardRuntime.readConfig(env) ?? nextConfig;
       currentEmbeddingKey = resolveEmbeddingKeyOrNull(workingConfig, env);
     }
   } else {
@@ -2113,6 +2111,20 @@ export async function runInitWizard(options: WizardOptions): Promise<void> {
         `--platform ${selectedPlatform.id}`,
     );
     watcherStatus = `Not supported on ${osName}`;
+  }
+
+  if (wizardChanges.modelChanged && selectedModel) {
+    const latestConfig = initWizardRuntime.readConfig(env) ?? workingConfig ?? {};
+    const nextConfig: AgenrConfig = {
+      ...latestConfig,
+      model: selectedModel,
+      ...(selectedTaskModels ? { models: selectedTaskModels } : {}),
+    };
+    if (!selectedTaskModels) {
+      delete nextConfig.models;
+    }
+    writeConfig(nextConfig, env);
+    workingConfig = nextConfig;
   }
 
   const openclawDatabase =

--- a/src/db/claim-extraction.ts
+++ b/src/db/claim-extraction.ts
@@ -157,6 +157,9 @@ function resolveEntityAlias(entity: string, existingEntities?: Set<string>): str
   }
 
   if (existingEntities && existingEntities.size > 0 && entity === "user") {
+    // When "user" maps to multiple non-user entities, pick the first
+    // alphabetically for deterministic behavior. A most-recently-used
+    // strategy could be considered later.
     const nonUserEntities = [...existingEntities]
       .filter((existingEntity) => existingEntity !== "user")
       .sort((a, b) => a.localeCompare(b));

--- a/src/db/claim-extraction.ts
+++ b/src/db/claim-extraction.ts
@@ -147,7 +147,7 @@ export interface ExtractClaimOptions {
 }
 
 function normalizeEntity(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, " ");
+  return value.trim().toLowerCase().replace(/\//g, "-").replace(/\s+/g, " ");
 }
 
 function resolveEntityAlias(entity: string, existingEntities?: Set<string>): string {
@@ -156,10 +156,12 @@ function resolveEntityAlias(entity: string, existingEntities?: Set<string>): str
     return aliased;
   }
 
-  if (existingEntities && existingEntities.size > 0 && entity === "user" && existingEntities.size === 1) {
-    const existing = [...existingEntities][0];
-    if (existing && existing !== "user") {
-      return existing;
+  if (existingEntities && existingEntities.size > 0 && entity === "user") {
+    const nonUserEntities = [...existingEntities]
+      .filter((existingEntity) => existingEntity !== "user")
+      .sort((a, b) => a.localeCompare(b));
+    if (nonUserEntities.length > 0) {
+      return nonUserEntities[0];
     }
   }
 
@@ -198,6 +200,7 @@ function buildClaimExtractionSystemPrompt(entityHints?: string[]): string {
     "",
     `Known entities in the knowledge base: ${normalizedHints.join(", ")}`,
     "Use one of these entities if the entry is about any of them.",
+    "If the subject is the user/owner of the knowledge base, use their actual name from the entity hints rather than generic terms like \"user\", \"me\", or \"I\".",
     "Only create a new entity name if none of the known entities apply.",
   ].join("\n");
 }

--- a/src/db/claim-extraction.ts
+++ b/src/db/claim-extraction.ts
@@ -152,8 +152,11 @@ function normalizeEntity(value: string): string {
 
 function resolveEntityAlias(entity: string, existingEntities?: Set<string>): string {
   const aliased = ENTITY_ALIASES[entity];
-  if (aliased) {
+  if (aliased && aliased !== "user") {
     return aliased;
+  }
+  if (aliased === "user") {
+    entity = "user";
   }
 
   if (existingEntities && existingEntities.size > 0 && entity === "user") {

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1499,7 +1499,12 @@ export async function storeEntries(
     }
 
     if (!entityHintsPromise) {
-      entityHintsPromise = getDistinctEntities(db);
+      entityHintsPromise = getDistinctEntities(db).catch((err) => {
+        console.warn(
+          `[store] entity hints lookup failed, proceeding without hints: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return [];
+      });
     }
 
     return entityHintsPromise;

--- a/src/db/subject-index.ts
+++ b/src/db/subject-index.ts
@@ -1,5 +1,79 @@
 import type { Client } from "@libsql/client";
 
+function parseSubjectKey(subjectKey: string): { entity: string; attribute: string } | null {
+  const trimmed = subjectKey.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const slashParts = trimmed.split("/", 2);
+  if (slashParts.length === 2) {
+    const entity = slashParts[0]?.trim().toLowerCase();
+    const attribute = slashParts[1]?.trim().toLowerCase();
+    if (entity && attribute) {
+      return { entity, attribute };
+    }
+  }
+
+  const legacyMatch = /^person:([^|]+)\|attr:(.+)$/i.exec(trimmed);
+  if (!legacyMatch) {
+    return null;
+  }
+
+  const entity = legacyMatch[1]?.trim().toLowerCase();
+  const attribute = legacyMatch[2]?.trim().toLowerCase();
+  if (!entity || !attribute) {
+    return null;
+  }
+
+  return { entity, attribute };
+}
+
+function normalizeAttributeToken(token: string): string {
+  const normalized = token.trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+
+  if (normalized === "change" || normalized === "changes" || normalized === "ownership") {
+    return "";
+  }
+
+  if (normalized.endsWith("ary") && normalized.length > 3) {
+    return normalized.slice(0, -3);
+  }
+
+  return normalized;
+}
+
+function tokenOverlap(a: string, b: string): number {
+  const tokensA = new Set(
+    a
+      .split("_")
+      .map((token) => normalizeAttributeToken(token))
+      .filter((token) => token.length > 0),
+  );
+  const tokensB = new Set(
+    b
+      .split("_")
+      .map((token) => normalizeAttributeToken(token))
+      .filter((token) => token.length > 0),
+  );
+  if (tokensA.size === 0 || tokensB.size === 0) {
+    return 0;
+  }
+
+  let intersection = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) {
+      intersection += 1;
+    }
+  }
+
+  const union = new Set([...tokensA, ...tokensB]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
 export class SubjectIndex {
   private index = new Map<string, Set<string>>();
   private initialized = false;
@@ -44,6 +118,62 @@ export class SubjectIndex {
   lookup(subjectKey: string): string[] {
     const set = this.index.get(subjectKey);
     return set ? [...set] : [];
+  }
+
+  /**
+   * Fuzzy lookup by subject key. Entity must match exactly, attribute uses token overlap.
+   */
+  fuzzyLookup(subjectKey: string, threshold = 0.6): string[] {
+    const parsed = parseSubjectKey(subjectKey);
+    if (!parsed) {
+      return [];
+    }
+
+    const matches = new Set<string>();
+    for (const [key, ids] of this.index.entries()) {
+      const indexed = parseSubjectKey(key);
+      if (!indexed || indexed.entity !== parsed.entity) {
+        continue;
+      }
+
+      const score = tokenOverlap(parsed.attribute, indexed.attribute);
+      if (score < threshold) {
+        continue;
+      }
+
+      for (const id of ids) {
+        matches.add(id);
+      }
+    }
+
+    return [...matches];
+  }
+
+  /**
+   * Lookup entries with the same attribute across different entities.
+   */
+  crossEntityLookup(subjectKey: string): string[] {
+    const parsed = parseSubjectKey(subjectKey);
+    if (!parsed) {
+      return [];
+    }
+
+    const matches = new Set<string>();
+    for (const [key, ids] of this.index.entries()) {
+      const indexed = parseSubjectKey(key);
+      if (!indexed) {
+        continue;
+      }
+      if (indexed.attribute !== parsed.attribute || indexed.entity === parsed.entity) {
+        continue;
+      }
+
+      for (const id of ids) {
+        matches.add(id);
+      }
+    }
+
+    return [...matches];
   }
 
   /**

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -44,7 +44,7 @@ function promptToEnterCredential(auth: AgenrAuthMethod): string {
   return "Enter OpenAI API key:";
 }
 
-function modelChoicesForAuth(auth: AgenrAuthMethod, provider: AgenrProvider): string[] {
+export function modelChoicesForAuth(auth: AgenrAuthMethod, provider: AgenrProvider): string[] {
   const definition = getAuthMethodDefinition(auth);
   const allModels = getModels(provider).map((model) => model.id);
 
@@ -76,7 +76,7 @@ function modelChoicesForAuth(auth: AgenrAuthMethod, provider: AgenrProvider): st
   return Array.from(new Set([...preferred, ...fallback]));
 }
 
-function modelHintForChoice(provider: AgenrProvider, modelId: string): string | undefined {
+export function modelHintForChoice(provider: AgenrProvider, modelId: string): string | undefined {
   if (provider === "openai") {
     if (modelId === "gpt-4.1-mini") {
       return "recommended - good balance of quality and cost";

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -179,9 +179,7 @@ async function promptPerTaskModels(baseModel: string): Promise<AgenrConfig["mode
       modelChoice = customModel.trim();
     }
 
-    if (modelChoice !== defaultModel) {
-      selectedModels[taskConfig.task] = modelChoice;
-    }
+    selectedModels[taskConfig.task] = modelChoice;
   }
 
   return Object.keys(selectedModels).length > 0 ? selectedModels : undefined;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { APP_VERSION } from "./version.js";
 
 export const ui = {
   brand: chalk.hex("#8B5CF6"),
@@ -23,7 +24,7 @@ export function banner(): string {
     chalk.hex("#E0B830")("╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚═╝  ╚═╝"),
   ];
 
-  return `\n${lines.join("\n")}\n${ui.dim("  AGENt memoRy")}`;
+  return `\n${lines.join("\n")}\n${ui.dim("  AGENt memoRy")}  ${ui.dim(`v${APP_VERSION}`)}`;
 }
 
 export function formatLabel(label: string, value: string): string {

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -330,8 +330,10 @@ describe("init wizard per-task model setup", () => {
     });
 
     expect(readConfig(env)?.models).toEqual({
+      extraction: "gpt-4.1-mini",
       claimExtraction: "gpt-4.1",
       contradictionJudge: "o3-mini",
+      handoffSummary: "gpt-4.1-nano",
     });
 
     const summaryCall = current.noteMock.mock.calls.find((call) => call[1] === "Setup summary");
@@ -399,7 +401,7 @@ describe("init wizard per-task model setup", () => {
     expect(changesNote?.[0]).toContain("Per-task model overrides updated");
   });
 
-  it("persists only tasks that differ from defaults", async () => {
+  it("persists explicit task selections even when they match defaults", async () => {
     const current = getMocks();
     const projectDir = await makeTempDir("agenr-init-project-test-");
     const env = await setupExistingConfig(projectDir);
@@ -419,7 +421,10 @@ describe("init wizard per-task model setup", () => {
     });
 
     expect(readConfig(env)?.models).toEqual({
+      extraction: "gpt-4.1-mini",
       claimExtraction: "gpt-4.1",
+      contradictionJudge: "gpt-4.1-nano",
+      handoffSummary: "gpt-4.1-nano",
     });
   });
 });

--- a/tests/db/claim-extraction.test.ts
+++ b/tests/db/claim-extraction.test.ts
@@ -256,6 +256,40 @@ describe("claim extraction", () => {
     expect(claim?.subjectEntity).toBe("alex");
   });
 
+  it("resolveEntityAlias resolves 'i' and 'me' to actual user name via existingEntities", async () => {
+    vi.mocked(runSimpleStream)
+      .mockResolvedValueOnce(
+        makeToolMessage({
+          no_claim: false,
+          subject_entity: "i",
+          subject_attribute: "editor",
+          predicate: "prefers",
+          object: "neovim",
+          confidence: 0.9,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeToolMessage({
+          no_claim: false,
+          subject_entity: "me",
+          subject_attribute: "editor",
+          predicate: "prefers",
+          object: "neovim",
+          confidence: 0.9,
+        }),
+      );
+
+    const firstClaim = await extractClaim("I prefer neovim", "preference", "editor", makeClient(), {
+      entityHints: ["sarah", "alex", "user"],
+    });
+    const secondClaim = await extractClaim("Me prefers neovim", "preference", "editor", makeClient(), {
+      entityHints: ["sarah", "alex", "user"],
+    });
+
+    expect(firstClaim?.subjectEntity).toBe("alex");
+    expect(secondClaim?.subjectEntity).toBe("alex");
+  });
+
   it("normalizeEntity replaces slashes with hyphens", async () => {
     vi.mocked(runSimpleStream).mockResolvedValueOnce(
       makeToolMessage({

--- a/tests/db/subject-index.test.ts
+++ b/tests/db/subject-index.test.ts
@@ -72,6 +72,39 @@ describe("SubjectIndex", () => {
     expect(index.lookup("missing:key")).toEqual([]);
   });
 
+  it("fuzzyLookup matches token overlap for related attributes", () => {
+    const index = new SubjectIndex();
+    index.add("alex/dietary_change", "entry-1");
+    index.add("alex/location", "entry-2");
+
+    expect(index.fuzzyLookup("alex/diet")).toEqual(["entry-1"]);
+  });
+
+  it("fuzzyLookup returns empty for unrelated attributes", () => {
+    const index = new SubjectIndex();
+    index.add("alex/employer", "entry-1");
+    index.add("alex/location", "entry-2");
+
+    expect(index.fuzzyLookup("alex/vehicle")).toEqual([]);
+  });
+
+  it("crossEntityLookup matches same attribute across entities", () => {
+    const index = new SubjectIndex();
+    index.add("alex/weight", "entry-1");
+    index.add("user/weight", "entry-2");
+    index.add("alex/diet", "entry-3");
+
+    expect(index.crossEntityLookup("alex/weight")).toEqual(["entry-2"]);
+  });
+
+  it("crossEntityLookup returns empty when attribute is unique", () => {
+    const index = new SubjectIndex();
+    index.add("alex/weight", "entry-1");
+    index.add("alex/diet", "entry-2");
+
+    expect(index.crossEntityLookup("alex/weight")).toEqual([]);
+  });
+
   it("add inserts entries and deduplicates per key", () => {
     const index = new SubjectIndex();
     index.add("person:alice|attr:role", "entry-1");

--- a/tests/db/subject-index.test.ts
+++ b/tests/db/subject-index.test.ts
@@ -105,6 +105,14 @@ describe("SubjectIndex", () => {
     expect(index.crossEntityLookup("alex/weight")).toEqual([]);
   });
 
+  it("parseSubjectKey handles entity names that originally contained slashes", () => {
+    const index = new SubjectIndex();
+    index.add("owner-repo/default_branch", "entry-1");
+    index.add("other-repo/default_branch", "entry-2");
+
+    expect(index.crossEntityLookup("owner-repo/default_branch")).toEqual(["entry-2"]);
+  });
+
   it("add inserts entries and deduplicates per key", () => {
     const index = new SubjectIndex();
     index.add("person:alice|attr:role", "entry-1");

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -553,6 +553,43 @@ describe("runSetupCore", () => {
       claimExtraction: "gpt-4.1-mini",
     });
   });
+
+  it("stores explicitly selected task model even when it matches the default", async () => {
+    const mocks = getMocks();
+    const env = await makeTempConfigEnv();
+
+    mocks.selectMock
+      .mockResolvedValueOnce("openai-api-key")
+      .mockResolvedValueOnce("gpt-4.1-mini")
+      .mockResolvedValueOnce("configure")
+      .mockResolvedValueOnce("__use_default__")
+      .mockResolvedValueOnce("__use_default__")
+      .mockResolvedValueOnce("gpt-4.1-nano")
+      .mockResolvedValueOnce("__use_default__");
+    mocks.probeCredentialsMock.mockReturnValue({
+      available: true,
+      source: "env:OPENAI_API_KEY",
+      guidance: "Credentials available.",
+      credentials: {
+        apiKey: "sk-test",
+        source: "env:OPENAI_API_KEY",
+      },
+    });
+    mocks.runConnectionTestMock.mockResolvedValueOnce({ ok: true });
+
+    const result = await setupModule.runSetupCore({
+      env,
+      existingConfig: null,
+      skipIntroOutro: true,
+    });
+
+    expect(result?.config.models).toEqual({
+      contradictionJudge: "gpt-4.1-nano",
+    });
+    expect(readConfig(env)?.models).toEqual({
+      contradictionJudge: "gpt-4.1-nano",
+    });
+  });
 });
 
 describe("runSetup", () => {


### PR DESCRIPTION
## Summary

Init/setup wizard improvements and swarm review fixes building on #266.

### Features
- Init wizard: three-way reconfigure (keep / change model only / change auth+model) (#275)
- Per-task model configuration in init wizard
- `config set models.<task>` dot-path support for task model overrides (#276)
- CLI banner displays agenr version (#278)

### Fixes (swarm review)
- `resolveConflict` now reads `autoSupersedeConfidence` from config instead of hardcoding 0.85
- Claim fields explicitly propagated through mutation pipeline (no object-identity dependency)
- Supersede + insert wrapped in transaction for online-dedup path
- Entity names with slashes sanitized during claim extraction
- LLM judge errors logged via console.warn instead of silent fallback
- Entity alias resolution no longer depends on single-entity heuristic
- Setup/init wizards write explicitly selected task models even when matching defaults

### Tests
- 1488+ tests passing

Closes #275, closes #276, closes #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-task model overrides via dot-path config (models.<task>)
  * Init wizard: change model without re-running auth; separate model-only path and per-task prompts
  * Entity hints retrieval to improve claim extraction; distinct-entity listing available

* **Bug Fixes**
  * CLI banner shows current version
  * Entity names with slashes sanitized in extraction
  * LLM judge errors now logged visibly
  * Per-task model selections persisted even when matching defaults
  * Entity alias resolution improved

* **Improvements**
  * Transactional handling for online deduplication
  * Fuzzy and cross-entity subject lookups for better matching
  * Configurable auto-supersede threshold for conflict resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->