### PR TITLE
chore: bump to 0.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.11 - 2026-02-27
+## 0.9.12 - 2026-02-27
 
 ### Fixed
 - Register pi-ai API providers before streamSimple calls so consolidate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"


### PR DESCRIPTION
Version bump for npm publish (0.9.11 was already published with timeout-only fix, this includes the root cause provider registration fix).