### PR TITLE
feat: add progress counter, spinner, and ETA to consolidate phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.16 - 2026-02-27
+
+### Added
+- Added progress logging throughout the consolidate pipeline. Pairwise
+  similarity scan, rules phases, cluster processing, LLM dedup checks, and
+  LLM merge calls now report progress so users can see the system is working.
+  Phase-level progress logs are always shown (not gated behind `--verbose`).
+- Added live cluster progress updates with ETA during consolidation phases so
+  long-running Phase 1, Phase 2, and Phase 3 work shows continuous terminal
+  activity.
+
 ## 0.9.14 - 2026-02-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/consolidate/merge.ts
+++ b/src/consolidate/merge.ts
@@ -281,6 +281,11 @@ export async function mergeCluster(
     }
   }
 
+  const subjectPreview = truncateContent(cluster.entries[0]?.subject ?? "", 60);
+  onLog(
+    `[merge-llm] Merging cluster of ${cluster.entries.length} entries (subject: "${subjectPreview || "unknown"}")`,
+  );
+
   let mergeResult: MergeResult | null = null;
   try {
     const response = await runSimpleStream({

--- a/tests/consolidate-orchestrate.test.ts
+++ b/tests/consolidate-orchestrate.test.ts
@@ -156,6 +156,28 @@ describe("consolidate orchestrator", () => {
     expect(phase2Call?.simThreshold).toBe(0.88);
   });
 
+  it("logs Phase 1 per-cluster progress", async () => {
+    const mod = await setupModule();
+    const { deps } = makeDeps({
+      buildClustersFn: (typeFilter) => (typeFilter === "fact" ? [makeCluster(["f1", "f2"])] : []),
+    });
+    const logs: string[] = [];
+
+    await mod.runConsolidationOrchestrator(
+      {} as Client,
+      "/tmp/knowledge.db",
+      makeLlmClient(),
+      "embed-key",
+      {
+        type: "fact",
+        onLog: (line) => logs.push(line),
+      },
+      deps,
+    );
+
+    expect(logs).toContain("[phase 1] Processing cluster 1/1...");
+  });
+
   it("stops after batch limit and persists checkpoint", async () => {
     const mod = await setupModule();
     const { deps } = makeDeps({


### PR DESCRIPTION
Adds progress visibility throughout the consolidate pipeline so users can see it is working, not hung.

- Pairwise similarity scan: logs entry count, comparison count, 10% progress increments with ETA
- Rules phases: logs each step (pruning, merging, orphan cleanup) always (not verbose-gated)
- Cluster processing: live TTY progress line with cluster K/T, type, and ETA after 2+ clusters
- LLM dedup: logs checked/total pairs with match count
- LLM merge: logs cluster size and subject before each merge call

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive progress logging across the consolidation pipeline, including similarity scanning, rules phases, cluster processing, deduplication checks, and merge operations.
  * Introduced live cluster progress updates with estimated time remaining during consolidation phases, providing continuous visibility into long-running operations.
  * Phase-level progress logs now display unconditionally, independent of verbose flag settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->