### PR TITLE
fix(init): resolve agenr MCP command via PATH shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.7 - 2026-02-27
+
+### Fixed
+- `agenr init` no longer pins MCP config to a version-specific path. It now
+  resolves the `agenr` shim or binary on PATH so upgrades take effect
+  automatically (#294).
+
 ## 0.9.6 - 2026-02-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -72,7 +72,25 @@ function escapeTomlString(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
 }
 
+function logInitDebug(message: string): void {
+  if (process.env.AGENR_DEBUG === "1") {
+    console.debug(`[agenr init] ${message}`);
+  }
+}
+
 export function resolveAgenrCommand(): { command: string; baseArgs: string[] } {
+  const agenrShim = findBinaryPath("agenr");
+  if (agenrShim) {
+    return {
+      command: agenrShim,
+      baseArgs: [],
+    };
+  }
+
+  logInitDebug(
+    "agenr binary not found on PATH; falling back to process.execPath + process.argv[1], which may pin MCP config to the current installed version.",
+  );
+
   const nodeBin = process.execPath;
   const scriptPath = process.argv[1];
   if (!scriptPath) {


### PR DESCRIPTION
## Summary

`resolveAgenrCommand()` now checks for the `agenr` shim/binary on PATH first, so MCP config written by `agenr init` automatically picks up new versions on upgrade. Falls back to the existing `process.execPath` approach only when the shim isn't found.

## Changes

- `src/commands/init.ts`: PATH-first resolution in `resolveAgenrCommand()`, debug logging
- `tests/commands/init.test.ts`: 59 lines of new test coverage
- `CHANGELOG.md`: v0.9.7 entry
- `package.json`: bumped to 0.9.7

## Testing

1560 tests passing. Build clean.

Closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced initialization process to dynamically resolve agenr binaries from system PATH instead of pinning to version-specific configurations, improving compatibility with software updates and supporting seamless installation upgrades.

* **Tests**
  * Added comprehensive test coverage for binary resolution during initialization, validating both successful detection and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->