### PR TITLE
feat: graph-augmented recall (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.9.9 - 2026-02-27
+
+### Added
+- Graph-augmented recall: top embedding matches seed 1-hop traversal of
+  co-recall edges, pulling in associatively connected entries that similarity
+  alone would miss. Graph neighbors are scored with real embedding similarity
+  plus an additive graph bonus (0.15 * edge weight). Seeds are selected by
+  embedding similarity only to prevent recency bias (#297).
+
 ## 0.9.8 - 2026-02-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -136,6 +136,14 @@ function formatRecallCount(count: number): string {
   return `recalled ${count} times`;
 }
 
+function formatGraphScore(result: RecallCommandResult): string {
+  const graphScore = result.scores.graph;
+  if (graphScore === undefined || graphScore <= 0) {
+    return "";
+  }
+  return ` | graph=${graphScore.toFixed(2)}`;
+}
+
 function printHumanResults(results: RecallCommandResult[], elapsedMs: number, now: Date, isSessionStart: boolean): void {
   const clackOutput = { output: process.stderr };
   clack.log.info(`${ui.bold(String(results.length))} results (${elapsedMs}ms)`, clackOutput);
@@ -166,7 +174,7 @@ function printHumanResults(results: RecallCommandResult[], elapsedMs: number, no
           clackOutput,
         );
         clack.log.info(
-          `   importance=${result.entry.importance} | ${formatAge(result.entry.created_at, now)} | ${formatRecallCount(result.entry.recall_count)}`,
+          `   importance=${result.entry.importance} | ${formatAge(result.entry.created_at, now)} | ${formatRecallCount(result.entry.recall_count)}${formatGraphScore(result)}`,
           clackOutput,
         );
         clack.log.info(`   tags: ${result.entry.tags.length > 0 ? result.entry.tags.join(", ") : "none"}`, clackOutput);
@@ -180,7 +188,7 @@ function printHumanResults(results: RecallCommandResult[], elapsedMs: number, no
   for (const result of results) {
     clack.log.info(`${index}. [${result.entry.type}] ${result.entry.subject}: ${result.entry.content}`, clackOutput);
     clack.log.info(
-      `   importance=${result.entry.importance} | ${formatAge(result.entry.created_at, now)} | ${formatRecallCount(result.entry.recall_count)}`,
+      `   importance=${result.entry.importance} | ${formatAge(result.entry.created_at, now)} | ${formatRecallCount(result.entry.recall_count)}${formatGraphScore(result)}`,
       clackOutput,
     );
     clack.log.info(`   tags: ${result.entry.tags.length > 0 ? result.entry.tags.join(", ") : "none"}`, clackOutput);

--- a/src/db/recall.ts
+++ b/src/db/recall.ts
@@ -1196,7 +1196,7 @@ export async function recall(
   scored.sort((a, b) => b.score - a.score);
 
   const graphEnabled = options.graphEnabled !== false;
-  if (graphEnabled && text && queryEmbedding && !isSessionStart) {
+  if (graphEnabled && text && queryEmbedding && !isSessionStart && !query.noBoost) {
     const seedCountRaw = options.graphSeedCount ?? GRAPH_SEED_COUNT;
     const seedCount = Number.isFinite(seedCountRaw) && seedCountRaw > 0 ? Math.floor(seedCountRaw) : GRAPH_SEED_COUNT;
     const minEdgeWeightRaw = options.graphMinEdgeWeight ?? GRAPH_MIN_EDGE_WEIGHT;

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,7 @@ export interface RecallResult {
     fts: number;
     spacing: number;
     quality: number;
+    graph?: number;
   };
 }
 


### PR DESCRIPTION
## Summary

Augment embedding-based recall with associative memory via co-recall edge traversal (Phase 3 of #265).

When recalling entries, top embedding matches seed 1-hop traversal of co-recall edges, pulling in associatively connected entries that similarity alone would miss.

## Key Design Decisions

- **Seeds by embedding similarity only** (not full score) - prevents recency bias from contaminating graph traversal
- **Real embedding similarity** computed for graph neighbors (not vectorSim=0)
- **Additive graph bonus:** `finalScore = min(1.0, baseScore + edgeWeight * 0.15)`
- **Loop existing `getCoRecallNeighbors`** per seed (proven code, no new SQL)
- **Semantic recall only** - skips browse mode and session-start
- **Always-on** when edges exist; `--no-graph` flag deferred to v2

## Changes

- `src/db/recall.ts` - graph augmentation step after scoring, `fetchEntriesByIds` helper, named constants
- `src/types.ts` - optional `graph` field in RecallResult scores
- `src/commands/recall.ts` - graph score in display output
- 12 new tests covering happy path, skip conditions, filtering, seed selection, dedup, threshold enforcement
- 1605 tests passing

## Design Doc

See `docs/internal/297-implementation-plan.md` for full architecture decisions, v2 enhancements, and review findings.

Closes #297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph-augmented recall: search results are extended with associatively connected entries via 1-hop neighbors, scored by embedding similarity plus an additive graph bonus; seeds are selected by embedding similarity only.

* **Chores**
  * Version bumped to 0.9.9

* **Documentation**
  * Added 0.9.9 changelog entry describing graph-augmented recall.

* **Tests**
  * Added comprehensive tests validating graph augmentation behavior and scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->