### PR TITLE
fix: add 15s timeout to LLM dedup pre-screening to prevent hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.11 - 2026-02-27
+
+### Fixed
+- Added 15s timeout to LLM dedup pre-screening calls in consolidate clustering
+  to prevent hangs from unresponsive LLM endpoints.
+
 ## 0.9.10 - 2026-02-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Hotfix for consolidate hanging in 0.9.10.

`runSimpleStream` calls in `llmDedupCheck` hang indefinitely when the LLM endpoint is unresponsive. Wraps the call in `Promise.race` with a 15s timeout. On timeout, returns `false` (entries treated as distinct) which is the safe default.

Discovered during first real-world consolidate run after DB reset + full re-ingest with 1215 entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added 15-second timeout to consolidate clustering operations to prevent hangs from unresponsive endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->