### PR TITLE
feat: co-recall edges + review queue (#267 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.9.8 - 2026-02-27
+
+### Added
+- Co-recall edge creation (Hebbian learning): entries that are both recalled and
+  used in the same session form weighted associations. Edges strengthen on
+  repeated co-occurrence and decay over time (#267 Phase 2).
+- Review queue: entries flagged for human review are tracked in a dedicated table.
+  Low-quality entries (quality_score < 0.2 after 10+ recalls) are auto-flagged
+  for retirement review (#267 Phase 2).
+- `agenr review` command to list, dismiss, or retire flagged entries.
+- `agenr edges` command to inspect co-recall edges.
+- Co-recall edge statistics and review queue summary in `agenr health` output.
+
 ## 0.9.7 - 2026-02-27
 
 ### Fixed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -559,6 +559,17 @@ Forgetting Candidates
 Consolidation Health
 - Contradiction flags: 4 entries
 - Stale todos (>30d old, not recalled): 18
+
+Co-Recall Edges
+- Total edges:       214
+- Average weight:    0.28
+- Top 5 strongest pairs:
+  - release checklist <-> deployment playbook (0.90)
+
+Review Queue
+- Total pending:     7
+- Pending by reason: low_quality=5, stale=2
+- Oldest pending age: 4d
 ```
 
 ## `retire`
@@ -589,6 +600,52 @@ agenr retire [subject] [options]
 $A retire "AGENR platform" --persist --reason "project killed"
 $A retire "old project" --contains --dry-run
 $A retire --id abc123 --force --reason "stale handoff"
+```
+
+## `review`
+
+Inspect and resolve pending review queue items.
+
+### Syntax
+
+```bash
+agenr review [options]
+agenr review dismiss <id> [options]
+agenr review retire <id> [options]
+```
+
+### Options
+- `--db <path>`: database path override.
+- `--limit <n>`: max rows for `agenr review` (default `20`).
+
+### Examples
+
+```bash
+$A review
+$A review dismiss 3d3c47dc-b242-4ce0-bf95-1af5a1e957e1
+$A review retire 3d3c47dc-b242-4ce0-bf95-1af5a1e957e1
+```
+
+## `edges`
+
+Inspect co-recall edges learned from entries used together.
+
+### Syntax
+
+```bash
+agenr edges [options]
+```
+
+### Options
+- `--entry <id>`: show neighbors for a specific entry.
+- `--limit <n>`: max rows to return (default `20`; with `--entry`, default `10`).
+- `--db <path>`: database path override.
+
+### Examples
+
+```bash
+$A edges
+$A edges --entry 4a9f2e60-4fd1-4d2d-b1a0-e5a40f151876
 ```
 
 ## `mcp`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -28,6 +28,7 @@ import { runConflictsUiCommand } from "./commands/conflicts-ui.js";
 import { runBenchmarkCommand } from "./commands/benchmark.js";
 import { runBackfillClaimsCommand } from "./commands/backfill-claims.js";
 import { runEvalRecallCommand } from "./commands/eval.js";
+import { runEdgesCommand } from "./commands/edges.js";
 import { runHealthCommand } from "./commands/health.js";
 import { runIngestCommand } from "./commands/ingest.js";
 import { runContextCommand } from "./commands/context.js";
@@ -35,6 +36,7 @@ import { runInitWizard } from "./commands/init.js";
 import { runMcpCommand } from "./commands/mcp.js";
 import { runRecallCommand } from "./commands/recall.js";
 import { runRetireCommand } from "./commands/retire.js";
+import { runReviewCommand, runReviewDismissCommand, runReviewRetireCommand } from "./commands/review.js";
 import { runStoreCommand } from "./commands/store.js";
 import { runTodoCommand } from "./commands/todo.js";
 import { runWatchCommand } from "./commands/watch.js";
@@ -616,6 +618,49 @@ export function createProgram(): Command {
         reason: opts.reason as string | undefined,
         db: opts.db as string | undefined,
         id: entryId,
+      });
+      process.exitCode = result.exitCode;
+    });
+
+  const reviewCommand = program
+    .command("review")
+    .description("Review pending low-quality and contradiction flags")
+    .option("--db <path>", "Database path override")
+    .option("--limit <n>", "Maximum pending review rows to show", parseIntOption, 20)
+    .action(async (opts: { db?: string; limit?: number }) => {
+      const result = await runReviewCommand({ db: opts.db, limit: opts.limit });
+      process.exitCode = result.exitCode;
+    });
+
+  reviewCommand
+    .command("dismiss <id>")
+    .description("Dismiss a pending review item")
+    .option("--db <path>", "Database path override")
+    .action(async (id: string, opts: { db?: string }) => {
+      const result = await runReviewDismissCommand(id, { db: opts.db });
+      process.exitCode = result.exitCode;
+    });
+
+  reviewCommand
+    .command("retire <id>")
+    .description("Retire the entry referenced by a pending review item and resolve it")
+    .option("--db <path>", "Database path override")
+    .action(async (id: string, opts: { db?: string }) => {
+      const result = await runReviewRetireCommand(id, { db: opts.db });
+      process.exitCode = result.exitCode;
+    });
+
+  program
+    .command("edges")
+    .description("Inspect co-recall edges")
+    .option("--entry <id>", "Show neighbors for one entry ID instead of global top edges")
+    .option("--limit <n>", "Maximum rows to return", parseIntOption)
+    .option("--db <path>", "Database path override")
+    .action(async (opts: { entry?: string; limit?: number; db?: string }) => {
+      const result = await runEdgesCommand({
+        entry: opts.entry,
+        limit: opts.limit,
+        db: opts.db,
       });
       process.exitCode = result.exitCode;
     });

