### PR TITLE
fix: register pi-ai API providers before streamSimple calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 0.9.11 - 2026-02-27
 
 ### Fixed
+- Register pi-ai API providers before streamSimple calls so consolidate
+  LLM dedup and merge can resolve the OpenAI/Anthropic streaming backend.
+  Root cause: tsup tree-shook the side-effect import; now uses explicit
+  registration via ensureApiProviders() guard.
 - Added 15s timeout to LLM dedup pre-screening calls in consolidate clustering
   to prevent hangs from unresponsive LLM endpoints.
 

--- a/src/llm/stream.ts
+++ b/src/llm/stream.ts
@@ -6,7 +6,15 @@ import type {
   Model,
   SimpleStreamOptions,
 } from "@mariozechner/pi-ai";
-import { streamSimple } from "@mariozechner/pi-ai";
+import { registerBuiltInApiProviders, streamSimple } from "@mariozechner/pi-ai";
+
+// Ensure pi-ai API providers are registered so streamSimple can resolve them.
+let _apiProvidersRegistered = false;
+function ensureApiProviders(): void {
+  if (_apiProvidersRegistered) return;
+  registerBuiltInApiProviders();
+  _apiProvidersRegistered = true;
+}
 
 export type SimpleAssistantStream = AsyncIterable<AssistantMessageEvent> & {
   result: () => Promise<AssistantMessage>;
@@ -38,6 +46,9 @@ function logVerbose(params: StreamRunParams, line: string): void {
 
 export async function runSimpleStream(params: StreamRunParams): Promise<AssistantMessage> {
   const streamFn = params.streamSimpleImpl ?? streamSimple;
+  if (!params.streamSimpleImpl) {
+    ensureApiProviders();
+  }
   const stream = streamFn(params.model, params.context, params.options);
 
   for await (const event of stream) {


### PR DESCRIPTION
Root cause fix for consolidate hang in 0.9.10/0.9.11.

**Problem:** `tsup` tree-shook the pi-ai provider registration side-effect import (`register-builtins.js`), so `streamSimple` could not resolve the API backend (`openai-responses`, `anthropic-messages`, etc.). This caused `llmDedupCheck` in consolidate clustering to hang indefinitely (the error was swallowed by the catch block, leaving the process idle).

**Fix:** Explicitly import `registerBuiltInApiProviders` from `@mariozechner/pi-ai` and call it via an `ensureApiProviders()` guard in `runSimpleStream` before any `streamSimple` call that does not use a provided `streamSimpleImpl`.

**Also fixes:** The same latent bug in `merge.ts` which calls `runSimpleStream` without `streamSimpleImpl` - merge would have hung too once clustering stopped blocking it.

1615 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where consolidation-based LLM dedup/merge functionality was not resolving streaming backends correctly. API providers are now automatically initialized before stream creation to ensure proper operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->