### PR TITLE
feat(mcp): expose --around in MCP agenr_recall tool (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - `gaussianRecency` scoring function for temporal targeting.
 - `agenr_recall` native tool now exposes `around` and `aroundRadius` parameters
   for temporal targeting in mid-session recall.
+- MCP server `agenr_recall` tool now exposes `around` and `aroundRadius`
+  parameters for temporal targeting.
 
 ## 0.9.5 - 2026-02-27
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -139,6 +139,16 @@ const TOOL_DEFINITIONS: McpToolDefinition[] = [
           description:
             "Only entries created before this point in time (ISO date or relative, e.g. 7d = entries older than 7 days). Use with since for a date range: since sets the lower bound, until the upper bound.",
         },
+        around: {
+          type: "string",
+          description:
+            "Bias recall toward a specific date. Entries closer to this date rank higher. ISO date or relative (e.g. 7d = 7 days ago).",
+        },
+        aroundRadius: {
+          type: "integer",
+          description: "Window radius in days for around targeting (default: 14).",
+          minimum: 1,
+        },
         threshold: {
           type: "number",
           description: "Minimum relevance score from 0.0 to 1.0.",
@@ -849,6 +859,15 @@ export function createMcpServer(
         throw new RpcError(JSON_RPC_INVALID_PARAMS, "Invalid until value");
       }
     }
+    let around: string | undefined;
+    if (typeof args.around === "string" && args.around.trim().length > 0) {
+      try {
+        around = parseSinceToIso(args.around, now);
+      } catch {
+        throw new RpcError(JSON_RPC_INVALID_PARAMS, "Invalid around value");
+      }
+    }
+    const aroundRadius = typeof args.aroundRadius === "number" ? args.aroundRadius : undefined;
     const platformRaw = typeof args.platform === "string" ? args.platform.trim() : "";
     const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
     if (platformRaw && !platform) {
@@ -896,6 +915,8 @@ export function createMcpServer(
           types,
           since,
           until,
+          around,
+          aroundRadius,
           platform: platform ?? undefined,
           project,
           projectStrict: projectStrict ? true : undefined,
@@ -913,6 +934,8 @@ export function createMcpServer(
           types,
           since,
           until,
+          around,
+          aroundRadius,
           platform: platform ?? undefined,
           project,
           projectStrict: projectStrict ? true : undefined,
@@ -934,6 +957,8 @@ export function createMcpServer(
           types,
           since,
           until,
+          around,
+          aroundRadius,
           platform: platform ?? undefined,
           project,
           projectStrict: projectStrict ? true : undefined,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -868,6 +868,9 @@ export function createMcpServer(
       }
     }
     const aroundRadius = typeof args.aroundRadius === "number" ? args.aroundRadius : undefined;
+    if (aroundRadius !== undefined && (!Number.isInteger(aroundRadius) || aroundRadius < 1)) {
+      throw new RpcError(JSON_RPC_INVALID_PARAMS, "aroundRadius must be a positive integer (days)");
+    }
     const platformRaw = typeof args.platform === "string" ? args.platform.trim() : "";
     const platform = platformRaw ? normalizeKnowledgePlatform(platformRaw) : null;
     if (platformRaw && !platform) {


### PR DESCRIPTION
Adds around and aroundRadius parameters to the MCP server's agenr_recall tool, matching the OpenClaw plugin and CLI support added in PR #291.

Closes #292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporal targeting for recall queries via new around and aroundRadius parameters, letting users focus recall results around a specific date with a configurable window (default 14 days).
* **Bug Fixes**
  * Invalid date input for the around parameter now yields a clear validation error.
* **Tests**
  * Added tests covering around/aroundRadius propagation and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->