--- a/src/commands/edges.ts
+++ b/src/commands/edges.ts
@@ -1,0 +1,151 @@
+import { readConfig } from "../config.js";
+import { closeDb, getDb, initDb } from "../db/client.js";
+import { getCoRecallNeighbors, getTopCoRecallEdges } from "../db/co-recall.js";
+import { toStringValue } from "../utils/entry-utils.js";
+
+export interface EdgesCommandOptions {
+  db?: string;
+  entry?: string;
+  limit?: number;
+}
+
+export interface EdgesCommandDeps {
+  readConfigFn: typeof readConfig;
+  getDbFn: typeof getDb;
+  initDbFn: typeof initDb;
+  closeDbFn: typeof closeDb;
+}
+
+interface EntryLabels {
+  [entryId: string]: string;
+}
+
+function summarize(text: string, maxLength = 40): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function pad(value: string, width: number): string {
+  if (value.length >= width) {
+    return value;
+  }
+  return `${value}${" ".repeat(width - value.length)}`;
+}
+
+function renderTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, index) => {
+    const rowMax = rows.reduce((max, row) => Math.max(max, row[index]?.length ?? 0), 0);
+    return Math.max(header.length, rowMax);
+  });
+
+  const headerLine = headers.map((header, index) => pad(header, widths[index] ?? header.length)).join(" | ");
+  const separator = widths.map((width) => "-".repeat(width)).join("-+-");
+  const body = rows.map((row) => row.map((cell, index) => pad(cell, widths[index] ?? cell.length)).join(" | "));
+
+  return [headerLine, separator, ...body].join("\n");
+}
+
+async function readEntryLabels(db: ReturnType<typeof getDb>, entryIds: string[]): Promise<EntryLabels> {
+  const uniqueIds = Array.from(new Set(entryIds.map((id) => id.trim()).filter((id) => id.length > 0)));
+  if (uniqueIds.length === 0) {
+    return {};
+  }
+
+  const placeholders = uniqueIds.map(() => "?").join(", ");
+  const result = await db.execute({
+    sql: `
+      SELECT id, subject, content
+      FROM entries
+      WHERE id IN (${placeholders})
+    `,
+    args: uniqueIds,
+  });
+
+  const labels: EntryLabels = {};
+  for (const row of result.rows) {
+    const id = toStringValue((row as { id?: unknown }).id);
+    if (!id) {
+      continue;
+    }
+    const subject = toStringValue((row as { subject?: unknown }).subject).trim();
+    const content = toStringValue((row as { content?: unknown }).content);
+    labels[id] = summarize(subject || content || "(missing entry)");
+  }
+
+  return labels;
+}
+
+export async function runEdgesCommand(
+  options: EdgesCommandOptions = {},
+  deps: Partial<EdgesCommandDeps> = {},
+): Promise<{ exitCode: number }> {
+  const resolvedDeps: EdgesCommandDeps = {
+    readConfigFn: deps.readConfigFn ?? readConfig,
+    getDbFn: deps.getDbFn ?? getDb,
+    initDbFn: deps.initDbFn ?? initDb,
+    closeDbFn: deps.closeDbFn ?? closeDb,
+  };
+
+  const config = resolvedDeps.readConfigFn(process.env);
+  const dbPath = options.db?.trim() || config?.db?.path;
+  const db = resolvedDeps.getDbFn(dbPath);
+
+  try {
+    await resolvedDeps.initDbFn(db);
+
+    const limit = Number.isFinite(options.limit) && (options.limit ?? 0) > 0 ? Math.floor(options.limit as number) : undefined;
+    const entryId = options.entry?.trim();
+
+    if (entryId) {
+      const neighbors = await getCoRecallNeighbors(db, entryId, 0.1, limit ?? 10);
+      if (neighbors.length === 0) {
+        process.stdout.write(`No co-recall neighbors found for entry: ${entryId}\n`);
+        return { exitCode: 0 };
+      }
+
+      const labels = await readEntryLabels(db, [entryId, ...neighbors.map((item) => item.entryId)]);
+      const rows = neighbors.map((neighbor) => [
+        neighbor.entryId,
+        labels[neighbor.entryId] ?? "(missing entry)",
+        neighbor.weight.toFixed(2),
+        String(neighbor.sessionCount),
+        neighbor.lastCoRecalled,
+      ]);
+
+      process.stdout.write(
+        `${renderTable(["neighbor_id", "subject", "weight", "sessions", "last_co_recalled"], rows)}\n`,
+      );
+      return { exitCode: 0 };
+    }
+
+    const edges = await getTopCoRecallEdges(db, limit ?? 20);
+    if (edges.length === 0) {
+      process.stdout.write("No co-recall edges found.\n");
+      return { exitCode: 0 };
+    }
+
+    const labels = await readEntryLabels(
+      db,
+      edges.flatMap((edge) => [edge.entryA, edge.entryB]),
+    );
+    const rows = edges.map((edge) => [
+      edge.entryA,
+      labels[edge.entryA] ?? "(missing entry)",
+      edge.entryB,
+      labels[edge.entryB] ?? "(missing entry)",
+      edge.weight.toFixed(2),
+      String(edge.sessionCount),
+      edge.lastCoRecalled,
+    ]);
+
+    process.stdout.write(
+      `${renderTable(["entry_a", "subject_a", "entry_b", "subject_b", "weight", "sessions", "last_co_recalled"], rows)}\n`,
+    );
+    return { exitCode: 0 };
+  } finally {
+    resolvedDeps.closeDbFn(db);
+  }
+}

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -4,6 +4,7 @@ import { retireEntries } from "../db/retirements.js";
 import {
   getPendingReviewById,
   getPendingReviews,
+  rehabilitateEntry,
   resolveReview,
   type PendingReviewItem,
 } from "../db/review-queue.js";
