### PR TITLE
feat: feedback-driven recall scoring - Phase 1 (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.9.5 - 2026-02-27
+
+### Added
+- Feedback-driven recall scoring (#267 Phase 1): recalled entries are tracked per
+  session and compared against agent responses at session end. Entries that are
+  used get quality score boosts; unused entries drift slightly downward.
+- Correction signal: if the agent stores a contradicting entry via agenr_store
+  during the session, the recalled entry that was corrected gets a strong
+  negative signal (quality score drops toward 0).
+- Rolling quality_score (0-1) per entry, integrated into recall ranking formula.
+  Consistently useful entries rank higher over time.
+- Entry-type quality floor: facts and preferences cannot drop below 0.35 to
+  prevent background-context entries from being unfairly penalized.
+- Auto-strengthen: entries reaching recall count milestones (3, 10, 25) get
+  importance bumped by 1 (capped at 9, never auto-promotes to 10).
+- Quality score distribution in `agenr health` output.
+
 ## 0.9.4 (2026-02-27)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/commands/consolidate.ts
+++ b/src/commands/consolidate.ts
@@ -342,6 +342,7 @@ async function collectForgettingCandidates(
         recall_count,
         confirmations,
         contradictions,
+        quality_score,
         superseded_by
       FROM entries
       WHERE superseded_by IS NULL

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -196,6 +196,7 @@ async function runTypedEval(
         e.recall_count,
         e.confirmations,
         e.contradictions,
+        e.quality_score,
         e.superseded_by
       FROM entries AS e
       WHERE e.type = ?

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -76,7 +76,8 @@ function truncateContextContent(content: string, max = 200): string {
 const ENTRY_SELECT_COLUMNS = `
         id, type, subject, canonical_key, content, importance, expiry, scope,
         platform, project, source_file, source_context, embedding, retired,
-        created_at, updated_at, last_recalled_at, recall_count, confirmations, contradictions, superseded_by
+        created_at, updated_at, last_recalled_at, recall_count, confirmations, contradictions,
+        quality_score, superseded_by
 `;
 
 function toRecallResult(entry: StoredEntry, now: Date): RecallResult {

--- a/src/db/feedback.ts
+++ b/src/db/feedback.ts
@@ -1,0 +1,366 @@
+import type { Client, InValue } from "@libsql/client";
+import { embed, resolveEmbeddingApiKey } from "../embeddings/client.js";
+import type { AgenrConfig } from "../types.js";
+import type { PluginLogger } from "../openclaw-plugin/types.js";
+import { toStringValue } from "../utils/entry-utils.js";
+
+const RESPONSE_MIN_CHARS = 50;
+const RESPONSE_MAX_CHARS = 8000;
+const SIGNAL_USED = 1.0;
+const SIGNAL_UNCLEAR = 0.4;
+const SIGNAL_CORRECTED = 0.0;
+const RESPONSE_USED_THRESHOLD = 0.5;
+const CORRECTION_THRESHOLD = 0.6;
+
+interface QualityUpdate {
+  id: string;
+  signal: number;
+}
+
+interface EmbeddedEntry {
+  id: string;
+  embedding: number[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (value <= 0) {
+    return 0;
+  }
+  if (value >= 1) {
+    return 1;
+  }
+  return value;
+}
+
+function mapBufferToVector(value: InValue | undefined): number[] {
+  if (value instanceof ArrayBuffer) {
+    return Array.from(new Float32Array(value));
+  }
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView;
+    return Array.from(
+      new Float32Array(view.buffer, view.byteOffset, Math.floor(view.byteLength / Float32Array.BYTES_PER_ELEMENT)),
+    );
+  }
+  return [];
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  const size = Math.min(a.length, b.length);
+  if (size === 0) {
+    return 0;
+  }
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < size; i += 1) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    dot += av * bv;
+    normA += av * av;
+    normB += bv * bv;
+  }
+
+  if (normA <= 0 || normB <= 0) {
+    return 0;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function extractTextFromContent(content: unknown, separator: string): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isRecord(block) || block.type !== "text") {
+      continue;
+    }
+    const text = block.text;
+    if (typeof text !== "string") {
+      continue;
+    }
+    const trimmed = text.trim();
+    if (trimmed) {
+      parts.push(trimmed);
+    }
+  }
+  return parts.join(separator).trim();
+}
+
+function collectAssistantText(messages: unknown[]): string {
+  const parts: string[] = [];
+  for (const message of messages) {
+    if (!isRecord(message) || message.role !== "assistant") {
+      continue;
+    }
+    const text = extractTextFromContent(message.content, "\n");
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+function extractStoreContentsFromInput(input: unknown): string[] {
+  if (!isRecord(input)) {
+    return [];
+  }
+
+  const out: string[] = [];
+  const directContent = input.content;
+  if (typeof directContent === "string" && directContent.trim()) {
+    out.push(directContent.trim());
+  }
+
+  const entries = input.entries;
+  if (Array.isArray(entries)) {
+    for (const item of entries) {
+      if (!isRecord(item)) {
+        continue;
+      }
+      const content = item.content;
+      if (typeof content === "string" && content.trim()) {
+        out.push(content.trim());
+      }
+    }
+  }
+
+  return out;
+}
+
+function parseFunctionArguments(rawArgs: unknown): Record<string, unknown> | null {
+  if (isRecord(rawArgs)) {
+    return rawArgs;
+  }
+  if (typeof rawArgs !== "string" || !rawArgs.trim()) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(rawArgs);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function collectAgenrStoreContents(messages: unknown[]): string[] {
+  const contents: string[] = [];
+
+  for (const message of messages) {
+    if (!isRecord(message) || message.role !== "assistant") {
+      continue;
+    }
+
+    const contentBlocks = message.content;
+    if (Array.isArray(contentBlocks)) {
+      for (const block of contentBlocks) {
+        if (!isRecord(block) || block.type !== "tool_use" || block.name !== "agenr_store") {
+          continue;
+        }
+        contents.push(...extractStoreContentsFromInput(block.input));
+      }
+    }
+
+    const toolCalls = message.tool_calls;
+    if (!Array.isArray(toolCalls)) {
+      continue;
+    }
+    for (const toolCall of toolCalls) {
+      if (!isRecord(toolCall)) {
+        continue;
+      }
+
+      if (typeof toolCall.name === "string" && toolCall.name === "agenr_store") {
+        contents.push(...extractStoreContentsFromInput(toolCall.input));
+        continue;
+      }
+
+      const fn = toolCall.function;
+      if (!isRecord(fn) || fn.name !== "agenr_store") {
+        continue;
+      }
+      const args = parseFunctionArguments(fn.arguments);
+      if (args) {
+        contents.push(...extractStoreContentsFromInput(args));
+      }
+    }
+  }
+
+  return Array.from(new Set(contents));
+}
+
+async function fetchEmbeddedEntries(db: Client, ids: Set<string>): Promise<EmbeddedEntry[]> {
+  const idList = Array.from(ids).filter((id) => id.trim().length > 0);
+  if (idList.length === 0) {
+    return [];
+  }
+
+  const placeholders = idList.map(() => "?").join(", ");
+  const result = await db.execute({
+    sql: `
+      SELECT id, embedding
+      FROM entries
+      WHERE id IN (${placeholders})
+        AND embedding IS NOT NULL
+    `,
+    args: idList,
+  });
+
+  const embeddedEntries: EmbeddedEntry[] = [];
+  for (const row of result.rows) {
+    const id = toStringValue(row.id);
+    const embedding = mapBufferToVector(row.embedding);
+    if (!id || embedding.length === 0) {
+      continue;
+    }
+    embeddedEntries.push({ id, embedding });
+  }
+  return embeddedEntries;
+}
+
+export async function updateQualityScores(
+  db: Client,
+  updates: Array<{ id: string; signal: number }>,
+): Promise<void> {
+  if (updates.length === 0) {
+    return;
+  }
+
+  const normalizedUpdates = new Map<string, number>();
+  for (const update of updates) {
+    const id = update.id.trim();
+    if (!id) {
+      continue;
+    }
+    normalizedUpdates.set(id, clamp01(update.signal));
+  }
+  if (normalizedUpdates.size === 0) {
+    return;
+  }
+
+  const sql = `
+    UPDATE entries
+    SET quality_score = MIN(
+      1.0,
+      MAX(
+        0.8 * COALESCE(quality_score, 0.5) + 0.2 * ?,
+        CASE WHEN type IN ('fact', 'preference') THEN 0.35 ELSE 0.1 END
+      )
+    )
+    WHERE id = ?
+  `;
+
+  await db.execute("BEGIN");
+  try {
+    for (const [id, signal] of normalizedUpdates.entries()) {
+      await db.execute({ sql, args: [signal, id] });
+    }
+    await db.execute("COMMIT");
+  } catch (error) {
+    await db.execute("ROLLBACK");
+    throw error;
+  }
+}
+
+export async function computeRecallFeedback(
+  db: Client,
+  sessionKey: string,
+  messages: unknown[],
+  recalledEntryIds: Set<string>,
+  config: AgenrConfig,
+  logger: PluginLogger,
+): Promise<void> {
+  if (recalledEntryIds.size === 0) {
+    return;
+  }
+
+  const assistantText = collectAssistantText(messages);
+  if (assistantText.length < RESPONSE_MIN_CHARS) {
+    return;
+  }
+
+  const responseCorpus = assistantText.slice(0, RESPONSE_MAX_CHARS);
+
+  let apiKey: string;
+  try {
+    apiKey = resolveEmbeddingApiKey(config, process.env);
+  } catch (error) {
+    logger.warn(
+      `[agenr] before_reset: feedback skipped for session=${sessionKey} - ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  let responseEmbedding: number[] | null = null;
+  try {
+    const vectors = await embed([responseCorpus], apiKey);
+    responseEmbedding = vectors[0] ?? null;
+  } catch (error) {
+    logger.warn(
+      `[agenr] before_reset: feedback embedding failed for session=${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  if (!responseEmbedding || responseEmbedding.length === 0) {
+    return;
+  }
+
+  const recalledEntries = await fetchEmbeddedEntries(db, recalledEntryIds);
+  if (recalledEntries.length === 0) {
+    return;
+  }
+
+  const storeContents = collectAgenrStoreContents(messages);
+  let correctionEmbeddings: number[][] = [];
+  if (storeContents.length > 0) {
+    try {
+      correctionEmbeddings = await embed(storeContents, apiKey);
+    } catch (error) {
+      logger.warn(
+        `[agenr] before_reset: correction embedding failed for session=${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      correctionEmbeddings = [];
+    }
+  }
+
+  const correctedIds = new Set<string>();
+  if (correctionEmbeddings.length > 0) {
+    for (const entry of recalledEntries) {
+      for (const correctionEmbedding of correctionEmbeddings) {
+        if (cosineSimilarity(entry.embedding, correctionEmbedding) >= CORRECTION_THRESHOLD) {
+          correctedIds.add(entry.id);
+          break;
+        }
+      }
+    }
+  }
+
+  const updates: QualityUpdate[] = recalledEntries.map((entry) => {
+    if (correctedIds.has(entry.id)) {
+      return { id: entry.id, signal: SIGNAL_CORRECTED };
+    }
+    const sim = cosineSimilarity(entry.embedding, responseEmbedding ?? []);
+    return {
+      id: entry.id,
+      signal: sim >= RESPONSE_USED_THRESHOLD ? SIGNAL_USED : SIGNAL_UNCLEAR,
+    };
+  });
+
+  if (updates.length > 0) {
+    await updateQualityScores(db, updates);
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -67,7 +67,7 @@ const CREATE_TABLE_AND_TRIGGER_STATEMENTS: readonly string[] = [
     recall_count INTEGER DEFAULT 0,
     confirmations INTEGER DEFAULT 0,
     contradictions INTEGER DEFAULT 0,
-    quality_score REAL DEFAULT 0.5,
+    quality_score REAL NOT NULL DEFAULT 0.5,
     superseded_by TEXT,
     content_hash TEXT,
     norm_content_hash TEXT,
@@ -262,7 +262,7 @@ const COLUMN_MIGRATIONS: readonly ColumnMigration[] = [
   {
     table: "entries",
     column: "quality_score",
-    sql: "ALTER TABLE entries ADD COLUMN quality_score REAL DEFAULT 0.5",
+    sql: "ALTER TABLE entries ADD COLUMN quality_score REAL NOT NULL DEFAULT 0.5",
   },
   // Claim/subject fields for contradiction detection (#266)
   {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -67,6 +67,7 @@ const CREATE_TABLE_AND_TRIGGER_STATEMENTS: readonly string[] = [
     recall_count INTEGER DEFAULT 0,
     confirmations INTEGER DEFAULT 0,
     contradictions INTEGER DEFAULT 0,
+    quality_score REAL DEFAULT 0.5,
     superseded_by TEXT,
     content_hash TEXT,
     norm_content_hash TEXT,
@@ -257,6 +258,11 @@ const COLUMN_MIGRATIONS: readonly ColumnMigration[] = [
     table: "entries",
     column: "recall_intervals",
     sql: "ALTER TABLE entries ADD COLUMN recall_intervals TEXT DEFAULT NULL",
+  },
+  {
+    table: "entries",
+    column: "quality_score",
+    sql: "ALTER TABLE entries ADD COLUMN quality_score REAL DEFAULT 0.5",
   },
   // Claim/subject fields for contradiction detection (#266)
   {

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -456,6 +456,7 @@ async function getTagsForEntryIds(db: Client, ids: string[]): Promise<Map<string
 function mapStoredEntry(row: Row, tags: string[]): StoredEntry {
   const importanceRaw = toNumber(row.importance);
   const importance = Number.isFinite(importanceRaw) ? Math.min(10, Math.max(1, Math.round(importanceRaw))) : 5;
+  const qualityScoreRaw = toNumber(row.quality_score);
   return {
     id: toStringValue(row.id),
     type: toStringValue(row.type) as StoredEntry["type"],
@@ -476,6 +477,7 @@ function mapStoredEntry(row: Row, tags: string[]): StoredEntry {
     recall_count: Number.isFinite(toNumber(row.recall_count)) ? toNumber(row.recall_count) : 0,
     confirmations: Number.isFinite(toNumber(row.confirmations)) ? toNumber(row.confirmations) : 0,
     contradictions: Number.isFinite(toNumber(row.contradictions)) ? toNumber(row.contradictions) : 0,
+    quality_score: Number.isFinite(qualityScoreRaw) ? Math.min(1, Math.max(0, qualityScoreRaw)) : 0.5,
     superseded_by: toStringValue(row.superseded_by) || undefined,
   };
 }

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -502,6 +502,7 @@ async function getStoredEntryById(db: Client, id: string): Promise<StoredEntry |
         recall_count,
         confirmations,
         contradictions,
+        quality_score,
         superseded_by
       FROM entries
       WHERE id = ?
@@ -739,6 +740,7 @@ export async function findSimilar(
         e.recall_count,
         e.confirmations,
         e.contradictions,
+        e.quality_score,
         e.superseded_by
       FROM vector_top_k('idx_entries_embedding', vector32(?), ?) AS v
       CROSS JOIN entries AS e ON e.rowid = v.id
@@ -935,6 +937,7 @@ async function findEntryByTypeAndCanonicalKey(
         recall_count,
         confirmations,
         contradictions,
+        quality_score,
         superseded_by
       FROM entries
       WHERE type = ?
@@ -981,6 +984,7 @@ export async function findRecentEntryBySubjectTypeAndSourceFile(
         recall_count,
         confirmations,
         contradictions,
+        quality_score,
         superseded_by
       FROM entries e
       WHERE lower(trim(e.subject)) = ?

--- a/src/db/stored-entry.ts
+++ b/src/db/stored-entry.ts
@@ -21,6 +21,7 @@ interface RawStoredEntryFields {
   recall_intervals?: unknown;
   confirmations?: unknown;
   contradictions?: unknown;
+  quality_score?: unknown;
   superseded_by?: unknown;
   subject_entity?: unknown;
   subject_attribute?: unknown;
@@ -51,6 +52,7 @@ export function mapRawStoredEntry(
   const recallCountRaw = toNumber(row.recall_count);
   const confirmationsRaw = toNumber(row.confirmations);
   const contradictionsRaw = toNumber(row.contradictions);
+  const qualityScoreRaw = toNumber(row.quality_score);
   const subjectEntity = toStringValue(row.subject_entity).trim();
   const subjectAttribute = toStringValue(row.subject_attribute).trim();
   const subjectKey = toStringValue(row.subject_key).trim();
@@ -111,6 +113,7 @@ export function mapRawStoredEntry(
     ...(recallIntervals !== undefined ? { recall_intervals: recallIntervals } : {}),
     confirmations: Number.isFinite(confirmationsRaw) ? confirmationsRaw : 0,
     contradictions: Number.isFinite(contradictionsRaw) ? contradictionsRaw : 0,
+    quality_score: Number.isFinite(qualityScoreRaw) ? Math.min(1, Math.max(0, qualityScoreRaw)) : 0.5,
     superseded_by: toStringValue(row.superseded_by) || undefined,
     ...(subjectEntity ? { subjectEntity } : {}),
     ...(subjectAttribute ? { subjectAttribute } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,6 +219,7 @@ export interface StoredEntry extends KnowledgeEntry {
   recall_intervals?: number[];
   confirmations: number;
   contradictions: number;
+  quality_score: number;
   superseded_by?: string;
 }
 
@@ -256,6 +257,7 @@ export interface RecallResult {
     todoPenalty: number;
     fts: number;
     spacing: number;
+    quality: number;
   };
 }
 

--- a/tests/commands/context.test.ts
+++ b/tests/commands/context.test.ts
@@ -30,6 +30,7 @@ function makeEntry(overrides: Partial<StoredEntry> = {}): StoredEntry {
     recall_count: 0,
     confirmations: 0,
     contradictions: 0,
+    quality_score: 0.5,
     ...overrides,
   };
 }
@@ -38,7 +39,7 @@ function makeResult(category: RecallCommandResult["category"], overrides: Partia
   return {
     entry: makeEntry(overrides),
     score: 0.8,
-    scores: { vector: 0, recency: 0, importance: 0, recall: 0, freshness: 1, todoPenalty: 1, fts: 0, spacing: 1 },
+    scores: { vector: 0, recency: 0, importance: 0, recall: 0, freshness: 1, todoPenalty: 1, fts: 0, spacing: 1, quality: 0.5 },
     category,
   };
 }

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -23,6 +23,7 @@ function makeEntry(overrides: Partial<StoredEntry> = {}): StoredEntry {
     recall_count: 0,
     confirmations: 0,
     contradictions: 0,
+    quality_score: 0.5,
     ...overrides,
   };
 }
@@ -40,6 +41,7 @@ function makeResult(overrides: Partial<RecallResult> = {}): RecallResult {
       todoPenalty: 1,
       fts: 0.15,
       spacing: 1,
+      quality: 0.5,
     },
     ...overrides,
   };

--- a/tests/consolidate/rules.test.ts
+++ b/tests/consolidate/rules.test.ts
@@ -137,6 +137,7 @@ describe("consolidate rules", () => {
       recall_count: 0,
       confirmations: 0,
       contradictions: 0,
+      quality_score: 0.5,
       ...overrides,
     };
   }

--- a/tests/db/contradiction.test.ts
+++ b/tests/db/contradiction.test.ts
@@ -145,6 +145,7 @@ function makeStoredEntry(params: {
     recall_count: 0,
     confirmations: 0,
     contradictions: 0,
+    quality_score: 0.5,
   };
 }
 

--- a/tests/db/feedback.test.ts
+++ b/tests/db/feedback.test.ts
@@ -1,0 +1,133 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { initDb } from "../../src/db/client.js";
+import { updateQualityScores } from "../../src/db/feedback.js";
+
+describe("db feedback", () => {
+  const clients: Client[] = [];
+
+  afterEach(() => {
+    while (clients.length > 0) {
+      clients.pop()?.close();
+    }
+  });
+
+  function makeClient(): Client {
+    const client = createClient({ url: ":memory:" });
+    clients.push(client);
+    return client;
+  }
+
+  async function insertEntry(
+    client: Client,
+    params: { id: string; type: string; qualityScore: number | null },
+  ): Promise<void> {
+    await client.execute({
+      sql: `
+        INSERT INTO entries (
+          id, type, subject, content, importance, expiry, scope, source_file, source_context,
+          created_at, updated_at, quality_score
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      args: [
+        params.id,
+        params.type,
+        `subject-${params.id}`,
+        `content-${params.id}`,
+        5,
+        "temporary",
+        "private",
+        "feedback.test.jsonl",
+        "test",
+        "2026-02-20T00:00:00.000Z",
+        "2026-02-20T00:00:00.000Z",
+        params.qualityScore,
+      ],
+    });
+  }
+
+  async function readQuality(client: Client, id: string): Promise<number> {
+    const result = await client.execute({
+      sql: "SELECT quality_score FROM entries WHERE id = ?",
+      args: [id],
+    });
+    return Number((result.rows[0] as { quality_score?: unknown } | undefined)?.quality_score ?? Number.NaN);
+  }
+
+  it("applies EMA update correctly", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "ema", type: "lesson", qualityScore: 0.5 });
+
+    await updateQualityScores(client, [{ id: "ema", signal: 1 }]);
+    expect(await readQuality(client, "ema")).toBeCloseTo(0.6, 8);
+  });
+
+  it("defaults null quality_score to 0.5 before EMA update", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "null-quality", type: "lesson", qualityScore: null });
+
+    await updateQualityScores(client, [{ id: "null-quality", signal: 1 }]);
+    expect(await readQuality(client, "null-quality")).toBeCloseTo(0.6, 8);
+  });
+
+  it("is a no-op when updates array is empty", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "noop", type: "lesson", qualityScore: 0.7 });
+
+    await updateQualityScores(client, []);
+    expect(await readQuality(client, "noop")).toBeCloseTo(0.7, 8);
+  });
+
+  it("accumulates EMA updates across multiple calls", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "chain", type: "lesson", qualityScore: 0.5 });
+
+    await updateQualityScores(client, [{ id: "chain", signal: 1 }]);
+    await updateQualityScores(client, [{ id: "chain", signal: 0.4 }]);
+    expect(await readQuality(client, "chain")).toBeCloseTo(0.56, 8);
+  });
+
+  it("keeps quality_score bounded in [0, 1]", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "upper", type: "lesson", qualityScore: 1 });
+    await insertEntry(client, { id: "lower", type: "lesson", qualityScore: 0 });
+
+    await updateQualityScores(client, [{ id: "upper", signal: 1 }]);
+    await updateQualityScores(client, [{ id: "lower", signal: 0 }]);
+    expect(await readQuality(client, "upper")).toBeCloseTo(1, 8);
+    expect(await readQuality(client, "lower")).toBeCloseTo(0.1, 8);
+  });
+
+  it("applies fact floor of 0.35 for signal 0", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "fact-floor", type: "fact", qualityScore: 0 });
+
+    await updateQualityScores(client, [{ id: "fact-floor", signal: 0 }]);
+    expect(await readQuality(client, "fact-floor")).toBeCloseTo(0.35, 8);
+  });
+
+  it("applies lesson floor of 0.1 for signal 0", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "lesson-floor", type: "lesson", qualityScore: 0 });
+
+    await updateQualityScores(client, [{ id: "lesson-floor", signal: 0 }]);
+    expect(await readQuality(client, "lesson-floor")).toBeCloseTo(0.1, 8);
+  });
+
+  it("applies preference floor of 0.35 for signal 0", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, { id: "pref-floor", type: "preference", qualityScore: 0 });
+
+    await updateQualityScores(client, [{ id: "pref-floor", signal: 0 }]);
+    expect(await readQuality(client, "pref-floor")).toBeCloseTo(0.35, 8);
+  });
+});

