### PR TITLE
feat(recall): --around temporal targeting with gaussian recency (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.6 - 2026-02-27
+
+### Added
+- `--around <date>` flag for recall: shifts recency scoring to peak at a target
+  date instead of now. Entries closer to the target date rank higher regardless
+  of whether they are older or newer than it (#189).
+- `--around-radius <days>` flag: controls the window width for `--around` queries
+  (default: 14 days). Also auto-sets since/until bounds when not explicitly
+  provided.
+- `gaussianRecency` scoring function for temporal targeting.
+
 ## 0.9.5 - 2026-02-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   (default: 14 days). Also auto-sets since/until bounds when not explicitly
   provided.
 - `gaussianRecency` scoring function for temporal targeting.
+- `agenr_recall` native tool now exposes `around` and `aroundRadius` parameters
+  for temporal targeting in mid-session recall.
 
 ## 0.9.5 - 2026-02-27
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ agenr recall "package manager"
    tags: tooling, package-manager
 ```
 
-Recall supports date range queries (`--since 14d --until 7d`) and temporal browse mode (`--browse --since 1d`) for recency-ordered lookups without embedding API calls.
+Recall supports date range queries (`--since 14d --until 7d`), temporal browse mode (`--browse --since 1d`), and around-date targeting (`--around 2026-02-15 --around-radius 14`) to rank entries by distance from a specific date.
 
 ### Cross-session Handoff
 
@@ -246,7 +246,7 @@ This exposes four tools: `agenr_recall`, `agenr_store`, `agenr_extract`, `agenr_
 | `agenr ingest <paths...>` | Bulk-ingest files and directories |
 | `agenr extract <files...>` | Extract knowledge entries from text files |
 | `agenr store [files...]` | Store entries with semantic dedup |
-| `agenr recall [query]` | Semantic + memory-aware recall. Use `--since`/`--until` for date ranges, `--browse` for temporal mode. |
+| `agenr recall [query]` | Semantic + memory-aware recall. Use `--since`/`--until` for date ranges, `--around` for target-date ranking, `--browse` for temporal mode. |
 | `agenr retire [subject]` | Retire a stale entry (hidden, not deleted). Match by subject or `--id`. |
 | `agenr watch [file]` | Live-watch files/directories, auto-extract knowledge |
 | `agenr watcher install` | Install background watch daemon (macOS launchd) |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -164,6 +164,8 @@ agenr recall [options] [query]
 - `--min-importance <n>`: minimum importance (1-10).
 - `--since <duration>`: recency filter (`1h`, `7d`, `30d`, `1y`, or ISO timestamp).
 - `--until <date>`: upper recency cap (`1h`, `7d`, `1m`, `1y`, or ISO timestamp). Includes entries at or before this time.
+- `--around <date>`: target date for temporal scoring (`1h`, `7d`, `1m`, `1y`, or ISO timestamp). Recency peaks at this date instead of now.
+- `--around-radius <days>`: radius for `--around` default window and gaussian recency width (default `14` days).
 - `--expiry <level>`: `core|permanent|temporary`.
 - `--platform <name>`: platform filter (`openclaw|claude-code|codex|plaud`).
 - `--project <name>`: project filter (repeatable for multiple).
@@ -992,6 +994,7 @@ The `--browse` flag activates a SQL-only temporal browse path:
 - Results are sorted by importance and date (with deterministic recency-decay scoring).
 - Zero embedding/OpenAI API calls are made.
 - Recall metadata is not incremented in browse mode.
+- With `--around`, browse mode uses gaussian temporal scoring centered on the target date and auto-applies a symmetric date window when `--since`/`--until` are omitted.
 
 ### `--budget` behavior
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -530,6 +530,8 @@ export function createProgram(): Command {
     .option("--min-importance <n>", "Minimum importance: 1-10")
     .option("--since <duration>", "Filter by recency (1h, 7d, 30d, 1y) or ISO timestamp")
     .option("--until <date>", "Only entries at or before this time (ISO date or relative, e.g. 7d, 1m)")
+    .option("--around <date>", "Center recency around this date (ISO date or relative, e.g. 7d)")
+    .option("--around-radius <days>", "Days on each side of --around for default window/scoring width", parseIntOption)
     .option("--expiry <level>", "Filter by expiry: core|permanent|temporary")
     .option("--platform <name>", "Filter by platform: openclaw, claude-code, codex, plaud")
     .option("--project <name>", "Filter by project (repeatable)", (val: string, prev: string[]) => [...prev, val], [] as string[])
@@ -551,6 +553,8 @@ export function createProgram(): Command {
         minImportance: opts.minImportance as string | undefined,
         since: opts.since as string | undefined,
         until: opts.until as string | undefined,
+        around: opts.around as string | undefined,
+        aroundRadius: opts.aroundRadius as number | undefined,
         expiry: opts.expiry as string | undefined,
         platform: opts.platform as string | undefined,
         project: opts.project as string | string[] | undefined,

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -30,6 +30,8 @@ export interface RecallCommandOptions {
   minImportance?: string;
   since?: string;
   until?: string;
+  around?: string;
+  aroundRadius?: number | string;
   expiry?: string;
   platform?: string;
   project?: string | string[];
@@ -316,6 +318,10 @@ export async function runRecallCommand(
 
   const sinceIso = parseSinceToIso(options.since, now, "Invalid --since value. Use 1h, 7d, 1m, 1y, or an ISO date.");
   const untilIso = parseSinceToIso(options.until, now, "Invalid --until value. Use 1h, 7d, 1m, 1y, or an ISO date.");
+  const aroundIso = parseSinceToIso(options.around, now, "Invalid --around value. Use 1h, 7d, 1m, 1y, or an ISO date.");
+  const aroundRadius = options.aroundRadius !== undefined
+    ? parsePositiveInt(options.aroundRadius, 0, "--around-radius")
+    : undefined;
   const queryForRecall: RecallQuery = {
     text: queryText && !isBrowse ? shapeRecallText(queryText, context) : undefined,
     limit,
@@ -324,6 +330,8 @@ export async function runRecallCommand(
     minImportance,
     since: sinceIso,
     until: untilIso,
+    around: aroundIso,
+    aroundRadius,
     expiry,
     scope: scope ?? "private",
     platform,

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -1490,6 +1490,15 @@ const plugin = {
             until: Type.Optional(
               Type.String({ description: "Only entries older than this ceiling (ISO date or relative, e.g. 7d = entries created before 7 days ago). Use with since for a date window." }),
             ),
+            around: Type.Optional(
+              Type.String({
+                description:
+                  "Bias recall toward a specific date. Entries closer to this date rank higher. ISO date or relative (e.g. 7d = 7 days ago).",
+              }),
+            ),
+            aroundRadius: Type.Optional(
+              Type.Number({ description: "Window radius in days for --around (default: 14)." }),
+            ),
             platform: Type.Optional(Type.String({ description: "Platform filter: openclaw, claude-code, codex." })),
             project: Type.Optional(Type.String({ description: "Project scope. Pass * for all projects." })),
           }),

--- a/src/openclaw-plugin/tools.ts
+++ b/src/openclaw-plugin/tools.ts
@@ -164,6 +164,8 @@ export async function runRecallTool(
   const types = asString(params.types);
   const since = asString(params.since);
   const until = asString(params.until);
+  const around = asString(params.around);
+  const aroundRadius = asNumber(params.aroundRadius);
   const platform = asString(params.platform);
   const project = asString(params.project) || defaultProject;
 
@@ -186,6 +188,12 @@ export async function runRecallTool(
   }
   if (until) {
     args.push("--until", until);
+  }
+  if (around) {
+    args.push("--around", around);
+  }
+  if (aroundRadius !== undefined) {
+    args.push("--around-radius", String(aroundRadius));
   }
   // threshold has no direct CLI equivalent in agenr recall
   if (platform) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,8 @@ export interface RecallQuery {
   minImportance?: number;
   since?: string;
   until?: string; // upper bound; same subtraction semantics as since (e.g. "7d" = entries older than 7 days ago)
+  around?: string;
+  aroundRadius?: number;
   expiry?: Expiry | Expiry[];
   scope?: Scope;
   context?: string;

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -82,6 +82,27 @@ describe("recall command", () => {
     expect(firstCall?.[1].project).toEqual(["foo", "bar"]);
   });
 
+  it("rejects --around-radius without --around at CLI parse time", async () => {
+    const { createProgram } = await import("../../src/cli-main.js");
+    const program = createProgram();
+    await expect(program.parseAsync(["node", "agenr", "recall", "query", "--around-radius", "7"])).rejects.toThrow(
+      "--around-radius requires --around",
+    );
+  });
+
+  it("rejects non-positive --around-radius values at CLI parse time", async () => {
+    const { createProgram } = await import("../../src/cli-main.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(
+      program.parseAsync(["node", "agenr", "recall", "query", "--around", "7d", "--around-radius", "0"]),
+    ).rejects.toThrow("--around-radius must be a positive integer (days)");
+    await expect(
+      program.parseAsync(["node", "agenr", "recall", "query", "--around", "7d", "--around-radius", "-3"]),
+    ).rejects.toThrow("--around-radius must be a positive integer (days)");
+  });
+
   it("parses duration strings into ISO cutoffs", () => {
     const now = new Date("2026-02-15T12:00:00.000Z");
     const oneHour = parseSinceToIso("1h", now);

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -230,6 +230,26 @@ describe("recall command", () => {
     expect(firstCall?.[1]?.until).toBe("2026-02-01T00:00:00.000Z");
   });
 
+  it("passes --around into recall query when provided", async () => {
+    const recallFn = vi.fn(async () => []);
+    const deps = makeDeps({ recallFn });
+
+    await runRecallCommand("work", { context: "default", json: true, around: "7d" }, deps);
+
+    const firstCall = (recallFn.mock.calls as unknown[][])[0] as [unknown, { around?: string }] | undefined;
+    expect(firstCall?.[1]?.around).toBe("2026-02-08T00:00:00.000Z");
+  });
+
+  it("passes --around-radius into recall query when provided", async () => {
+    const recallFn = vi.fn(async () => []);
+    const deps = makeDeps({ recallFn });
+
+    await runRecallCommand("work", { context: "default", json: true, aroundRadius: "21" }, deps);
+
+    const firstCall = (recallFn.mock.calls as unknown[][])[0] as [unknown, { aroundRadius?: number }] | undefined;
+    expect(firstCall?.[1]?.aroundRadius).toBe(21);
+  });
+
   it("passes --project into recall query when provided", async () => {
     const recallFn = vi.fn(async () => []);
     const deps = makeDeps({ recallFn });


### PR DESCRIPTION
## Summary

Adds `--around <date>` and `--around-radius <days>` flags to recall, enabling temporal targeting that peaks recency scoring at a specific date instead of always favoring now.

## Changes

- **gaussianRecency()** - Gaussian curve centered on target date (sigma = radius/2), replacing standard recency when --around is active
- **Auto-window** - When --around is set without explicit --since/--until, auto-applies a symmetric window of +/- radius days
- **Browse mode** - Around targeting works in browse path via browseRecencyFactor() helper
- **Session-start** - Skips default 30d/7d --since windows when --around is provided
- **Plugin** - agenr_recall native tool exposes `around` and `aroundRadius` parameters
- **CLI** - `--around` and `--around-radius` wired through command options

## Testing

New tests covering gaussianRecency math (exact match, decreasing, symmetric), semantic recall with around, auto-window, explicit since/until respected, radius affects width, browse mode, session-start integration, command parsing, and plugin CLI arg wiring.

Closes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --around <date> and --around-radius <days> to target recall results around a specific date; browse now centers ranking on that date using a gaussian recency function and auto-applies a symmetric window when since/until are omitted.
  * agenr_recall tool exposes around and aroundRadius parameters.

* **Bug Fixes**
  * CLI now validates --around-radius (requires --around and must be positive).

* **Documentation**
  * CLI docs and README updated for around-date ranking.

* **Chores**
  * Version bumped to 0.9.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->