@@ -143,6 +144,10 @@ export async function runReviewDismissCommand(
     if (!updated) {
       process.stdout.write(`No pending review found for id: ${normalizedId}\n`);
       return { exitCode: 1 };
+    }
+    const review = await getPendingReviewById(db, normalizedId);
+    if (review) {
+      await rehabilitateEntry(db, review.entryId);
     }
 
     process.stdout.write(`Dismissed review ${normalizedId}.\n`);

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,0 +1,211 @@
+import { readConfig } from "../config.js";
+import { closeDb, getDb, initDb } from "../db/client.js";
+import { retireEntries } from "../db/retirements.js";
+import {
+  getPendingReviewById,
+  getPendingReviews,
+  resolveReview,
+  type PendingReviewItem,
+} from "../db/review-queue.js";
+import { parseDaysBetween } from "../utils/entry-utils.js";
+
+export interface ReviewCommandOptions {
+  db?: string;
+  limit?: number;
+}
+
+export interface ReviewCommandDeps {
+  readConfigFn: typeof readConfig;
+  getDbFn: typeof getDb;
+  initDbFn: typeof initDb;
+  closeDbFn: typeof closeDb;
+  retireEntriesFn: typeof retireEntries;
+  nowFn: () => Date;
+}
+
+function summarize(text: string, maxLength = 40): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function resolveEntryLabel(item: PendingReviewItem): string {
+  const subject = item.entrySubject.trim();
+  if (subject) {
+    return summarize(subject, 40);
+  }
+  return summarize(item.entryContent, 40) || "(missing entry)";
+}
+
+function formatAge(iso: string, now: Date): string {
+  const ageDays = parseDaysBetween(now, iso);
+  if (ageDays < 1 / 24) {
+    return "<1h";
+  }
+  if (ageDays < 1) {
+    return `${Math.max(1, Math.round(ageDays * 24))}h`;
+  }
+  return `${Math.round(ageDays)}d`;
+}
+
+function pad(value: string, width: number): string {
+  if (value.length >= width) {
+    return value;
+  }
+  return `${value}${" ".repeat(width - value.length)}`;
+}
+
+function renderTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, index) => {
+    const rowMax = rows.reduce((max, row) => Math.max(max, row[index]?.length ?? 0), 0);
+    return Math.max(header.length, rowMax);
+  });
+
+  const headerLine = headers.map((header, index) => pad(header, widths[index] ?? header.length)).join(" | ");
+  const separator = widths.map((width) => "-".repeat(width)).join("-+-");
+  const body = rows.map((row) => row.map((cell, index) => pad(cell, widths[index] ?? cell.length)).join(" | "));
+
+  return [headerLine, separator, ...body].join("\n");
+}
+
+export async function runReviewCommand(
+  options: ReviewCommandOptions = {},
+  deps: Partial<ReviewCommandDeps> = {},
+): Promise<{ exitCode: number }> {
+  const resolvedDeps: ReviewCommandDeps = {
+    readConfigFn: deps.readConfigFn ?? readConfig,
+    getDbFn: deps.getDbFn ?? getDb,
+    initDbFn: deps.initDbFn ?? initDb,
+    closeDbFn: deps.closeDbFn ?? closeDb,
+    retireEntriesFn: deps.retireEntriesFn ?? retireEntries,
+    nowFn: deps.nowFn ?? (() => new Date()),
+  };
+
+  const config = resolvedDeps.readConfigFn(process.env);
+  const dbPath = options.db?.trim() || config?.db?.path;
+  const db = resolvedDeps.getDbFn(dbPath);
+
+  try {
+    await resolvedDeps.initDbFn(db);
+    const pending = await getPendingReviews(db, options.limit ?? 20);
+    if (pending.length === 0) {
+      process.stdout.write("No pending review items.\n");
+      return { exitCode: 0 };
+    }
+
+    const now = resolvedDeps.nowFn();
+    const rows = pending.map((item) => [
+      item.id,
+      resolveEntryLabel(item),
+      item.reason,
+      summarize(item.detail, 60),
+      item.suggestedAction,
+      formatAge(item.createdAt, now),
+    ]);
+
+    process.stdout.write(
+      `${renderTable(["id", "entry", "reason", "detail", "action", "age"], rows)}\n`,
+    );
+    return { exitCode: 0 };
+  } finally {
+    resolvedDeps.closeDbFn(db);
+  }
+}
+
+export async function runReviewDismissCommand(
+  reviewId: string,
+  options: ReviewCommandOptions = {},
+  deps: Partial<ReviewCommandDeps> = {},
+): Promise<{ exitCode: number }> {
+  const resolvedDeps: ReviewCommandDeps = {
+    readConfigFn: deps.readConfigFn ?? readConfig,
+    getDbFn: deps.getDbFn ?? getDb,
+    initDbFn: deps.initDbFn ?? initDb,
+    closeDbFn: deps.closeDbFn ?? closeDb,
+    retireEntriesFn: deps.retireEntriesFn ?? retireEntries,
+    nowFn: deps.nowFn ?? (() => new Date()),
+  };
+
+  const normalizedId = reviewId.trim();
+  if (!normalizedId) {
+    throw new Error("review id is required");
+  }
+
+  const config = resolvedDeps.readConfigFn(process.env);
+  const dbPath = options.db?.trim() || config?.db?.path;
+  const db = resolvedDeps.getDbFn(dbPath);
+
+  try {
+    await resolvedDeps.initDbFn(db);
+    const updated = await resolveReview(db, normalizedId, "dismissed");
+    if (!updated) {
+      process.stdout.write(`No pending review found for id: ${normalizedId}\n`);
+      return { exitCode: 1 };
+    }
+
+    process.stdout.write(`Dismissed review ${normalizedId}.\n`);
+    return { exitCode: 0 };
+  } finally {
+    resolvedDeps.closeDbFn(db);
+  }
+}
+
+export async function runReviewRetireCommand(
+  reviewId: string,
+  options: ReviewCommandOptions = {},
+  deps: Partial<ReviewCommandDeps> = {},
+): Promise<{ exitCode: number }> {
+  const resolvedDeps: ReviewCommandDeps = {
+    readConfigFn: deps.readConfigFn ?? readConfig,
+    getDbFn: deps.getDbFn ?? getDb,
+    initDbFn: deps.initDbFn ?? initDb,
+    closeDbFn: deps.closeDbFn ?? closeDb,
+    retireEntriesFn: deps.retireEntriesFn ?? retireEntries,
+    nowFn: deps.nowFn ?? (() => new Date()),
+  };
+
+  const normalizedId = reviewId.trim();
+  if (!normalizedId) {
+    throw new Error("review id is required");
+  }
+
+  const config = resolvedDeps.readConfigFn(process.env);
+  const dbPath = options.db?.trim() || config?.db?.path;
+  const db = resolvedDeps.getDbFn(dbPath);
+
+  try {
+    await resolvedDeps.initDbFn(db);
+    const review = await getPendingReviewById(db, normalizedId);
+    if (!review) {
+      process.stdout.write(`Review item not found: ${normalizedId}\n`);
+      return { exitCode: 1 };
+    }
+    if (review.status !== "pending") {
+      process.stdout.write(`Review item is already ${review.status}: ${normalizedId}\n`);
+      return { exitCode: 1 };
+    }
+
+    const retired = await resolvedDeps.retireEntriesFn({
+      entryId: review.entryId,
+      reason: `review_queue:${normalizedId}:${review.reason}`,
+      writeLedger: false,
+      db,
+      dbPath,
+    });
+
+    const resolved = await resolveReview(db, normalizedId, "resolved");
+    if (!resolved) {
+      process.stdout.write(`Failed to resolve review item: ${normalizedId}\n`);
+      return { exitCode: 1 };
+    }
+
+    process.stdout.write(
+      `Retired ${retired.count} entr${retired.count === 1 ? "y" : "ies"} and resolved review ${normalizedId}.\n`,
+    );
+    return { exitCode: 0 };
+  } finally {
+    resolvedDeps.closeDbFn(db);
+  }
+}

--- a/src/db/co-recall.ts
+++ b/src/db/co-recall.ts
@@ -1,0 +1,193 @@
+import type { Client } from "@libsql/client";
+import { toNumber, toStringValue } from "../utils/entry-utils.js";
+
+const DEFAULT_EDGE_INCREMENT = 0.1;
+const MIN_EDGE_WEIGHT = 0.05;
+
+export interface CoRecallNeighbor {
+  entryId: string;
+  weight: number;
+  sessionCount: number;
+  lastCoRecalled: string;
+}
+
+export interface CoRecallEdge {
+  entryA: string;
+  entryB: string;
+  weight: number;
+  sessionCount: number;
+  lastCoRecalled: string;
+}
+
+function normalizePair(a: string, b: string): [string, string] {
+  return a < b ? [a, b] : [b, a];
+}
+
+function toRowsAffected(value: unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return Number(value);
+  }
+  return 0;
+}
+
+export async function strengthenCoRecallEdges(
+  db: Client,
+  usedEntryIds: string[],
+  timestamp: string,
+): Promise<void> {
+  const uniqueIds = Array.from(
+    new Set(
+      usedEntryIds
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0),
+    ),
+  );
+
+  if (uniqueIds.length < 2) {
+    return;
+  }
+
+  const now = timestamp || new Date().toISOString();
+  const pairs: Array<[string, string]> = [];
+  for (let i = 0; i < uniqueIds.length; i += 1) {
+    const a = uniqueIds[i];
+    if (!a) {
+      continue;
+    }
+    for (let j = i + 1; j < uniqueIds.length; j += 1) {
+      const b = uniqueIds[j];
+      if (!b || a === b) {
+        continue;
+      }
+      pairs.push(normalizePair(a, b));
+    }
+  }
+
+  if (pairs.length === 0) {
+    return;
+  }
+
+  await db.execute("BEGIN");
+  try {
+    for (const [entryA, entryB] of pairs) {
+      await db.execute({
+        sql: `
+          INSERT INTO co_recall_edges (
+            entry_a, entry_b, weight, session_count, last_co_recalled, created_at
+          )
+          VALUES (?, ?, ?, 1, ?, ?)
+          ON CONFLICT(entry_a, entry_b)
+          DO UPDATE SET
+            weight = MIN(co_recall_edges.weight + ?, 1.0),
+            session_count = co_recall_edges.session_count + 1,
+            last_co_recalled = excluded.last_co_recalled
+        `,
+        args: [
+          entryA,
+          entryB,
+          DEFAULT_EDGE_INCREMENT,
+          now,
+          now,
+          DEFAULT_EDGE_INCREMENT,
+        ],
+      });
+    }
+    await db.execute("COMMIT");
+  } catch (error) {
+    try {
+      await db.execute("ROLLBACK");
+    } catch {
+      // Ignore rollback failures and rethrow original error.
+    }
+    throw error;
+  }
+}
+
+export async function decayCoRecallEdges(db: Client, decayFactor = 0.95): Promise<number> {
+  if (!Number.isFinite(decayFactor) || decayFactor < 0) {
+    throw new Error("decayFactor must be a finite number >= 0");
+  }
+
+  await db.execute({
+    sql: `
+      UPDATE co_recall_edges
+      SET weight = weight * ?
+    `,
+    args: [decayFactor],
+  });
+
+  const pruned = await db.execute({
+    sql: `
+      DELETE FROM co_recall_edges
+      WHERE weight < ?
+    `,
+    args: [MIN_EDGE_WEIGHT],
+  });
+
+  return toRowsAffected(pruned.rowsAffected);
+}
+
+export async function getCoRecallNeighbors(
+  db: Client,
+  entryId: string,
+  minWeight = 0.1,
+  limit = 10,
+): Promise<CoRecallNeighbor[]> {
+  const normalizedId = entryId.trim();
+  if (!normalizedId) {
+    return [];
+  }
+
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 10;
+  const safeMinWeight = Number.isFinite(minWeight) ? Math.max(minWeight, 0) : 0.1;
+
+  const result = await db.execute({
+    sql: `
+      SELECT
+        CASE WHEN entry_a = ? THEN entry_b ELSE entry_a END AS neighbor_id,
+        weight,
+        session_count,
+        last_co_recalled
+      FROM co_recall_edges
+      WHERE (entry_a = ? OR entry_b = ?)
+        AND weight >= ?
+      ORDER BY weight DESC, session_count DESC, last_co_recalled DESC
+      LIMIT ?
+    `,
+    args: [normalizedId, normalizedId, normalizedId, safeMinWeight, safeLimit],
+  });
+
+  return result.rows.map((row) => ({
+    entryId: toStringValue((row as { neighbor_id?: unknown }).neighbor_id),
+    weight: toNumber((row as { weight?: unknown }).weight),
+    sessionCount: toNumber((row as { session_count?: unknown }).session_count),
+    lastCoRecalled: toStringValue((row as { last_co_recalled?: unknown }).last_co_recalled),
+  }));
+}
+
+export async function getTopCoRecallEdges(db: Client, limit = 20): Promise<CoRecallEdge[]> {
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20;
+  const result = await db.execute({
+    sql: `
+      SELECT entry_a, entry_b, weight, session_count, last_co_recalled
+      FROM co_recall_edges
+      ORDER BY weight DESC, session_count DESC, last_co_recalled DESC
+      LIMIT ?
+    `,
+    args: [safeLimit],
+  });
+
+  return result.rows.map((row) => ({
+    entryA: toStringValue((row as { entry_a?: unknown }).entry_a),
+    entryB: toStringValue((row as { entry_b?: unknown }).entry_b),
+    weight: toNumber((row as { weight?: unknown }).weight),
+    sessionCount: toNumber((row as { session_count?: unknown }).session_count),
+    lastCoRecalled: toStringValue((row as { last_co_recalled?: unknown }).last_co_recalled),
+  }));
+}

