### PR TITLE
perf: batch and parallelize consolidate LLM dedup checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.17 - 2026-02-27
+
+### Changed
+- Optimized LLM dedup in consolidate clustering: batch up to 10 pairs per API
+  call with 5 concurrent batches. Reduces a 2400-pair dedup queue from ~60min
+  (sequential, 1 call per pair) to ~2min.
+
 ## 0.9.16 - 2026-02-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/consolidate/cluster.ts
+++ b/src/consolidate/cluster.ts
@@ -244,6 +244,7 @@ export async function llmDedupCheck(
 ): Promise<boolean> {
   try {
     const timeoutMs = 15_000;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const response = await Promise.race([
       runSimpleStream({
         model: llmClient.resolvedModel.model,
@@ -253,10 +254,10 @@ export async function llmDedupCheck(
         },
         verbose: false,
       }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("llmDedupCheck timed out")), timeoutMs),
-      ),
-    ]);
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("llmDedupCheck timed out")), timeoutMs);
+      }),
+    ]).finally(() => clearTimeout(timer));
 
     if (response.stopReason === "error" || response.errorMessage) {
       return false;
@@ -278,6 +279,7 @@ export async function llmDedupCheckBatch(llmClient: LlmClient, pairs: LlmDedupPa
 
   try {
     const timeoutMs = 30_000;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const response = await Promise.race([
       runSimpleStream({
         model: llmClient.resolvedModel.model,
@@ -287,10 +289,10 @@ export async function llmDedupCheckBatch(llmClient: LlmClient, pairs: LlmDedupPa
         },
         verbose: false,
       }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("llmDedupCheckBatch timed out")), timeoutMs),
-      ),
-    ]);
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("llmDedupCheckBatch timed out")), timeoutMs);
+      }),
+    ]).finally(() => clearTimeout(timer));
 
     if (response.stopReason === "error" || response.errorMessage) {
       return fallback;


### PR DESCRIPTION
Batches up to 10 dedup pairs per API call with 5 concurrent batches. Reduces a 2473-pair dedup queue from ~60min (sequential, 1 call/pair) to ~2min.

- New `llmDedupCheckBatch` sends multiple pairs in a single tool call
- Concurrent batch groups via `Promise.allSettled`
- Conservative fallback: failed/partial batches default to same=false
- Timer leak fix: `clearTimeout` on both single and batch dedup checks
- Progress logging with ETA based on checked pairs

1626 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.9.17

* **New Features**
  * Batch deduplication: Improved processing speed by executing multiple deduplication checks concurrently. Typical workloads now complete in ~2 minutes instead of ~60 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->