--- a/tests/db/feedback.test.ts
+++ b/tests/db/feedback.test.ts
@@ -1,7 +1,7 @@
 import { createClient, type Client } from "@libsql/client";
 import { afterEach, describe, expect, it } from "vitest";
 import { initDb } from "../../src/db/client.js";
-import { updateQualityScores } from "../../src/db/feedback.js";
+import { __testing, updateQualityScores } from "../../src/db/feedback.js";
 
 describe("db feedback", () => {
   const clients: Client[] = [];
@@ -20,8 +20,36 @@ describe("db feedback", () => {
 
   async function insertEntry(
     client: Client,
-    params: { id: string; type: string; qualityScore: number | null },
+    params: { id: string; type: string; qualityScore?: number },
   ): Promise<void> {
+    const baseArgs = [
+      params.id,
+      params.type,
+      `subject-${params.id}`,
+      `content-${params.id}`,
+      5,
+      "temporary",
+      "private",
+      "feedback.test.jsonl",
+      "test",
+      "2026-02-20T00:00:00.000Z",
+      "2026-02-20T00:00:00.000Z",
+    ];
+
+    if (params.qualityScore === undefined) {
+      await client.execute({
+        sql: `
+          INSERT INTO entries (
+            id, type, subject, content, importance, expiry, scope, source_file, source_context,
+            created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        args: baseArgs,
+      });
+      return;
+    }
+
     await client.execute({
       sql: `
         INSERT INTO entries (
@@ -31,17 +59,7 @@ describe("db feedback", () => {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       args: [
-        params.id,
-        params.type,
-        `subject-${params.id}`,
-        `content-${params.id}`,
-        5,
-        "temporary",
-        "private",
-        "feedback.test.jsonl",
-        "test",
-        "2026-02-20T00:00:00.000Z",
-        "2026-02-20T00:00:00.000Z",
+        ...baseArgs,
         params.qualityScore,
       ],
     });
@@ -64,13 +82,13 @@ describe("db feedback", () => {
     expect(await readQuality(client, "ema")).toBeCloseTo(0.6, 8);
   });
 
-  it("defaults null quality_score to 0.5 before EMA update", async () => {
+  it("uses default quality_score 0.5 before EMA update when omitted on insert", async () => {
     const client = makeClient();
     await initDb(client);
-    await insertEntry(client, { id: "null-quality", type: "lesson", qualityScore: null });
+    await insertEntry(client, { id: "default-quality", type: "lesson" });
 
-    await updateQualityScores(client, [{ id: "null-quality", signal: 1 }]);
-    expect(await readQuality(client, "null-quality")).toBeCloseTo(0.6, 8);
+    await updateQualityScores(client, [{ id: "default-quality", signal: 1 }]);
+    expect(await readQuality(client, "default-quality")).toBeCloseTo(0.6, 8);
   });
 
   it("is a no-op when updates array is empty", async () => {
@@ -129,5 +147,138 @@ describe("db feedback", () => {
 
     await updateQualityScores(client, [{ id: "pref-floor", signal: 0 }]);
     expect(await readQuality(client, "pref-floor")).toBeCloseTo(0.35, 8);
+  });
+});
+
+describe("collectAgenrStoreContents", () => {
+  it("extracts Anthropic tool_use agenr_store content blocks", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "agenr_store",
+            input: { content: "anthropic content" },
+          },
+        ],
+      },
+    ];
+
+    expect(__testing.collectAgenrStoreContents(messages)).toEqual(["anthropic content"]);
+  });
+
+  it("extracts OpenAI named tool_calls arguments payload", () => {
+    const messages = [
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            name: "agenr_store",
+            arguments: "{\"content\":\"openai named content\"}",
+          },
+        ],
+      },
+    ];
+
+    expect(__testing.collectAgenrStoreContents(messages)).toEqual(["openai named content"]);
+  });
+
+  it("extracts OpenAI tool_calls function.name arguments payload", () => {
+    const messages = [
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "agenr_store",
+              arguments: "{\"content\":\"openai function content\"}",
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(__testing.collectAgenrStoreContents(messages)).toEqual(["openai function content"]);
+  });
+
+  it("extracts only agenr_store content across mixed messages", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "agenr_store",
+            input: { content: "first" },
+          },
+          {
+            type: "tool_use",
+            name: "other_tool",
+            input: { content: "ignored" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            function: {
+              name: "agenr_store",
+              arguments: "{\"content\":\"second\"}",
+            },
+          },
+          {
+            function: {
+              name: "different_tool",
+              arguments: "{\"content\":\"ignored\"}",
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: "not assistant",
+      },
+    ];
+
+    expect(__testing.collectAgenrStoreContents(messages)).toEqual(["first", "second"]);
+  });
+
+  it("returns empty array when no agenr_store calls are present", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+      },
+      {
+        role: "assistant",
+        tool_calls: [{ name: "other_tool", arguments: "{\"content\":\"ignored\"}" }],
+      },
+    ];
+
+    expect(__testing.collectAgenrStoreContents(messages)).toEqual([]);
+  });
+});
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors", () => {
+    expect(__testing.cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 8);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    expect(__testing.cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0, 8);
+  });
+
+  it("returns a negative value for opposite vectors", () => {
+    expect(__testing.cosineSimilarity([1, -2], [-1, 2])).toBeLessThan(0);
+  });
+
+  it("returns 0 when one vector is empty", () => {
+    expect(__testing.cosineSimilarity([], [1, 2, 3])).toBe(0);
+  });
+
+  it("handles different-length vectors safely", () => {
+    expect(__testing.cosineSimilarity([1, 1], [1])).toBeCloseTo(1, 8);
   });
 });