--- a/src/db/review-queue.ts
+++ b/src/db/review-queue.ts
@@ -1,0 +1,269 @@
+import { randomUUID } from "node:crypto";
+import type { Client } from "@libsql/client";
+import { toNumber, toStringValue } from "../utils/entry-utils.js";
+
+export const REVIEW_REASONS = ["low_quality", "contradicted", "stale", "manual"] as const;
+export const REVIEW_ACTIONS = ["retire", "review", "merge"] as const;
+export const REVIEW_STATUSES = ["pending", "dismissed", "resolved"] as const;
+
+export type ReviewReason = (typeof REVIEW_REASONS)[number];
+export type ReviewSuggestedAction = (typeof REVIEW_ACTIONS)[number];
+export type ReviewStatus = (typeof REVIEW_STATUSES)[number];
+
+export interface PendingReviewItem {
+  id: string;
+  entryId: string;
+  reason: ReviewReason;
+  detail: string;
+  suggestedAction: ReviewSuggestedAction;
+  status: ReviewStatus;
+  createdAt: string;
+  resolvedAt: string;
+  entrySubject: string;
+  entryContent: string;
+}
+
+function toRowsAffected(value: unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return Number(value);
+  }
+  return 0;
+}
+
+function ensureReason(reason: string): ReviewReason {
+  if ((REVIEW_REASONS as readonly string[]).includes(reason)) {
+    return reason as ReviewReason;
+  }
+  throw new Error(`Invalid review reason: ${reason}`);
+}
+
+function ensureAction(action: string): ReviewSuggestedAction {
+  if ((REVIEW_ACTIONS as readonly string[]).includes(action)) {
+    return action as ReviewSuggestedAction;
+  }
+  throw new Error(`Invalid review suggested action: ${action}`);
+}
+
+export async function flagForReview(
+  db: Client,
+  entryId: string,
+  reason: ReviewReason,
+  detail: string | null,
+  suggestedAction: ReviewSuggestedAction,
+): Promise<{ created: boolean; id: string | null }> {
+  const normalizedEntryId = entryId.trim();
+  const normalizedReason = ensureReason(reason);
+  const normalizedAction = ensureAction(suggestedAction);
+
+  if (!normalizedEntryId) {
+    throw new Error("entryId is required");
+  }
+
+  const existing = await db.execute({
+    sql: `
+      SELECT id
+      FROM review_queue
+      WHERE entry_id = ?
+        AND reason = ?
+        AND status = 'pending'
+      LIMIT 1
+    `,
+    args: [normalizedEntryId, normalizedReason],
+  });
+
+  if (existing.rows.length > 0) {
+    return {
+      created: false,
+      id: toStringValue((existing.rows[0] as { id?: unknown }).id) || null,
+    };
+  }
+
+  const id = randomUUID();
+  const createdAt = new Date().toISOString();
+
+  await db.execute({
+    sql: `
+      INSERT INTO review_queue (
+        id,
+        entry_id,
+        reason,
+        detail,
+        suggested_action,
+        status,
+        created_at
+      )
+      VALUES (?, ?, ?, ?, ?, 'pending', ?)
+    `,
+    args: [id, normalizedEntryId, normalizedReason, detail, normalizedAction, createdAt],
+  });
+
+  return { created: true, id };
+}
+
+export async function getPendingReviews(db: Client, limit = 20): Promise<PendingReviewItem[]> {
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20;
+
+  const result = await db.execute({
+    sql: `
+      SELECT
+        review_queue.id,
+        review_queue.entry_id,
+        review_queue.reason,
+        review_queue.detail,
+        review_queue.suggested_action,
+        review_queue.status,
+        review_queue.created_at,
+        review_queue.resolved_at,
+        entries.subject,
+        entries.content
+      FROM review_queue
+      LEFT JOIN entries ON entries.id = review_queue.entry_id
+      WHERE review_queue.status = 'pending'
+      ORDER BY review_queue.created_at ASC
+      LIMIT ?
+    `,
+    args: [safeLimit],
+  });
+
+  return result.rows.map((row) => ({
+    id: toStringValue((row as { id?: unknown }).id),
+    entryId: toStringValue((row as { entry_id?: unknown }).entry_id),
+    reason: ensureReason(toStringValue((row as { reason?: unknown }).reason)),
+    detail: toStringValue((row as { detail?: unknown }).detail),
+    suggestedAction: ensureAction(toStringValue((row as { suggested_action?: unknown }).suggested_action)),
+    status: (toStringValue((row as { status?: unknown }).status) || "pending") as ReviewStatus,
+    createdAt: toStringValue((row as { created_at?: unknown }).created_at),
+    resolvedAt: toStringValue((row as { resolved_at?: unknown }).resolved_at),
+    entrySubject: toStringValue((row as { subject?: unknown }).subject),
+    entryContent: toStringValue((row as { content?: unknown }).content),
+  }));
+}
+
+export async function resolveReview(
+  db: Client,
+  reviewId: string,
+  status: "dismissed" | "resolved",
+): Promise<boolean> {
+  const normalizedReviewId = reviewId.trim();
+  if (!normalizedReviewId) {
+    return false;
+  }
+
+  const resolvedAt = new Date().toISOString();
+  const result = await db.execute({
+    sql: `
+      UPDATE review_queue
+      SET status = ?,
+          resolved_at = ?
+      WHERE id = ?
+        AND status = 'pending'
+    `,
+    args: [status, resolvedAt, normalizedReviewId],
+  });
+
+  return toRowsAffected(result.rowsAffected) > 0;
+}
+
+export async function checkAndFlagLowQuality(
+  db: Client,
+  entryId: string,
+  qualityScore: number,
+  recallCount: number,
+): Promise<void> {
+  if (!Number.isFinite(qualityScore) || !Number.isFinite(recallCount)) {
+    return;
+  }
+  if (qualityScore >= 0.2 || recallCount < 10) {
+    return;
+  }
+
+  const roundedQuality = Math.max(0, Math.min(1, qualityScore));
+  const detail = `quality_score ${roundedQuality.toFixed(3)} after ${Math.floor(recallCount)} recalls`;
+  await flagForReview(db, entryId, "low_quality", detail, "retire");
+}
+
+export async function getPendingReviewById(db: Client, reviewId: string): Promise<PendingReviewItem | null> {
+  const normalizedReviewId = reviewId.trim();
+  if (!normalizedReviewId) {
+    return null;
+  }
+
+  const result = await db.execute({
+    sql: `
+      SELECT
+        review_queue.id,
+        review_queue.entry_id,
+        review_queue.reason,
+        review_queue.detail,
+        review_queue.suggested_action,
+        review_queue.status,
+        review_queue.created_at,
+        review_queue.resolved_at,
+        entries.subject,
+        entries.content
+      FROM review_queue
+      LEFT JOIN entries ON entries.id = review_queue.entry_id
+      WHERE review_queue.id = ?
+      LIMIT 1
+    `,
+    args: [normalizedReviewId],
+  });
+
+  const row = result.rows[0] as Record<string, unknown> | undefined;
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: toStringValue(row.id),
+    entryId: toStringValue(row.entry_id),
+    reason: ensureReason(toStringValue(row.reason)),
+    detail: toStringValue(row.detail),
+    suggestedAction: ensureAction(toStringValue(row.suggested_action)),
+    status: (toStringValue(row.status) || "pending") as ReviewStatus,
+    createdAt: toStringValue(row.created_at),
+    resolvedAt: toStringValue(row.resolved_at),
+    entrySubject: toStringValue(row.subject),
+    entryContent: toStringValue(row.content),
+  };
+}
+
+export async function getPendingReviewCountsByReason(
+  db: Client,
+): Promise<Array<{ reason: ReviewReason; count: number }>> {
+  const result = await db.execute({
+    sql: `
+      SELECT reason, COUNT(*) AS count
+      FROM review_queue
+      WHERE status = 'pending'
+      GROUP BY reason
+      ORDER BY count DESC, reason ASC
+    `,
+    args: [],
+  });
+
+  return result.rows.map((row) => ({
+    reason: ensureReason(toStringValue((row as { reason?: unknown }).reason)),
+    count: toNumber((row as { count?: unknown }).count),
+  }));
+}
+
+export async function getOldestPendingReviewCreatedAt(db: Client): Promise<string | null> {
+  const result = await db.execute({
+    sql: `
+      SELECT MIN(created_at) AS oldest_created_at
+      FROM review_queue
+      WHERE status = 'pending'
+    `,
+    args: [],
+  });
+
+  const oldest = toStringValue((result.rows[0] as { oldest_created_at?: unknown } | undefined)?.oldest_created_at);
+  return oldest || null;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -143,6 +143,36 @@ const CREATE_TABLE_AND_TRIGGER_STATEMENTS: readonly string[] = [
     created_at TEXT NOT NULL
   )
   `,
+  `
+  CREATE TABLE IF NOT EXISTS co_recall_edges (
+    entry_a TEXT NOT NULL,
+    entry_b TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 0.1,
+    session_count INTEGER NOT NULL DEFAULT 1,
+    last_co_recalled TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (entry_a, entry_b),
+    FOREIGN KEY (entry_a) REFERENCES entries(id),
+    FOREIGN KEY (entry_b) REFERENCES entries(id)
+  )
+  `,
+  "CREATE INDEX IF NOT EXISTS idx_co_recall_a ON co_recall_edges(entry_a)",
+  "CREATE INDEX IF NOT EXISTS idx_co_recall_b ON co_recall_edges(entry_b)",
+  `
+  CREATE TABLE IF NOT EXISTS review_queue (
+    id TEXT PRIMARY KEY,
+    entry_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    detail TEXT,
+    suggested_action TEXT NOT NULL DEFAULT 'review',
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL,
+    resolved_at TEXT,
+    FOREIGN KEY (entry_id) REFERENCES entries(id)
+  )
+  `,
+  "CREATE INDEX IF NOT EXISTS idx_review_queue_status ON review_queue(status)",
+  "CREATE INDEX IF NOT EXISTS idx_review_queue_entry ON review_queue(entry_id)",
   CREATE_ENTRIES_FTS_TABLE_SQL,
   CREATE_ENTRIES_FTS_TRIGGER_AI_SQL,
   CREATE_ENTRIES_FTS_TRIGGER_AD_SQL,

--- a/src/utils/entry-utils.ts
+++ b/src/utils/entry-utils.ts
@@ -23,6 +23,19 @@ export function toStringValue(value: unknown): string {
   return "";
 }
 
+export function toRowsAffected(value: unknown): number {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return Number(value);
+  }
+  return 0;
+}
+
 export function parseDaysBetween(now: Date, pastIso: string | undefined): number {
   if (!pastIso) {
     return 0;

--- a/tests/db/co-recall.test.ts
+++ b/tests/db/co-recall.test.ts
@@ -1,0 +1,191 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { initDb } from "../../src/db/client.js";
+import {
+  decayCoRecallEdges,
+  getCoRecallNeighbors,
+  strengthenCoRecallEdges,
+} from "../../src/db/co-recall.js";
+
+describe("co-recall edges", () => {
+  const clients: Client[] = [];
+
+  afterEach(() => {
+    while (clients.length > 0) {
+      clients.pop()?.close();
+    }
+  });
+
+  function makeClient(): Client {
+    const client = createClient({ url: ":memory:" });
+    clients.push(client);
+    return client;
+  }
+
+  async function insertEntry(client: Client, id: string): Promise<void> {
+    await client.execute({
+      sql: `
+        INSERT INTO entries (
+          id,
+          type,
+          subject,
+          content,
+          importance,
+          expiry,
+          scope,
+          source_file,
+          source_context,
+          created_at,
+          updated_at
+        )
+        VALUES (?, 'fact', ?, ?, 5, 'temporary', 'private', 'co-recall.test.jsonl', 'test', ?, ?)
+      `,
+      args: [
+        id,
+        `subject-${id}`,
+        `content-${id}`,
+        "2026-02-27T00:00:00.000Z",
+        "2026-02-27T00:00:00.000Z",
+      ],
+    });
+  }
+
+  async function countEdges(client: Client): Promise<number> {
+    const result = await client.execute("SELECT COUNT(*) AS count FROM co_recall_edges");
+    return Number((result.rows[0] as { count?: unknown } | undefined)?.count ?? 0);
+  }
+
+  it("creates one edge from two used entries", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+
+    await strengthenCoRecallEdges(client, ["a", "b"], "2026-02-27T00:00:00.000Z");
+
+    const result = await client.execute("SELECT weight, session_count FROM co_recall_edges");
+    expect(result.rows).toHaveLength(1);
+    expect(Number((result.rows[0] as { weight?: unknown }).weight)).toBeCloseTo(0.1, 6);
+    expect(Number((result.rows[0] as { session_count?: unknown }).session_count)).toBe(1);
+  });
+
+  it("creates all pairs from three used entries", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+    await insertEntry(client, "c");
+
+    await strengthenCoRecallEdges(client, ["a", "b", "c"], "2026-02-27T00:00:00.000Z");
+
+    expect(await countEdges(client)).toBe(3);
+  });
+
+  it("creates nothing for one or zero used entries", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+
+    await strengthenCoRecallEdges(client, ["a"], "2026-02-27T00:00:00.000Z");
+    await strengthenCoRecallEdges(client, [], "2026-02-27T00:00:00.000Z");
+
+    expect(await countEdges(client)).toBe(0);
+  });
+
+  it("increments weight and session_count on repeated strengthening", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+
+    await strengthenCoRecallEdges(client, ["a", "b"], "2026-02-27T00:00:00.000Z");
+    await strengthenCoRecallEdges(client, ["b", "a"], "2026-02-27T01:00:00.000Z");
+
+    const result = await client.execute("SELECT weight, session_count FROM co_recall_edges");
+    expect(Number((result.rows[0] as { weight?: unknown }).weight)).toBeCloseTo(0.2, 6);
+    expect(Number((result.rows[0] as { session_count?: unknown }).session_count)).toBe(2);
+  });
+
+  it("caps weight at 1.0", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+
+    for (let i = 0; i < 20; i += 1) {
+      await strengthenCoRecallEdges(client, ["a", "b"], `2026-02-27T${String(i).padStart(2, "0")}:00:00.000Z`);
+    }
+
+    const result = await client.execute("SELECT weight FROM co_recall_edges");
+    expect(Number((result.rows[0] as { weight?: unknown }).weight)).toBeCloseTo(1.0, 6);
+  });
+
+  it("enforces normalized order entry_a < entry_b", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "entry-z");
+    await insertEntry(client, "entry-a");
+
+    await strengthenCoRecallEdges(client, ["entry-z", "entry-a"], "2026-02-27T00:00:00.000Z");
+
+    const result = await client.execute("SELECT entry_a, entry_b FROM co_recall_edges");
+    expect((result.rows[0] as { entry_a?: unknown }).entry_a).toBe("entry-a");
+    expect((result.rows[0] as { entry_b?: unknown }).entry_b).toBe("entry-z");
+  });
+
+  it("decays weights and prunes edges below threshold", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+
+    await strengthenCoRecallEdges(client, ["a", "b"], "2026-02-27T00:00:00.000Z");
+    const pruned = await decayCoRecallEdges(client, 0.4);
+
+    expect(pruned).toBe(1);
+    expect(await countEdges(client)).toBe(0);
+  });
+
+  it("returns neighbors sorted by weight desc", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+    await insertEntry(client, "c");
+
+    await strengthenCoRecallEdges(client, ["a", "b"], "2026-02-27T00:00:00.000Z");
+    await strengthenCoRecallEdges(client, ["a", "c"], "2026-02-27T01:00:00.000Z");
+    await strengthenCoRecallEdges(client, ["a", "c"], "2026-02-27T02:00:00.000Z");
+
+    const neighbors = await getCoRecallNeighbors(client, "a");
+    expect(neighbors.map((item) => item.entryId)).toEqual(["c", "b"]);
+  });
+
+  it("respects minWeight filter", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+    await insertEntry(client, "c");
+
+    await strengthenCoRecallEdges(client, ["a", "b"], "2026-02-27T00:00:00.000Z");
+    await strengthenCoRecallEdges(client, ["a", "c"], "2026-02-27T01:00:00.000Z");
+    await strengthenCoRecallEdges(client, ["a", "c"], "2026-02-27T02:00:00.000Z");
+
+    const neighbors = await getCoRecallNeighbors(client, "a", 0.2);
+    expect(neighbors.map((item) => item.entryId)).toEqual(["c"]);
+  });
+
+  it("respects neighbor limit", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "a");
+    await insertEntry(client, "b");
+    await insertEntry(client, "c");
+
+    await strengthenCoRecallEdges(client, ["a", "b", "c"], "2026-02-27T00:00:00.000Z");
+
+    const neighbors = await getCoRecallNeighbors(client, "a", 0.1, 1);
+    expect(neighbors).toHaveLength(1);
+  });
+});

--- a/tests/db/review-queue.test.ts
+++ b/tests/db/review-queue.test.ts
@@ -1,0 +1,184 @@
+import { createClient, type Client } from "@libsql/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { initDb } from "../../src/db/client.js";
+import {
+  checkAndFlagLowQuality,
+  flagForReview,
+  getPendingReviews,
+  resolveReview,
+} from "../../src/db/review-queue.js";
+
+describe("review queue", () => {
+  const clients: Client[] = [];
+
+  afterEach(() => {
+    while (clients.length > 0) {
+      clients.pop()?.close();
+    }
+  });
+
+  function makeClient(): Client {
+    const client = createClient({ url: ":memory:" });
+    clients.push(client);
+    return client;
+  }
+
+  async function insertEntry(client: Client, id: string, subject?: string, content?: string): Promise<void> {
+    await client.execute({
+      sql: `
+        INSERT INTO entries (
+          id,
+          type,
+          subject,
+          content,
+          importance,
+          expiry,
+          scope,
+          source_file,
+          source_context,
+          created_at,
+          updated_at,
+          quality_score,
+          recall_count
+        )
+        VALUES (?, 'fact', ?, ?, 5, 'temporary', 'private', 'review-queue.test.jsonl', 'test', ?, ?, 0.5, 0)
+      `,
+      args: [
+        id,
+        subject ?? `subject-${id}`,
+        content ?? `content-${id}`,
+        "2026-02-27T00:00:00.000Z",
+        "2026-02-27T00:00:00.000Z",
+      ],
+    });
+  }
+
+  it("creates a pending review item", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "e1");
+
+    const result = await flagForReview(client, "e1", "manual", "needs review", "review");
+    expect(result.created).toBe(true);
+
+    const pending = await getPendingReviews(client);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.entryId).toBe("e1");
+    expect(pending[0]?.reason).toBe("manual");
+  });
+
+  it("skips duplicate pending review for same entry and reason", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "dup");
+
+    await flagForReview(client, "dup", "stale", "first", "review");
+    const second = await flagForReview(client, "dup", "stale", "second", "retire");
+
+    expect(second.created).toBe(false);
+    const pending = await getPendingReviews(client);
+    expect(pending).toHaveLength(1);
+  });
+
+  it("allows new pending review after previous one is resolved", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "resolved");
+
+    const first = await flagForReview(client, "resolved", "manual", "first", "review");
+    expect(first.id).toBeTruthy();
+    const didResolve = await resolveReview(client, first.id ?? "", "resolved");
+    expect(didResolve).toBe(true);
+
+    const second = await flagForReview(client, "resolved", "manual", "second", "retire");
+    expect(second.created).toBe(true);
+
+    const pending = await getPendingReviews(client);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.detail).toBe("second");
+  });
+
+  it("returns pending items ordered by created_at", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "old");
+    await insertEntry(client, "new");
+
+    await client.execute({
+      sql: `
+        INSERT INTO review_queue (id, entry_id, reason, detail, suggested_action, status, created_at)
+        VALUES
+          ('r-old', 'old', 'manual', 'old item', 'review', 'pending', '2026-02-26T00:00:00.000Z'),
+          ('r-new', 'new', 'manual', 'new item', 'review', 'pending', '2026-02-27T00:00:00.000Z')
+      `,
+      args: [],
+    });
+
+    const pending = await getPendingReviews(client);
+    expect(pending.map((item) => item.id)).toEqual(["r-old", "r-new"]);
+  });
+
+  it("joins entry content in pending review results", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "join", "Join Subject", "Join Content");
+
+    await flagForReview(client, "join", "manual", "detail", "review");
+    const pending = await getPendingReviews(client);
+
+    expect(pending[0]?.entrySubject).toBe("Join Subject");
+    expect(pending[0]?.entryContent).toBe("Join Content");
+  });
+
+  it("resolveReview updates status and resolved_at", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "resolve");
+
+    const review = await flagForReview(client, "resolve", "manual", "detail", "review");
+    const updated = await resolveReview(client, review.id ?? "", "dismissed");
+    expect(updated).toBe(true);
+
+    const row = await client.execute({
+      sql: "SELECT status, resolved_at FROM review_queue WHERE id = ?",
+      args: [review.id],
+    });
+    expect((row.rows[0] as { status?: unknown }).status).toBe("dismissed");
+    expect(String((row.rows[0] as { resolved_at?: unknown }).resolved_at ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("flags low-quality entries when quality < 0.2 and recall >= 10", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "low-quality");
+
+    await checkAndFlagLowQuality(client, "low-quality", 0.19, 10);
+
+    const pending = await getPendingReviews(client);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.reason).toBe("low_quality");
+    expect(pending[0]?.suggestedAction).toBe("retire");
+  });
+
+  it("does not flag when quality is >= 0.2", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "quality-ok");
+
+    await checkAndFlagLowQuality(client, "quality-ok", 0.2, 20);
+
+    const pending = await getPendingReviews(client);
+    expect(pending).toHaveLength(0);
+  });
+
+  it("does not flag when recall count is below 10", async () => {
+    const client = makeClient();
+    await initDb(client);
+    await insertEntry(client, "recall-low");
+
+    await checkAndFlagLowQuality(client, "recall-low", 0.1, 9);
+
+    const pending = await getPendingReviews(client);
+    expect(pending).toHaveLength(0);
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -37,6 +37,7 @@ describe("db schema", () => {
       "idx_co_recall_b",
       "idx_review_queue_status",
       "idx_review_queue_entry",
+      "idx_review_queue_pending_dedup",
       "idx_entries_embedding",
       "idx_entries_type",
       "idx_entries_type_canonical_key",
@@ -99,6 +100,7 @@ describe("db schema", () => {
         'idx_co_recall_b',
         'idx_review_queue_status',
         'idx_review_queue_entry',
+        'idx_review_queue_pending_dedup',
         'idx_entries_embedding',
         'idx_entries_type',
         'idx_entries_type_canonical_key',
@@ -120,7 +122,7 @@ describe("db schema", () => {
       )
       GROUP BY name
     `);
