### PR TITLE
refactor: remove top-level model, require task models (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.9.4 (2026-02-27)
+
+### Changed
+- refactor: removed top-level `model` config field; `models` is now required with all four task keys (extraction, claimExtraction, contradictionJudge, handoffSummary) always explicit (#277)
+- `resolveModelForTask` simplified to direct lookup (no fallback chain)
+- `isCompleteConfig` now checks for complete `models` instead of top-level `model`
+- Old configs with top-level `model` auto-upgrade on read (value populates all task models)
+- `config set model <value>` removed; use `config set models.extraction <value>` etc.
+
 ## 0.9.3 (2026-02-26)
 
 ### Added

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -664,6 +664,10 @@ Configuration
 Auth: OpenAI API key
 Provider: openai
 Model: gpt-4.1-mini
+  Extraction: gpt-4.1-mini
+  Claim extraction: gpt-4.1-nano
+  Contradiction judge: gpt-4.1-nano
+  Handoff summary: gpt-4.1-nano
 Credentials
   Anthropic API Key: (not set)
   Anthropic Token: (not set)
@@ -681,7 +685,7 @@ agenr config set <key> <value>
 ```
 
 ### Arguments
-- `key`: `provider|model|auth`
+- `key`: `provider|auth|models.<task>`
 - `value`: new value
 
 ### Options
@@ -691,14 +695,16 @@ agenr config set <key> <value>
 
 ```bash
 $A config set auth openai-api-key
-$A config set model gpt-4.1-mini
+$A config set models.extraction gpt-4.1-mini
+$A config set models.claimExtraction gpt-4.1-nano
 ```
 
 ### Example Output
 
 ```text
 Updated auth: openai-api-key
-Updated model: gpt-4.1-mini
+Updated models.extraction: gpt-4.1-mini
+Updated models.claimExtraction: gpt-4.1-nano
 ```
 
 ## `config set-key`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,7 +19,7 @@ Created and updated by `agenr setup`. You can also edit it directly or use `agen
 |-----|------|-------------|
 | `auth` | string | Authentication method (see [Auth Methods](#auth-methods)). |
 | `provider` | string | LLM provider: `anthropic`, `openai`, or `openai-codex`. |
-| `model` | string | Model name for extraction. |
+| `models` | object | Per-task model map with required keys: `extraction`, `claimExtraction`, `contradictionJudge`, `handoffSummary`. |
 | `credentials` | object | Stored API keys (see [Credentials](#credentials)). |
 | `embedding` | object | Embedding provider settings (see [Embedding](#embedding)). |
 | `db` | object | Database path configuration (see [Database](#database)). |
@@ -144,7 +144,7 @@ Controls deduplication behavior when storing entries. Applies globally to all st
 `agenr setup` is interactive. It:
 1. Asks which auth method to use
 2. Prompts for credentials if needed (API keys, OAuth login)
-3. Lets you pick a default model
+3. Lets you pick extraction and per-task models
 4. Writes everything to `~/.agenr/config.json`
 
 Config file values take precedence over environment variables for embedding API key resolution: `embedding.apiKey` -> `credentials.openaiApiKey` -> `OPENAI_API_KEY` env var. See [Embedding](#embedding) for details.
@@ -156,3 +156,19 @@ Database migrations auto-apply on first run after an upgrade. We recommend backi
 ```bash
 cp ~/.agenr/knowledge.db ~/.agenr/knowledge.db.backup
 ```
+### Models
+
+`models` is required and always contains all task keys:
+
+```json
+{
+  "models": {
+    "extraction": "gpt-4.1-nano",
+    "claimExtraction": "gpt-4.1-nano",
+    "contradictionJudge": "gpt-4.1-nano",
+    "handoffSummary": "gpt-4.1-nano"
+  }
+}
+```
+
+Use `agenr config set models.<task> <value>` to update one task model.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/auth-status.ts
+++ b/src/auth-status.ts
@@ -11,6 +11,7 @@ export interface AuthStatusResult {
   provider?: AgenrProvider;
   auth?: AgenrAuthMethod;
   model?: string;
+  models?: AgenrConfig["models"];
   credentialAvailable: boolean;
   credentialSource?: string;
   authenticated?: boolean;
@@ -147,7 +148,8 @@ function configNotReadyResult(config: AgenrConfig | null): AuthStatusResult {
     configured: false,
     provider: config?.provider,
     auth: config?.auth,
-    model: config?.model,
+    model: config?.models?.extraction,
+    models: config?.models,
     credentialAvailable: false,
     guidance: "Not configured. Run `agenr setup`.",
   };
@@ -170,7 +172,8 @@ export function getQuickStatus(env: NodeJS.ProcessEnv = process.env): AuthStatus
       configured: true,
       provider: config.provider,
       auth: config.auth,
-      model: config.model,
+      model: config.models.extraction,
+      models: config.models,
       credentialAvailable: false,
       guidance: probe.guidance,
     };
@@ -180,7 +183,8 @@ export function getQuickStatus(env: NodeJS.ProcessEnv = process.env): AuthStatus
     configured: true,
     provider: config.provider,
     auth: config.auth,
-    model: config.model,
+    model: config.models.extraction,
+    models: config.models,
     credentialAvailable: true,
     credentialSource: probe.source,
     guidance: "Credentials available.",
@@ -210,7 +214,8 @@ export async function getAuthStatus(
               configured: true,
               provider: loadedConfig.provider,
               auth: loadedConfig.auth,
-              model: loadedConfig.model,
+              model: loadedConfig.models.extraction,
+              models: loadedConfig.models,
               credentialAvailable: false,
               guidance: probe.guidance,
             } satisfies AuthStatusResult;
@@ -220,7 +225,8 @@ export async function getAuthStatus(
             configured: true,
             provider: loadedConfig.provider,
             auth: loadedConfig.auth,
-            model: loadedConfig.model,
+            model: loadedConfig.models.extraction,
+            models: loadedConfig.models,
             credentialAvailable: true,
             credentialSource: probe.source,
             guidance: "Credentials available.",

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1125,7 +1125,6 @@ export function createProgram(): Command {
         [
           formatLabel("Auth", config.auth ? describeAuth(config.auth) : ui.dim("(not set)")),
           formatLabel("Provider", config.provider ?? ui.dim("(not set)")),
-          formatLabel("Model", config.models.extraction),
           ...formatTaskModelLines(config.models),
           "",
           ui.bold("Credentials"),

--- a/src/commands/backfill-claims.ts
+++ b/src/commands/backfill-claims.ts
@@ -1,4 +1,4 @@
-import { readConfig, resolveModelForTask } from "../config.js";
+import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
 import { closeDb, DEFAULT_DB_PATH, getDb, initDb } from "../db/client.js";
 import { extractClaim } from "../db/claim-extraction.js";
 import { SubjectIndex } from "../db/subject-index.js";
@@ -128,7 +128,7 @@ export async function runBackfillClaimsCommand(
 
     const total = candidates.entries.length;
     if (total > 0) {
-      const model = opts.model?.trim() || resolveModelForTask(config ?? {}, "claimExtraction");
+      const model = opts.model?.trim() || config?.models?.claimExtraction || DEFAULT_TASK_MODEL;
       const llmClient = createLlmClient({
         model,
         env: process.env,

--- a/src/commands/backfill-claims.ts
+++ b/src/commands/backfill-claims.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
+import { readConfig, resolveModelForTask } from "../config.js";
 import { closeDb, DEFAULT_DB_PATH, getDb, initDb } from "../db/client.js";
 import { extractClaim } from "../db/claim-extraction.js";
 import { SubjectIndex } from "../db/subject-index.js";
@@ -128,7 +128,7 @@ export async function runBackfillClaimsCommand(
 
     const total = candidates.entries.length;
     if (total > 0) {
-      const model = opts.model?.trim() || config?.models?.claimExtraction || DEFAULT_TASK_MODEL;
+      const model = opts.model?.trim() || resolveModelForTask(config, "claimExtraction");
       const llmClient = createLlmClient({
         model,
         env: process.env,

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { Client } from "@libsql/client";
 import * as clack from "@clack/prompts";
-import { readConfig, resolveModelForTask } from "../config.js";
+import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
 import { deduplicateEntries } from "../dedup.js";
 import { closeDb, getDb, initDb, walCheckpoint } from "../db/client.js";
 import { computeMinhashSig, computeNormContentHash, minhashSigToBuffer } from "../db/minhash.js";
@@ -688,7 +688,7 @@ export async function runIngestCommand(
   const config = resolvedDeps.readConfigFn(process.env);
   const claimExtractionEnabled = config?.contradiction?.enabled !== false;
   const contradictionEnabled = config?.contradiction?.enabled !== false;
-  const claimExtractionModel = resolveModelForTask(config ?? {}, "claimExtraction");
+  const claimExtractionModel = config?.models?.claimExtraction ?? DEFAULT_TASK_MODEL;
   const client = resolvedDeps.createLlmClientFn({
     provider: options.provider,
     model: options.model,

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { Client } from "@libsql/client";
 import * as clack from "@clack/prompts";
-import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
+import { readConfig, resolveModelForTask } from "../config.js";
 import { deduplicateEntries } from "../dedup.js";
 import { closeDb, getDb, initDb, walCheckpoint } from "../db/client.js";
 import { computeMinhashSig, computeNormContentHash, minhashSigToBuffer } from "../db/minhash.js";
@@ -688,7 +688,7 @@ export async function runIngestCommand(
   const config = resolvedDeps.readConfigFn(process.env);
   const claimExtractionEnabled = config?.contradiction?.enabled !== false;
   const contradictionEnabled = config?.contradiction?.enabled !== false;
-  const claimExtractionModel = config?.models?.claimExtraction ?? DEFAULT_TASK_MODEL;
+  const claimExtractionModel = resolveModelForTask(config, "claimExtraction");
   const client = resolvedDeps.createLlmClientFn({
     provider: options.provider,
     model: options.model,

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -536,7 +536,7 @@ describe("runInitCommand", () => {
       const projects = config.projects as Record<string, unknown>;
       expect(config.auth).toBe("openai-api-key");
       expect(config.provider).toBe("openai");
-      expect(config.model).toBe("gpt-4.1-mini");
+      expect((config.models as Record<string, string>)?.extraction).toBe("gpt-4.1-mini");
       expect(projects[path.resolve(dir)]).toEqual({
         project: result.project,
         platform: "openclaw",
@@ -993,7 +993,17 @@ describe("runInitWizard", () => {
       await runInitWizard({ isInteractive: true, path: dir });
 
       expect(formatExistingConfigMock).toHaveBeenCalledWith(
-        existingConfig,
+        expect.objectContaining({
+          auth: "openai-api-key",
+          provider: "openai",
+          projects: existingConfig.projects,
+          models: {
+            extraction: "gpt-4.1-mini",
+            claimExtraction: "gpt-4.1-mini",
+            contradictionJudge: "gpt-4.1-mini",
+            handoffSummary: "gpt-4.1-mini",
+          },
+        }),
         path.join(homeDir, ".agenr", "knowledge.db"),
       );
       expect(clackNoteMock).toHaveBeenCalledWith(expect.stringContaining("Projects:\n  openclaw"), "Current config");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -936,13 +936,13 @@ function normalizeTaskModels(models: Partial<AgenrConfig["models"]> | undefined)
   return normalized;
 }
 
-function resolveTaskModelDefaults(baseModel: string | undefined): TaskModelRecord {
-  const extractionModel = baseModel?.trim() || DEFAULT_TASK_MODEL;
+export function resolveTaskModelDefaults(baseModel: string | undefined): TaskModelRecord {
+  const model = baseModel?.trim() || DEFAULT_TASK_MODEL;
   return {
-    extraction: extractionModel,
-    claimExtraction: DEFAULT_TASK_MODEL,
-    contradictionJudge: DEFAULT_TASK_MODEL,
-    handoffSummary: DEFAULT_TASK_MODEL,
+    extraction: model,
+    claimExtraction: model,
+    contradictionJudge: model,
+    handoffSummary: model,
   };
 }
 

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import * as clack from "@clack/prompts";
-import { readConfig, resolveModelForTask } from "../config.js";
+import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
 import { closeDb, getDb, initDb, walCheckpoint } from "../db/client.js";
 import { hashText, storeEntries } from "../db/store.js";
 import { acquireDbLock, releaseDbLock } from "../db/lockfile.js";
@@ -332,7 +332,7 @@ export async function runStoreCommand(
   const llmClient = onlineDedup && hasAnyEntries ? resolvedDeps.createLlmClientFn({ env: process.env }) : undefined;
   const claimExtractionEnabled = config?.contradiction?.enabled !== false;
   const contradictionEnabled = config?.contradiction?.enabled !== false;
-  const claimExtractionModel = resolveModelForTask(config ?? {}, "claimExtraction");
+  const claimExtractionModel = config?.models?.claimExtraction ?? DEFAULT_TASK_MODEL;
 
   const dbPath = options.db?.trim() || config?.db?.path;
   const shouldLockDb = dbPath !== ":memory:";

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import * as clack from "@clack/prompts";
-import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
+import { readConfig, resolveModelForTask } from "../config.js";
 import { closeDb, getDb, initDb, walCheckpoint } from "../db/client.js";
 import { hashText, storeEntries } from "../db/store.js";
 import { acquireDbLock, releaseDbLock } from "../db/lockfile.js";
@@ -332,7 +332,7 @@ export async function runStoreCommand(
   const llmClient = onlineDedup && hasAnyEntries ? resolvedDeps.createLlmClientFn({ env: process.env }) : undefined;
   const claimExtractionEnabled = config?.contradiction?.enabled !== false;
   const contradictionEnabled = config?.contradiction?.enabled !== false;
-  const claimExtractionModel = config?.models?.claimExtraction ?? DEFAULT_TASK_MODEL;
+  const claimExtractionModel = resolveModelForTask(config, "claimExtraction");
 
   const dbPath = options.db?.trim() || config?.db?.path;
   const shouldLockDb = dbPath !== ":memory:";

--- a/src/config.ts
+++ b/src/config.ts
@@ -834,6 +834,9 @@ export function describeAuth(auth: AgenrAuthMethod): string {
   return "OpenAI API key";
 }
 
-export function resolveModelForTask(config: AgenrConfig, task: ModelTask): string {
-  return config.models[task];
+export function resolveModelForTask(
+  config: AgenrConfig | null | undefined,
+  task: ModelTask,
+): string {
+  return config?.models?.[task] ?? DEFAULT_TASK_MODEL;
 }

--- a/src/db/llm-helpers.ts
+++ b/src/db/llm-helpers.ts
@@ -1,4 +1,4 @@
-import { resolveModelForTask, type ModelTask } from "../config.js";
+import { DEFAULT_TASK_MODEL, type ModelTask } from "../config.js";
 import { resolveModel } from "../llm/models.js";
 import type { AgenrConfig, LlmClient } from "../types.js";
 
@@ -25,7 +25,7 @@ export function resolveModelForLlmClient(
   model?: string,
   config?: AgenrConfig,
 ): ReturnType<typeof resolveModel>["model"] {
-  const modelId = model?.trim() || resolveModelForTask(config ?? {}, taskKey);
+  const modelId = model?.trim() || config?.models?.[taskKey]?.trim() || DEFAULT_TASK_MODEL;
   return resolveModel(client.resolvedModel.provider, modelId).model;
 }
 

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -23,7 +23,7 @@ export function resolveProviderAndModel(input: ResolveLlmClientInput): {
   }
 
   const providerRaw = input.provider?.trim() || config.provider?.trim();
-  const modelRaw = input.model?.trim() || config.model?.trim();
+  const modelRaw = input.model?.trim() || config?.models?.extraction?.trim();
 
   if (!providerRaw || !modelRaw) {
     throw new Error(

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -120,13 +120,12 @@ const TASK_MODEL_PROMPTS: Array<{ task: TaskModelKey; title: string; options: st
   },
 ];
 
-function buildTaskModels(baseModel: string, overrides?: Partial<AgenrConfig["models"]>): AgenrConfig["models"] {
-  const extractionModel = overrides?.extraction?.trim() || baseModel;
+export function buildTaskModels(baseModel: string, overrides?: Partial<AgenrConfig["models"]>): AgenrConfig["models"] {
   return {
-    extraction: extractionModel,
-    claimExtraction: overrides?.claimExtraction?.trim() || DEFAULT_TASK_MODEL,
-    contradictionJudge: overrides?.contradictionJudge?.trim() || DEFAULT_TASK_MODEL,
-    handoffSummary: overrides?.handoffSummary?.trim() || DEFAULT_TASK_MODEL,
+    extraction: overrides?.extraction?.trim() || baseModel,
+    claimExtraction: overrides?.claimExtraction?.trim() || baseModel,
+    contradictionJudge: overrides?.contradictionJudge?.trim() || baseModel,
+    handoffSummary: overrides?.handoffSummary?.trim() || baseModel,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,12 +44,11 @@ export interface AgenrStoredCredentials {
 export interface AgenrConfig {
   auth?: AgenrAuthMethod;
   provider?: AgenrProvider;
-  model?: string;
-  models?: {
-    extraction?: string;
-    claimExtraction?: string;
-    contradictionJudge?: string;
-    handoffSummary?: string;
+  models: {
+    extraction: string;
+    claimExtraction: string;
+    contradictionJudge: string;
+    handoffSummary: string;
   };
   labelProjectMap?: Record<string, string>;
   projects?: Record<

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { Client } from "@libsql/client";
-import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
+import { readConfig, resolveModelForTask } from "../config.js";
 import { deduplicateEntries } from "../dedup.js";
 import { closeDb, getDb, initDb, walCheckpoint } from "../db/client.js";
 import { storeEntries } from "../db/store.js";
@@ -279,7 +279,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
   const config = resolvedDeps.readConfigFn(process.env);
   const claimExtractionEnabled = config?.contradiction?.enabled !== false;
   const contradictionEnabled = config?.contradiction?.enabled !== false;
-  const claimExtractionModel = config?.models?.claimExtraction ?? DEFAULT_TASK_MODEL;
+  const claimExtractionModel = resolveModelForTask(config, "claimExtraction");
   const dbPath = options.dbPath?.trim() || config?.db?.path;
   const db = options.dryRun ? null : resolvedDeps.getDbFn(dbPath);
   let embeddingApiKey: string | null = null;

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { Client } from "@libsql/client";
-import { readConfig, resolveModelForTask } from "../config.js";
+import { DEFAULT_TASK_MODEL, readConfig } from "../config.js";
 import { deduplicateEntries } from "../dedup.js";
 import { closeDb, getDb, initDb, walCheckpoint } from "../db/client.js";
 import { storeEntries } from "../db/store.js";
@@ -279,7 +279,7 @@ export async function runWatcher(options: WatcherOptions, deps?: Partial<Watcher
   const config = resolvedDeps.readConfigFn(process.env);
   const claimExtractionEnabled = config?.contradiction?.enabled !== false;
   const contradictionEnabled = config?.contradiction?.enabled !== false;
-  const claimExtractionModel = resolveModelForTask(config ?? {}, "claimExtraction");
+  const claimExtractionModel = config?.models?.claimExtraction ?? DEFAULT_TASK_MODEL;
   const dbPath = options.dbPath?.trim() || config?.db?.path;
   const db = options.dryRun ? null : resolvedDeps.getDbFn(dbPath);
   let embeddingApiKey: string | null = null;

--- a/tests/auth-status.test.ts
+++ b/tests/auth-status.test.ts
@@ -62,7 +62,12 @@ describe("auth status", () => {
     const config: AgenrConfig = {
       auth: "openai-api-key",
       provider: "openai",
-      model: "gpt-5.2-codex",
+      models: {
+        extraction: "gpt-5.2-codex",
+        claimExtraction: "gpt-5.2-codex",
+        contradictionJudge: "gpt-5.2-codex",
+        handoffSummary: "gpt-5.2-codex",
+      },
     };
 
     const status = await getAuthStatus(
@@ -84,7 +89,12 @@ describe("auth status", () => {
     const config: AgenrConfig = {
       auth: "openai-api-key",
       provider: "openai",
-      model: "gpt-5.2-codex",
+      models: {
+        extraction: "gpt-5.2-codex",
+        claimExtraction: "gpt-5.2-codex",
+        contradictionJudge: "gpt-5.2-codex",
+        handoffSummary: "gpt-5.2-codex",
+      },
       credentials: {
         openaiApiKey: "sk-test",
       },
@@ -107,7 +117,12 @@ describe("auth status", () => {
     const config: AgenrConfig = {
       auth: "openai-api-key",
       provider: "openai",
-      model: "gpt-5.2-codex",
+      models: {
+        extraction: "gpt-5.2-codex",
+        claimExtraction: "gpt-5.2-codex",
+        contradictionJudge: "gpt-5.2-codex",
+        handoffSummary: "gpt-5.2-codex",
+      },
       credentials: {
         openaiApiKey: "sk-test",
       },

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -48,7 +48,12 @@ describe("llm client", () => {
       {
         auth: "anthropic-api-key",
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        models: {
+          extraction: "claude-opus-4-6",
+          claimExtraction: "claude-opus-4-6",
+          contradictionJudge: "claude-opus-4-6",
+          handoffSummary: "claude-opus-4-6",
+        },
       },
       env,
     );
@@ -66,7 +71,12 @@ describe("llm client", () => {
       {
         auth: "anthropic-api-key",
         provider: "anthropic",
-        model: "claude-opus-4-6",
+        models: {
+          extraction: "claude-opus-4-6",
+          claimExtraction: "claude-opus-4-6",
+          contradictionJudge: "claude-opus-4-6",
+          handoffSummary: "claude-opus-4-6",
+        },
       },
       env,
     );
@@ -93,7 +103,12 @@ describe("llm client", () => {
       {
         auth: "openai-subscription",
         provider: "openai-codex",
-        model: "gpt-5.3-codex",
+        models: {
+          extraction: "gpt-5.3-codex",
+          claimExtraction: "gpt-5.3-codex",
+          contradictionJudge: "gpt-5.3-codex",
+          handoffSummary: "gpt-5.3-codex",
+        },
       },
       env,
     );
@@ -113,7 +128,12 @@ describe("llm client", () => {
       {
         auth: "openai-api-key",
         provider: "openai",
-        model: "gpt-5.2-codex",
+        models: {
+          extraction: "gpt-5.2-codex",
+          claimExtraction: "gpt-5.2-codex",
+          contradictionJudge: "gpt-5.2-codex",
+          handoffSummary: "gpt-5.2-codex",
+        },
         credentials: {
           openaiApiKey: "sk-from-config",
         },

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -200,6 +200,17 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
+describe("task model defaults", () => {
+  it("resolveTaskModelDefaults applies the base model to all tasks", () => {
+    expect(initModule.resolveTaskModelDefaults("claude-sonnet-4-20250514")).toEqual({
+      extraction: "claude-sonnet-4-20250514",
+      claimExtraction: "claude-sonnet-4-20250514",
+      contradictionJudge: "claude-sonnet-4-20250514",
+      handoffSummary: "claude-sonnet-4-20250514",
+    });
+  });
+});
+
 describe("init wizard auth/model reconfigure", () => {
   it("updates model via change-model without re-running auth setup", async () => {
     const current = getMocks();

--- a/tests/config-commands.test.ts
+++ b/tests/config-commands.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { maskSecret, setConfigKey, setStoredCredential } from "../src/config.js";
 import type { AgenrConfig } from "../src/types.js";
 
+const DEFAULT_MODELS: AgenrConfig["models"] = {
+  extraction: "gpt-4.1-nano",
+  claimExtraction: "gpt-4.1-nano",
+  contradictionJudge: "gpt-4.1-nano",
+  handoffSummary: "gpt-4.1-nano",
+};
+
 describe("config command helpers", () => {
   it("sets auth and automatically maps provider", () => {
     const result = setConfigKey({}, "auth", "openai-subscription");
@@ -14,28 +21,33 @@ describe("config command helpers", () => {
     const current: AgenrConfig = {
       auth: "openai-subscription",
       provider: "openai-codex",
-      model: "gpt-5.3-codex",
+      models: {
+        extraction: "gpt-5.3-codex",
+        claimExtraction: "gpt-5.3-codex",
+        contradictionJudge: "gpt-5.3-codex",
+        handoffSummary: "gpt-5.3-codex",
+      },
     };
 
     expect(() => setConfigKey(current, "provider", "openai")).toThrow("is incompatible with auth");
   });
 
-  it("validates model against current provider", () => {
-    const current: AgenrConfig = {
-      auth: "openai-api-key",
-      provider: "openai",
-      model: "gpt-5.2-codex",
-    };
-
-    const result = setConfigKey(current, "model", "gpt-4o");
-    expect(result.config.model).toBe("gpt-4o");
+  it("rejects top-level model key", () => {
+    expect(() => setConfigKey({}, "model", "gpt-4o")).toThrow(
+      'Invalid key. Expected one of: "provider", "auth", or "models.<task>".',
+    );
   });
 
   it("warns when changing auth leaves model incompatible", () => {
     const current: AgenrConfig = {
       auth: "openai-api-key",
       provider: "openai",
-      model: "definitely-not-an-anthropic-model",
+      models: {
+        extraction: "definitely-not-an-anthropic-model",
+        claimExtraction: "gpt-4.1-nano",
+        contradictionJudge: "gpt-4.1-nano",
+        handoffSummary: "gpt-4.1-nano",
+      },
     };
 
     const result = setConfigKey(current, "auth", "anthropic-api-key");
@@ -46,14 +58,14 @@ describe("config command helpers", () => {
   it("sets per-task model override via dot-path", () => {
     const result = setConfigKey({}, "models.extraction", "gpt-4.1");
 
-    expect(result.config.models?.extraction).toBe("gpt-4.1");
+    expect(result.config.models.extraction).toBe("gpt-4.1");
   });
 
-  it("removes per-task override when value is default", () => {
+  it("resets task model to default when value is default", () => {
     const first = setConfigKey({}, "models.extraction", "gpt-4.1");
     const second = setConfigKey(first.config, "models.extraction", "default");
 
-    expect(second.config.models?.extraction).toBeUndefined();
+    expect(second.config.models.extraction).toBe("gpt-4.1-nano");
   });
 
   it("rejects invalid task name in models dot-path", () => {
@@ -67,23 +79,20 @@ describe("config command helpers", () => {
     const second = setConfigKey(first.config, "models.claimExtraction", "gpt-4.1-mini");
     const third = setConfigKey(second.config, "models.extraction", "gpt-4.1-nano");
 
-    expect(third.config.models).toEqual({
-      extraction: "gpt-4.1-nano",
-      claimExtraction: "gpt-4.1-mini",
-    });
+    expect(third.config.models).toEqual({ ...DEFAULT_MODELS, claimExtraction: "gpt-4.1-mini" });
   });
 
-  it("removes models field when last override is cleared", () => {
+  it("keeps full models when values are reset", () => {
     const first = setConfigKey({}, "models.handoffSummary", "gpt-4.1-mini");
     const second = setConfigKey(first.config, "models.handoffSummary", "default");
 
-    expect(second.config.models).toBeUndefined();
+    expect(second.config.models).toEqual(DEFAULT_MODELS);
   });
 
   it("writes task model override even when value matches task default", () => {
     const result = setConfigKey({}, "models.contradictionJudge", "gpt-4.1-nano");
 
-    expect(result.config.models?.contradictionJudge).toBe("gpt-4.1-nano");
+    expect(result.config.models.contradictionJudge).toBe("gpt-4.1-nano");
   });
 
   it("stores and overwrites credential fields", () => {

--- a/tests/config-commands.test.ts
+++ b/tests/config-commands.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { maskSecret, setConfigKey, setStoredCredential } from "../src/config.js";
+import { DEFAULT_TASK_MODEL, maskSecret, setConfigKey, setStoredCredential } from "../src/config.js";
 import type { AgenrConfig } from "../src/types.js";
 
 const DEFAULT_MODELS: AgenrConfig["models"] = {
-  extraction: "gpt-4.1-nano",
-  claimExtraction: "gpt-4.1-nano",
-  contradictionJudge: "gpt-4.1-nano",
-  handoffSummary: "gpt-4.1-nano",
+  extraction: DEFAULT_TASK_MODEL,
+  claimExtraction: DEFAULT_TASK_MODEL,
+  contradictionJudge: DEFAULT_TASK_MODEL,
+  handoffSummary: DEFAULT_TASK_MODEL,
 };
 
 describe("config command helpers", () => {
@@ -65,7 +65,7 @@ describe("config command helpers", () => {
     const first = setConfigKey({}, "models.extraction", "gpt-4.1");
     const second = setConfigKey(first.config, "models.extraction", "default");
 
-    expect(second.config.models.extraction).toBe("gpt-4.1-nano");
+    expect(second.config.models.extraction).toBe(DEFAULT_TASK_MODEL);
   });
 
   it("rejects invalid task name in models dot-path", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -464,8 +464,8 @@ describe("resolveModelForTask", () => {
       models: {
         extraction: "gpt-4.1",
         claimExtraction: "gpt-4.1-mini",
-        contradictionJudge: "gpt-4.1-nano",
-        handoffSummary: "gpt-4.1-nano",
+        contradictionJudge: DEFAULT_TASK_MODEL,
+        handoffSummary: DEFAULT_TASK_MODEL,
       },
     };
 
@@ -478,14 +478,22 @@ describe("resolveModelForTask", () => {
         extraction: "gpt-4.1",
         claimExtraction: "gpt-4.1-mini",
         contradictionJudge: "gpt-4.1",
-        handoffSummary: "gpt-4.1-nano",
+        handoffSummary: DEFAULT_TASK_MODEL,
       },
     };
 
     expect(resolveModelForTask(config, "extraction")).toBe("gpt-4.1");
     expect(resolveModelForTask(config, "claimExtraction")).toBe("gpt-4.1-mini");
     expect(resolveModelForTask(config, "contradictionJudge")).toBe("gpt-4.1");
-    expect(resolveModelForTask(config, "handoffSummary")).toBe("gpt-4.1-nano");
+    expect(resolveModelForTask(config, "handoffSummary")).toBe(DEFAULT_TASK_MODEL);
+  });
+
+  it("falls back to default when config is null", () => {
+    expect(resolveModelForTask(null, "claimExtraction")).toBe(DEFAULT_TASK_MODEL);
+  });
+
+  it("falls back to default when config is undefined", () => {
+    expect(resolveModelForTask(undefined, "claimExtraction")).toBe(DEFAULT_TASK_MODEL);
   });
 });
 

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -96,15 +96,15 @@ import * as setupModule from "../src/setup.js";
 const tempDirs: string[] = [];
 const OPENAI_BASE_MODELS = {
   extraction: "openai/gpt-4.1",
-  claimExtraction: "gpt-4.1-nano",
-  contradictionJudge: "gpt-4.1-nano",
-  handoffSummary: "gpt-4.1-nano",
+  claimExtraction: "openai/gpt-4.1",
+  contradictionJudge: "openai/gpt-4.1",
+  handoffSummary: "openai/gpt-4.1",
 } as const;
 const OPENAI_MINI_MODELS = {
   extraction: "openai/gpt-4.1-mini",
-  claimExtraction: "gpt-4.1-nano",
-  contradictionJudge: "gpt-4.1-nano",
-  handoffSummary: "gpt-4.1-nano",
+  claimExtraction: "openai/gpt-4.1-mini",
+  contradictionJudge: "openai/gpt-4.1-mini",
+  handoffSummary: "openai/gpt-4.1-mini",
 } as const;
 
 async function makeTempConfigEnv(): Promise<NodeJS.ProcessEnv> {
@@ -225,6 +225,15 @@ describe("formatExistingConfig", () => {
 });
 
 describe("runSetupCore", () => {
+  it("buildTaskModels defaults every task to the base model", () => {
+    expect(setupModule.buildTaskModels("claude-sonnet-4-20250514")).toEqual({
+      extraction: "claude-sonnet-4-20250514",
+      claimExtraction: "claude-sonnet-4-20250514",
+      contradictionJudge: "claude-sonnet-4-20250514",
+      handoffSummary: "claude-sonnet-4-20250514",
+    });
+  });
+
   it("returns SetupResult with auth, provider, model on success", async () => {
     const mocks = getMocks();
     const env = await makeTempConfigEnv();
@@ -571,14 +580,14 @@ describe("runSetupCore", () => {
     expect(result?.config.models).toEqual({
       extraction: "openai/gpt-4.1-mini",
       claimExtraction: "gpt-4.1-mini",
-      contradictionJudge: "gpt-4.1-nano",
-      handoffSummary: "gpt-4.1-nano",
+      contradictionJudge: "openai/gpt-4.1-mini",
+      handoffSummary: "openai/gpt-4.1-mini",
     });
     expect(readConfig(env)?.models).toEqual({
       extraction: "openai/gpt-4.1-mini",
       claimExtraction: "gpt-4.1-mini",
-      contradictionJudge: "gpt-4.1-nano",
-      handoffSummary: "gpt-4.1-nano",
+      contradictionJudge: "openai/gpt-4.1-mini",
+      handoffSummary: "openai/gpt-4.1-mini",
     });
   });
 
@@ -613,15 +622,15 @@ describe("runSetupCore", () => {
 
     expect(result?.config.models).toEqual({
       extraction: "openai/gpt-4.1-mini",
-      claimExtraction: "gpt-4.1-nano",
+      claimExtraction: "openai/gpt-4.1-mini",
       contradictionJudge: "gpt-4.1-nano",
-      handoffSummary: "gpt-4.1-nano",
+      handoffSummary: "openai/gpt-4.1-mini",
     });
     expect(readConfig(env)?.models).toEqual({
       extraction: "openai/gpt-4.1-mini",
-      claimExtraction: "gpt-4.1-nano",
+      claimExtraction: "openai/gpt-4.1-mini",
       contradictionJudge: "gpt-4.1-nano",
-      handoffSummary: "gpt-4.1-nano",
+      handoffSummary: "openai/gpt-4.1-mini",
     });
   });
 });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -94,6 +94,18 @@ vi.mock("../src/auth-status.js", () => ({
 import * as setupModule from "../src/setup.js";
 
 const tempDirs: string[] = [];
+const OPENAI_BASE_MODELS = {
+  extraction: "openai/gpt-4.1",
+  claimExtraction: "gpt-4.1-nano",
+  contradictionJudge: "gpt-4.1-nano",
+  handoffSummary: "gpt-4.1-nano",
+} as const;
+const OPENAI_MINI_MODELS = {
+  extraction: "openai/gpt-4.1-mini",
+  claimExtraction: "gpt-4.1-nano",
+  contradictionJudge: "gpt-4.1-nano",
+  handoffSummary: "gpt-4.1-nano",
+} as const;
 
 async function makeTempConfigEnv(): Promise<NodeJS.ProcessEnv> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agenr-setup-test-"));
@@ -126,7 +138,7 @@ describe("formatExistingConfig", () => {
       {
         auth: "openai-api-key",
         provider: "openai",
-        model: "openai/gpt-4.1",
+        models: OPENAI_BASE_MODELS,
         projects: {
           [path.join(os.homedir(), ".openclaw")]: {
             project: "openclaw",
@@ -152,7 +164,7 @@ describe("formatExistingConfig", () => {
     const formatted = setupModule.formatExistingConfig({
       auth: "openai-api-key",
       provider: "openai",
-      model: "openai/gpt-4.1",
+      models: OPENAI_BASE_MODELS,
     });
 
     expect(formatted).not.toContain("Projects:");
@@ -164,7 +176,7 @@ describe("formatExistingConfig", () => {
       {
         auth: "openai-api-key",
         provider: "openai",
-        model: "openai/gpt-4.1",
+        models: OPENAI_BASE_MODELS,
         projects: {
           "/tmp/openclaw-main": {
             project: "openclaw",
@@ -190,7 +202,7 @@ describe("formatExistingConfig", () => {
       {
         auth: "openai-api-key",
         provider: "openai",
-        model: "openai/gpt-4.1",
+        models: OPENAI_BASE_MODELS,
         projects: {
           [path.join(os.homedir(), ".openclaw")]: {
             project: "openclaw",
@@ -244,7 +256,7 @@ describe("runSetupCore", () => {
     expect(readConfig(env)).toMatchObject({
       auth: "openai-api-key",
       provider: "openai",
-      model: "openai/gpt-4.1-mini",
+      models: OPENAI_MINI_MODELS,
     });
   });
 
@@ -476,7 +488,12 @@ describe("runSetupCore", () => {
       existingConfig: {
         auth: "anthropic-api-key",
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        models: {
+          extraction: "claude-sonnet-4-20250514",
+          claimExtraction: "claude-sonnet-4-20250514",
+          contradictionJudge: "claude-sonnet-4-20250514",
+          handoffSummary: "claude-sonnet-4-20250514",
+        },
         credentials: {
           anthropicApiKey: "sk-ant-existing",
           openaiApiKey: "sk-openai-old",
@@ -502,7 +519,12 @@ describe("runSetupCore", () => {
       existingConfig: {
         auth: "anthropic-api-key",
         provider: "anthropic",
-        model: "claude-sonnet-4-20250514",
+        models: {
+          extraction: "claude-sonnet-4-20250514",
+          claimExtraction: "claude-sonnet-4-20250514",
+          contradictionJudge: "claude-sonnet-4-20250514",
+          handoffSummary: "claude-sonnet-4-20250514",
+        },
         credentials: {
           anthropicApiKey: "sk-ant-existing",
           openaiApiKey: "sk-openai-old",
@@ -517,7 +539,7 @@ describe("runSetupCore", () => {
     expect(readConfig(env)).toBeNull();
   });
 
-  it("stores only non-default per-task models when advanced config is enabled", async () => {
+  it("stores complete task models when advanced config is enabled", async () => {
     const mocks = getMocks();
     const env = await makeTempConfigEnv();
 
@@ -547,10 +569,16 @@ describe("runSetupCore", () => {
     });
 
     expect(result?.config.models).toEqual({
+      extraction: "openai/gpt-4.1-mini",
       claimExtraction: "gpt-4.1-mini",
+      contradictionJudge: "gpt-4.1-nano",
+      handoffSummary: "gpt-4.1-nano",
     });
     expect(readConfig(env)?.models).toEqual({
+      extraction: "openai/gpt-4.1-mini",
       claimExtraction: "gpt-4.1-mini",
+      contradictionJudge: "gpt-4.1-nano",
+      handoffSummary: "gpt-4.1-nano",
     });
   });
 
@@ -584,10 +612,16 @@ describe("runSetupCore", () => {
     });
 
     expect(result?.config.models).toEqual({
+      extraction: "openai/gpt-4.1-mini",
+      claimExtraction: "gpt-4.1-nano",
       contradictionJudge: "gpt-4.1-nano",
+      handoffSummary: "gpt-4.1-nano",
     });
     expect(readConfig(env)?.models).toEqual({
+      extraction: "openai/gpt-4.1-mini",
+      claimExtraction: "gpt-4.1-nano",
       contradictionJudge: "gpt-4.1-nano",
+      handoffSummary: "gpt-4.1-nano",
     });
   });
 });
@@ -602,7 +636,12 @@ describe("runSetup", () => {
       config: {
         auth: "openai-api-key",
         provider: "openai",
-        model: "gpt-4.1-mini",
+        models: {
+          extraction: "gpt-4.1-mini",
+          claimExtraction: "gpt-4.1-nano",
+          contradictionJudge: "gpt-4.1-nano",
+          handoffSummary: "gpt-4.1-nano",
+        },
       },
       changed: true,
     });


### PR DESCRIPTION
## Summary

Removes the top-level `model` field from `AgenrConfig` and makes `models` (with all 4 task keys: `extraction`, `consolidation`, `contradiction`, `general`) required.

## Changes

- **`AgenrConfig.model` removed** - no longer part of the type or stored in config
- **`models` required with all 4 keys** - `hasCompleteTaskModels()` validates completeness
- **`resolveModelForTask`** simplified to one-liner: `return config.models[task]`
- **`isCompleteConfig`** checks `models` instead of `model`
- **`normalizeConfig`** migrates legacy `model` field via `toLegacyBaseModel()` fallback
- **`setConfigKey`** supports `models.<task>` dot-path, rejects bare `model` key
- **Init wizard** updated to set all 4 task model keys
- **CLI banner** displays per-task models

## Migration

Existing configs with a top-level `model` field are auto-migrated on first load - the legacy value becomes the lowest-priority fallback for any unset task model.

## Testing

- 1506 tests passing
- `pnpm build` clean

Closes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-task model settings for extraction, claim extraction, contradiction judgement, and handoff summary.

* **Configuration Changes**
  * Single global model replaced by a required `models` object; legacy configs are auto-upgraded on read.
  * Exposed default task model constant for tooling.

* **CLI**
  * `config set model` replaced by `config set models.<task>` (e.g., `models.extraction`).

* **Documentation**
  * CLI and configuration docs updated to show per-task model setup.

* **Chores**
  * Package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->