--- a/tests/db/migration.test.ts
+++ b/tests/db/migration.test.ts
@@ -47,6 +47,7 @@ describe("db schema migrations", () => {
     expect(entries.has("retired_reason")).toBe(true);
     expect(entries.has("suppressed_contexts")).toBe(true);
     expect(entries.has("recall_intervals")).toBe(true);
+    expect(entries.has("quality_score")).toBe(true);
     expect(entries.has("subject_entity")).toBe(true);
     expect(entries.has("subject_attribute")).toBe(true);
     expect(entries.has("subject_key")).toBe(true);
@@ -211,6 +212,7 @@ describe("db schema migrations", () => {
     const retiredReason = entriesColumns.find((row) => toStringValue(row.name) === "retired_reason");
     const suppressedContexts = entriesColumns.find((row) => toStringValue(row.name) === "suppressed_contexts");
     const recallIntervals = entriesColumns.find((row) => toStringValue(row.name) === "recall_intervals");
+    const qualityScore = entriesColumns.find((row) => toStringValue(row.name) === "quality_score");
     const subjectEntity = entriesColumns.find((row) => toStringValue(row.name) === "subject_entity");
     const subjectAttribute = entriesColumns.find((row) => toStringValue(row.name) === "subject_attribute");
     const subjectKey = entriesColumns.find((row) => toStringValue(row.name) === "subject_key");
@@ -235,6 +237,7 @@ describe("db schema migrations", () => {
     expect(retiredReason).toBeTruthy();
     expect(suppressedContexts).toBeTruthy();
     expect(recallIntervals).toBeTruthy();
+    expect(qualityScore).toBeTruthy();
     expect(subjectEntity).toBeTruthy();
     expect(subjectAttribute).toBeTruthy();
     expect(subjectKey).toBeTruthy();

--- a/tests/db/recall-spacing.test.ts
+++ b/tests/db/recall-spacing.test.ts
@@ -47,6 +47,7 @@ function makeEntry(overrides: Partial<StoredEntry> = {}): StoredEntry {
     recall_intervals: undefined,
     confirmations: 0,
     contradictions: 0,
+    quality_score: 0.5,
     ...overrides,
   };
 }

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -137,6 +137,7 @@ describe("db schema", () => {
     expect(entryColumns.has("retired_reason")).toBe(true);
     expect(entryColumns.has("suppressed_contexts")).toBe(true);
     expect(entryColumns.has("recall_intervals")).toBe(true);
+    expect(entryColumns.has("quality_score")).toBe(true);
     expect(entryColumns.has("subject_entity")).toBe(true);
     expect(entryColumns.has("subject_attribute")).toBe(true);
     expect(entryColumns.has("subject_key")).toBe(true);

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -56,6 +56,7 @@ function makeRecallResult(overrides?: Partial<RecallResult>): RecallResult {
       todoPenalty: 1,
       fts: 0,
       spacing: 1,
+      quality: 0.5,
     },
     entry: {
       id: "entry-1",
@@ -72,6 +73,7 @@ function makeRecallResult(overrides?: Partial<RecallResult>): RecallResult {
       recall_count: 0,
       confirmations: 0,
       contradictions: 0,
+      quality_score: 0.5,
     },
     ...overrides,
   };


### PR DESCRIPTION
## Summary

Closes the feedback loop between recall and utility. Entries that are consistently useful in agent responses rank higher over time; entries that are consistently ignored sink.

## Changes

### Core
- **`quality_score`** column on entries (0-1, default 0.5), updated via exponential moving average (`0.8 * old + 0.2 * signal`)
- **Three feedback signals**: used (1.0, cosine sim >= 0.5 with response), not used (0.4, weak neutral), corrected (0.0, agent stored contradicting entry via agenr_store)
- **Entry-type quality floor**: facts/preferences floor at 0.35, others at 0.1 - prevents background-context entries from unfair drift
- **Quality factor in recall scoring**: maps quality 0-1 to 0.7-1.3 multiplier
- **Auto-strengthen**: importance +1 at recall count milestones 3, 10, 25 (capped at 9, never auto-10)

### Plugin
- Session recall tracking via in-memory Map (capped at 200 sessions)
- Captures entry IDs from both browse and semantic recall paths
- Feedback computation in `before_reset` - embeds response corpus, compares against recalled entries
- Correction detection: scans for `agenr_store` tool calls, cosine-sims stored content against recalled entries

### Reporting
- Quality score distribution in `agenr health` output

## Design Decisions
- Feedback only fires at session end (OpenClaw has no after_turn hook)
- Conservative signals: 'not used' is 0.4 (barely below 0.5 neutral) - only sustained irrelevance matters
- EMA alpha 0.2 means ~20 sessions to converge
- Correction threshold 0.6 (higher than 'used' at 0.5) to reduce false positives

## Testing
- 1527 tests passing (17 new)
- `pnpm build` clean

## Phase 2 (future, see docs/internal/267-implementation-plan.md)
- Watcher-based retroactive feedback for Claude Code/Codex sessions
- Co-recall edges, SRS interval adaptation, auto-flag low-quality for retirement

Closes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quality scoring system (0–1) to track and favor consistently useful entries, with an entry-type floor.
  * Session-driven feedback and correction signals that adjust recall ranking and apply milestone-based importance bumps (3, 10, 25).
  * Health reports now include a Quality Score Distribution (high/medium/low/average).

* **Tests**
  * Added comprehensive tests for quality scoring, feedback flows, migrations, and recall behavior.

* **Documentation**
  * Updated changelog and package version for v0.9.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->