-    expect(namesResult.rows).toHaveLength(32);
+    expect(namesResult.rows).toHaveLength(33);
     for (const row of namesResult.rows as Array<{ count?: unknown }>) {
       expect(Number(row.count)).toBe(1);
     }

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -30,7 +30,13 @@ describe("db schema", () => {
       "entry_sources",
       "signal_watermarks",
       "conflict_log",
+      "co_recall_edges",
+      "review_queue",
       "entries_fts",
+      "idx_co_recall_a",
+      "idx_co_recall_b",
+      "idx_review_queue_status",
+      "idx_review_queue_entry",
       "idx_entries_embedding",
       "idx_entries_type",
       "idx_entries_type_canonical_key",
@@ -86,7 +92,13 @@ describe("db schema", () => {
         'entry_sources',
         'signal_watermarks',
         'conflict_log',
+        'co_recall_edges',
+        'review_queue',
         'entries_fts',
+        'idx_co_recall_a',
+        'idx_co_recall_b',
+        'idx_review_queue_status',
+        'idx_review_queue_entry',
         'idx_entries_embedding',
         'idx_entries_type',
         'idx_entries_type_canonical_key',
@@ -108,7 +120,7 @@ describe("db schema", () => {
       )
       GROUP BY name
     `);
-    expect(namesResult.rows).toHaveLength(26);
+    expect(namesResult.rows).toHaveLength(32);
     for (const row of namesResult.rows as Array<{ count?: unknown }>) {
       expect(Number(row.count)).toBe(1);
     }

--- a/tests/openclaw-plugin/index.test.ts
+++ b/tests/openclaw-plugin/index.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  BeforePromptBuildEvent,
+  BeforePromptBuildResult,
+  BeforeResetEvent,
+  PluginHookAgentContext,
+} from "../../src/openclaw-plugin/types.js";
+
+type BeforePromptBuildHandler = (
+  event: BeforePromptBuildEvent,
+  ctx: PluginHookAgentContext,
+) => Promise<BeforePromptBuildResult | undefined>;
+
+type BeforeResetHandler = (event: BeforeResetEvent, ctx: PluginHookAgentContext) => Promise<void>;
+
+const indexModulePath = "../../src/openclaw-plugin/index.js";
+const recallModulePath = "../../src/openclaw-plugin/recall.js";
+const sessionQueryModulePath = "../../src/openclaw-plugin/session-query.js";
+const dbClientModulePath = "../../src/db/client.js";
+const configModulePath = "../../src/config.js";
+const feedbackModulePath = "../../src/db/feedback.js";
+const coRecallModulePath = "../../src/db/co-recall.js";
+const reviewQueueModulePath = "../../src/db/review-queue.js";
+const toolsModulePath = "../../src/openclaw-plugin/tools.js";
+
+async function registerPlugin(pluginConfig?: Record<string, unknown>): Promise<{
+  beforePromptBuildHandler: BeforePromptBuildHandler;
+  beforeResetHandler: BeforeResetHandler;
+}> {
+  const mod = await import(indexModulePath);
+  const plugin = mod.default;
+
+  let beforePromptBuildHandler: BeforePromptBuildHandler | null = null;
+  let beforeResetHandler: BeforeResetHandler | null = null;
+
+  const api = {
+    id: "agenr",
+    name: "agenr",
+    pluginConfig,
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+    on: (hook: string, handler: unknown) => {
+      if (hook === "before_prompt_build") {
+        beforePromptBuildHandler = handler as BeforePromptBuildHandler;
+      }
+      if (hook === "before_reset") {
+        beforeResetHandler = handler as BeforeResetHandler;
+      }
+    },
+  };
+
+  plugin.register(api as never);
+
+  if (!beforePromptBuildHandler || !beforeResetHandler) {
+    throw new Error("Expected before_prompt_build and before_reset handlers");
+  }
+
+  return {
+    beforePromptBuildHandler,
+    beforeResetHandler,
+  };
+}
+
+function buildRecallResults(ids: string[]): {
+  query: string;
+  results: Array<{ entry: { id: string; type: string; subject: string; content: string }; score: number }>;
+} {
+  return {
+    query: "",
+    results: ids.map((id) => ({
+      entry: {
+        id,
+        type: "fact",
+        subject: `subject-${id}`,
+        content: `content-${id}`,
+      },
+      score: 0.9,
+    })),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock(recallModulePath);
+  vi.doUnmock(sessionQueryModulePath);
+  vi.doUnmock(dbClientModulePath);
+  vi.doUnmock(configModulePath);
+  vi.doUnmock(feedbackModulePath);
+  vi.doUnmock(coRecallModulePath);
+  vi.doUnmock(reviewQueueModulePath);
+  vi.doUnmock(toolsModulePath);
+});
+
+describe("openclaw plugin before_reset phase 2", () => {
+  it("calls strengthenCoRecallEdges with used IDs returned from feedback", async () => {
+    vi.resetModules();
+
+    const fakeDb = { execute: vi.fn(async () => ({ rows: [], rowsAffected: 0 })) };
+    const strengthenCoRecallEdges = vi.fn(async () => undefined);
+    const computeRecallFeedback = vi.fn(async () => ({
+      usedIds: ["e1", "e2"],
+      correctedIds: [],
+      updatedIds: [],
+    }));
+
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall: vi.fn(async () => buildRecallResults(["e1", "e2"])),
+      formatRecallAsMarkdown: vi.fn(() => ""),
+    }));
+    vi.doMock(sessionQueryModulePath, () => ({
+      buildSemanticSeed: vi.fn(() => ""),
+      extractLastExchangeText: vi.fn(() => ""),
+      extractRecentTurns: vi.fn(async () => ""),
+      findPreviousSessionFile: vi.fn(async () => null),
+      stripPromptMetadata: vi.fn((text: string) => text),
+    }));
+    vi.doMock(dbClientModulePath, () => ({
+      getDb: vi.fn(() => fakeDb),
+      initDb: vi.fn(async () => undefined),
+      closeDb: vi.fn(() => undefined),
+    }));
+    vi.doMock(configModulePath, () => ({
+      readConfig: vi.fn(() => ({ models: { extraction: "x", claimExtraction: "x", contradictionJudge: "x", handoffSummary: "x" } })),
+    }));
+    vi.doMock(feedbackModulePath, () => ({ computeRecallFeedback }));
+    vi.doMock(coRecallModulePath, () => ({
+      strengthenCoRecallEdges,
+    }));
+    vi.doMock(reviewQueueModulePath, () => ({
+      checkAndFlagLowQuality: vi.fn(async () => undefined),
+    }));
+    vi.doMock(toolsModulePath, () => ({
+      runExtractTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+      runRecallTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+      runRetireTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+      runStoreTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+    }));
+
+    const { beforePromptBuildHandler, beforeResetHandler } = await registerPlugin({ signalsEnabled: false });
+
+    await beforePromptBuildHandler({ prompt: "test" }, { sessionKey: "agent:main:phase2-strengthen" });
+    await beforeResetHandler(
+      {
+        messages: [{ role: "assistant", content: [{ type: "text", text: "final response" }] }],
+      },
+      { sessionKey: "agent:main:phase2-strengthen" },
+    );
+
+    expect(computeRecallFeedback).toHaveBeenCalledTimes(1);
+    expect(strengthenCoRecallEdges).toHaveBeenCalledTimes(1);
+    expect(strengthenCoRecallEdges).toHaveBeenCalledWith(fakeDb, ["e1", "e2"], expect.any(String));
+  });
+
+  it("checks low-quality thresholds after feedback updates", async () => {
+    vi.resetModules();
+
+    const fakeDb = {
+      execute: vi.fn(async (query: string | { sql: string }) => {
+        const sql = typeof query === "string" ? query : query.sql;
+        if (sql.includes("SELECT id, quality_score, recall_count")) {
+          return {
+            rows: [
+              { id: "e1", quality_score: 0.15, recall_count: 12 },
+              { id: "e2", quality_score: 0.42, recall_count: 15 },
+            ],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      }),
+    };
+
+    const checkAndFlagLowQuality = vi.fn(async () => undefined);
+
+    vi.doMock(recallModulePath, () => ({
+      resolveAgenrPath: vi.fn(() => "/tmp/agenr"),
+      resolveBudget: vi.fn(() => 2000),
+      runRecall: vi.fn(async () => buildRecallResults(["e1", "e2"])),
+      formatRecallAsMarkdown: vi.fn(() => ""),
+    }));
+    vi.doMock(sessionQueryModulePath, () => ({
+      buildSemanticSeed: vi.fn(() => ""),
+      extractLastExchangeText: vi.fn(() => ""),
+      extractRecentTurns: vi.fn(async () => ""),
+      findPreviousSessionFile: vi.fn(async () => null),
+      stripPromptMetadata: vi.fn((text: string) => text),
+    }));
+    vi.doMock(dbClientModulePath, () => ({
+      getDb: vi.fn(() => fakeDb),
+      initDb: vi.fn(async () => undefined),
+      closeDb: vi.fn(() => undefined),
+    }));
+    vi.doMock(configModulePath, () => ({
+      readConfig: vi.fn(() => ({ models: { extraction: "x", claimExtraction: "x", contradictionJudge: "x", handoffSummary: "x" } })),
+    }));
+    vi.doMock(feedbackModulePath, () => ({
+      computeRecallFeedback: vi.fn(async () => ({
+        usedIds: [],
+        correctedIds: [],
+        updatedIds: ["e1", "e2"],
+      })),
+    }));
+    vi.doMock(coRecallModulePath, () => ({
+      strengthenCoRecallEdges: vi.fn(async () => undefined),
+    }));
+    vi.doMock(reviewQueueModulePath, () => ({
+      checkAndFlagLowQuality,
+    }));
+    vi.doMock(toolsModulePath, () => ({
+      runExtractTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+      runRecallTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+      runRetireTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+      runStoreTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+    }));
+
+    const { beforePromptBuildHandler, beforeResetHandler } = await registerPlugin({ signalsEnabled: false });
+
+    await beforePromptBuildHandler({ prompt: "test" }, { sessionKey: "agent:main:phase2-low-quality" });
+    await beforeResetHandler(
+      {
+        messages: [{ role: "assistant", content: [{ type: "text", text: "final response" }] }],
+      },
+      { sessionKey: "agent:main:phase2-low-quality" },
+    );
+
+    expect(checkAndFlagLowQuality).toHaveBeenCalledTimes(2);
+    expect(checkAndFlagLowQuality).toHaveBeenNthCalledWith(1, fakeDb, "e1", 0.15, 12);
+    expect(checkAndFlagLowQuality).toHaveBeenNthCalledWith(2, fakeDb, "e2", 0.42, 15);
+  });
+});


### PR DESCRIPTION
## What

Phase 2 of feedback-driven recall scoring (#267). Two features:

1. **Co-recall edge creation (Hebbian learning)** - entries recalled and used together form weighted associations. Edges strengthen on repeated co-occurrence, decay over time, and get pruned when weak.
2. **Review queue** - entries flagged for human review tracked in a dedicated table. Low-quality entries (quality_score < 0.2 after 10+ recalls) auto-flagged for retirement.

## Key decisions

- **Separate table for co-recall edges** (not the relations table) because co-recall edges are statistical/undirected/frequently updated vs semantic relations which are LLM-determined/directional/static.
- **Dedicated review_queue table** (not query-time detection) to decouple detection from presentation and serve as data layer for future web UI (#296).
- **edge_type column** on co_recall_edges for future-proofing Phase 3 directed relationships.

## Changes

- New tables: co_recall_edges, review_queue (with partial unique index for atomic dedup)
- New files: src/db/co-recall.ts, src/db/review-queue.ts
- Refactored computeRecallFeedback to return used/corrected/updated entry IDs
- Plugin integration: co-recall strengthening + low-quality flagging in before_reset
- CLI: `agenr review`, `agenr review dismiss`, `agenr review retire`, `agenr edges`
- Health report: co-recall edge stats + review queue summary
- Cascade delete of co_recall_edges on entry retirement
- Rehabilitation (quality floor bump) on review dismiss
- Independent error handling per step in plugin

## Tests

1593 tests passing (+35 new). Covers edge CRUD, decay/pruning, review queue lifecycle, retirement cascade, rehabilitation, and plugin integration.

Closes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.9.8

* **New Features**
  * Added co-recall edge tracking for entries used together in sessions via Hebbian learning.
  * Added review queue system with automatic flagging for low-quality entries.
  * Added `review` command group to list, dismiss, and retire pending reviews.
  * Added `edges` command to inspect co-recall relationships between entries.
  * Enhanced `health` command output with co-recall edge statistics and review queue summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->