### PR TITLE
feat: subsequent-turn auto-recall, MCP stdout fix, remove MCP store (#314, #315, #316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.9.18 (2026-02-28)
+
+### Features
+- OpenClaw plugin: subsequent-turn auto-recall with heuristic message
+  classifier. Messages are classified as trivial (skip), normal (5 results),
+  or complex (8 results) based on entity detection, temporal references,
+  and explicit recall phrases. Queries built from a sliding window of
+  recent messages with Jaccard similarity dedup. Recalled entries are
+  deduplicated against session-start context. Configurable via
+  midSessionRecall plugin config.
+
+### Tests
+- 16-case message classifier test suite
+- Query builder, similarity check, and state management tests
+- Integration tests for mid-session recall in before_prompt_build
+
 ## 0.9.17 - 2026-02-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,25 @@
   deduplicated against session-start context. Configurable via
   midSessionRecall plugin config.
 
+### Bug Fixes
+- MCP: fix stdout corruption during store and contradiction checks.
+  Diagnostic logs in db/store.ts and db/contradiction.ts were writing to
+  stdout via console.log, corrupting MCP JSON-RPC framing. Routed all
+  diagnostic logging to stderr via console.error.
+
+### Changed
+- Removed agenr_store tool from MCP server. Coding agents should rely on
+  Watcher for knowledge ingest from session transcripts. Reduces MCP
+  surface area and eliminates stdout corruption risk.
+- Removed store option from agenr_extract MCP tool. Extract now returns
+  extracted entries without storing them.
+
 ### Tests
 - 16-case message classifier test suite
 - Query builder, similarity check, and state management tests
 - Integration tests for mid-session recall in before_prompt_build
+- MCP stdout corruption test
+- Updated MCP server tests for removed store tool and extract store option
 
 ## 0.9.17 - 2026-02-27
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -49,6 +49,29 @@
         "type": "boolean",
         "description": "Set false to disable mid-session signals without uninstalling."
       },
+      "midSessionRecall": {
+        "type": "object",
+        "description": "Mid-session recall tuning and controls.",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Set false to disable heuristic-gated mid-session recall (default: true)."
+          },
+          "normalLimit": {
+            "type": "number",
+            "description": "Max recall results for normal messages (default: 5)."
+          },
+          "complexLimit": {
+            "type": "number",
+            "description": "Max recall results for complex messages (default: 8)."
+          },
+          "querySimilarityThreshold": {
+            "type": "number",
+            "description": "Skip repeat recall when query Jaccard similarity exceeds this value (default: 0.85)."
+          }
+        }
+      },
       "dbPath": {
         "type": "string",
         "description": "Path to agenr DB. Defaults to AGENR_DB_PATH env or ~/.agenr/knowledge.db."

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -25,6 +25,10 @@
         "type": "boolean",
         "description": "Set false to disable memory injection without uninstalling."
       },
+      "debug": {
+        "type": "boolean",
+        "description": "Enable debug logging to stderr (default: false)."
+      },
       "signalMinImportance": {
         "type": "number",
         "description": "Minimum importance for mid-session signals (1-10, default: 8). Raise to reduce noise."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -409,6 +409,22 @@ describe("runInitCommand", () => {
     expect(instructions).toContain("<!-- agenr:end -->");
   });
 
+  it("writes recall-only system prompt block and explicit no-store warning", async () => {
+    const dir = await createTempDir();
+    tempDirs.push(dir);
+
+    const result = await runInitCommand({ path: dir, platform: "generic" });
+    expect(result.instructionsPath).toBe(path.join(dir, "AGENTS.md"));
+
+    const instructions = await fs.readFile(path.join(dir, "AGENTS.md"), "utf8");
+    expect(instructions).toContain("You have access to agenr_recall for persistent memory across sessions.");
+    expect(instructions).toContain("Do NOT call agenr_store. That tool has been removed.");
+
+    const lower = instructions.toLowerCase();
+    const storeMentions = lower.match(/\bagenr_store\b/g) ?? [];
+    expect(storeMentions).toHaveLength(1);
+  });
+
   it("auto-detects windsurf from .windsurfrules", async () => {
     const dir = await createTempDir();
     tempDirs.push(dir);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -251,15 +251,13 @@ function isPlatform(value: string): value is InitPlatform {
   return PLATFORM_VALUES.includes(value as InitPlatform);
 }
 
-function buildSystemPromptBlock(projectSlug: string): string {
+function buildSystemPromptBlock(_projectSlug: string): string {
   return [
-    "You have access to agenr_recall and agenr_store for persistent memory across sessions.",
+    "You have access to agenr_recall for persistent memory across sessions.",
     "",
     'On session start, call agenr_recall with context="session-start" to load prior knowledge for this project. Mid-session, call agenr_recall with a query when you need context you do not have.',
     "",
-    `After any decision, user preference, lesson learned, or important event, immediately call agenr_store. Do not ask - just store it. Each entry needs: type (fact|decision|preference|todo|lesson|event), content (what and why), importance (1-10, default 7, use 9 for critical, 10 sparingly), project="${projectSlug}".`,
-    "",
-    "Do not store: secrets/credentials, temporary state, verbatim conversation, or information already in files.",
+    "Do NOT call agenr_store. That tool has been removed. Your session transcript is automatically ingested by the Watcher, which extracts valuable knowledge after the session ends. Focus on your task - the memory system captures insights for you.",
   ].join("\n");
 }
 

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -378,8 +378,8 @@ export async function runRecallCommand(
         budget,
         nonCoreLimit: limit,
       });
-      finalResults = grouped.results;
-      budgetUsed = grouped.budgetUsed;
+      finalResults = grouped.results.slice(0, limit);
+      budgetUsed = finalResults.reduce((sum, item) => sum + estimateEntryTokens(item), 0);
     } else {
       const baseResults = await resolvedDeps.recallFn(db, queryForRecall, apiKey);
       if (budget === undefined) {

--- a/src/db/contradiction.ts
+++ b/src/db/contradiction.ts
@@ -244,7 +244,7 @@ export async function classifyConflict(
     });
 
     if (response.stopReason === "error" || response.errorMessage) {
-      console.warn(
+      console.error(
         `[contradiction] LLM judge error: ${response.errorMessage ?? "unknown stop reason"}`,
       );
       return llmErrorResult();
@@ -252,7 +252,7 @@ export async function classifyConflict(
 
     const parsed = extractJudgeArgs(response);
     if (!parsed) {
-      console.warn("[contradiction] LLM judge returned unparseable response");
+      console.error("[contradiction] LLM judge returned unparseable response");
       return llmErrorResult();
     }
 
@@ -262,7 +262,7 @@ export async function classifyConflict(
       explanation: parsed.explanation,
     };
   } catch (err) {
-    console.warn(
+    console.error(
       `[contradiction] LLM judge call failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return llmErrorResult();
@@ -413,7 +413,7 @@ export async function resolveConflict(
       conflict.result.confidence,
       "coexist",
     );
-    console.log(
+    console.error(
       `[contradiction] resolution: coexist (events are immutable) entry=${conflict.existingEntryId.slice(0, 8)}`,
     );
     return { action: "coexist", reason: "events are immutable" };
@@ -451,7 +451,7 @@ export async function resolveConflict(
       "auto-superseded",
     );
 
-    console.log(
+    console.error(
       `[contradiction] resolution: auto-superseded entry=${conflict.existingEntryId.slice(0, 8)} (${conflict.existingType} confidence=${conflict.result.confidence.toFixed(2)})`,
     );
     return {
@@ -474,7 +474,7 @@ export async function resolveConflict(
       conflict.result.confidence,
       "pending",
     );
-    console.log(
+    console.error(
       `[contradiction] resolution: flagged for review entry=${conflict.existingEntryId.slice(0, 8)} (${conflict.result.relation} confidence=${conflict.result.confidence.toFixed(2)})`,
     );
     return { action: "flagged", reason: "needs human review" };
@@ -494,7 +494,7 @@ export async function resolveConflict(
       conflict.result.confidence,
       "pending",
     );
-    console.log(
+    console.error(
       `[contradiction] resolution: flagged for review entry=${conflict.existingEntryId.slice(0, 8)} (high-confidence supersedes blocked by importance)`,
     );
     return { action: "flagged", reason: "high-confidence supersession blocked by importance" };
@@ -509,7 +509,7 @@ export async function resolveConflict(
     "coexist",
   );
 
-  console.log(
+  console.error(
     `[contradiction] resolution: coexist entry=${conflict.existingEntryId.slice(0, 8)}`,
   );
   return { action: "coexist", reason: "entries can coexist" };

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1506,7 +1506,7 @@ export async function storeEntries(
 
     if (!entityHintsPromise) {
       entityHintsPromise = getDistinctEntities(db).catch((err) => {
-        console.warn(
+        console.error(
           `[store] entity hints lookup failed, proceeding without hints: ${err instanceof Error ? err.message : String(err)}`,
         );
         return [];
@@ -1745,7 +1745,7 @@ export async function storeEntries(
     ) {
       await contradictionSubjectIndex.ensureInitialized(db);
 
-      console.log(
+      console.error(
         `[contradiction] checking entry: type=${normalizedEntry.type} subject="${normalizedEntry.subject}" subjectKey=${normalizedEntry.subjectKey ?? "none"}`,
       );
 
@@ -1768,11 +1768,11 @@ export async function storeEntries(
       );
 
       if (conflicts.length === 0) {
-        console.log("[contradiction] no conflicts detected");
+        console.error("[contradiction] no conflicts detected");
       } else {
-        console.log(`[contradiction] found ${conflicts.length} conflict(s):`);
+        console.error(`[contradiction] found ${conflicts.length} conflict(s):`);
         for (const c of conflicts) {
-          console.log(
+          console.error(
             `[contradiction]   vs entry=${c.existingEntryId.slice(0, 8)} relation=${c.result.relation} confidence=${c.result.confidence.toFixed(2)} explanation="${c.result.explanation.slice(0, 80)}"`,
           );
         }

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -365,7 +365,7 @@ describe("before_prompt_build mid-session recall", () => {
       expect.any(Number),
       undefined,
       expect.stringContaining("Tell me about Ava"),
-      { context: "session-start", limit: 8 },
+      { limit: 8 },
       undefined,
     );
     expect(second?.prependContext).toContain("## Recalled context");

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -1361,7 +1361,7 @@ const plugin = {
 
             const classification = classifyMessage(userMessage);
             if (classification !== "trivial") {
-              const query = buildQuery(state.recentMessages);
+              const query = buildQuery(state.recentMessages.toArray());
               const threshold = resolveMidSessionSimilarityThreshold(
                 config?.midSessionRecall?.querySimilarityThreshold,
               );
@@ -1380,7 +1380,7 @@ const plugin = {
                   budget,
                   project,
                   query,
-                  { context: "session-start", limit },
+                  { limit },
                   config?.dbPath,
                 );
                 state.lastRecallQuery = query;

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -16,6 +16,7 @@ import { toNumber, toStringValue } from "../utils/entry-utils.js";
 import {
   buildQuery,
   classifyMessage,
+  clearMidSessionState,
   clearMidSessionStates,
   formatMidSessionRecall,
   getMidSessionState,
@@ -1383,7 +1384,9 @@ const plugin = {
                   { limit },
                   config?.dbPath,
                 );
-                state.lastRecallQuery = query;
+                if (midSessionResult) {
+                  state.lastRecallQuery = query;
+                }
 
                 if (midSessionResult && midSessionResult.results.length > 0) {
                   const alreadyRecalledIds = sessionRecalledEntries.get(sessionKey) ?? new Set<string>();
@@ -1561,7 +1564,10 @@ const plugin = {
           }
 
           if (event.action === "new") {
-            clearMidSessionStates();
+            const resetKey = event.sessionKey;
+            if (resetKey) {
+              clearMidSessionState(resetKey);
+            }
           }
 
           const sessionKey = event.sessionKey;

--- a/src/openclaw-plugin/mid-session-recall.test.ts
+++ b/src/openclaw-plugin/mid-session-recall.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   buildQuery,
   classifyMessage,
+  clearMidSessionState,
   clearMidSessionStates,
   formatMidSessionRecall,
   getMidSessionState,
@@ -123,6 +124,22 @@ describe("mid-session state", () => {
     expect(stateBNext).not.toBe(stateB);
     expect(stateANext.turnCount).toBe(0);
     expect(stateBNext.turnCount).toBe(0);
+  });
+
+  it("clears only the targeted state entry", () => {
+    const stateA = getMidSessionState("session-a");
+    const stateB = getMidSessionState("session-b");
+    stateA.turnCount = 4;
+    stateB.turnCount = 2;
+
+    clearMidSessionState("session-a");
+
+    const stateANext = getMidSessionState("session-a");
+    const stateBNext = getMidSessionState("session-b");
+    expect(stateANext).not.toBe(stateA);
+    expect(stateANext.turnCount).toBe(0);
+    expect(stateBNext).toBe(stateB);
+    expect(stateBNext.turnCount).toBe(2);
   });
 
   it("caps window buffer at five messages", () => {

--- a/src/openclaw-plugin/mid-session-recall.test.ts
+++ b/src/openclaw-plugin/mid-session-recall.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildQuery,
+  classifyMessage,
+  clearMidSessionStates,
+  formatMidSessionRecall,
+  getMidSessionState,
+  shouldRecall,
+} from "./mid-session-recall.js";
+
+describe("classifyMessage", () => {
+  it.each([
+    { input: "yes", expected: "trivial" },
+    { input: "do it", expected: "trivial" },
+    { input: "what do you think?", expected: "normal" },
+    { input: "How's Duke doing?", expected: "complex" },
+    { input: "Can you check PR #312?", expected: "complex" },
+    { input: "yeah put it in the web ui", expected: "normal" },
+    { input: "What did we decide about the extraction pipeline?", expected: "complex" },
+    { input: "fix the bug", expected: "trivial" },
+    { input: "Jim mentioned something about the Tesla last week", expected: "complex" },
+    { input: "send Kevin a message", expected: "complex" },
+    { input: "lgtm ship it", expected: "trivial" },
+    { input: "How does consolidate handle crashes?", expected: "normal" },
+    { input: "1", expected: "trivial" },
+    {
+      input: "can you remind me what agenr-ai/agenr's default branch is?",
+      expected: "complex",
+    },
+    { input: "nice", expected: "trivial" },
+    { input: "Tell me about Ava", expected: "complex" },
+  ])("$input -> $expected", ({ input, expected }) => {
+    expect(classifyMessage(input)).toBe(expected);
+  });
+});
+
+describe("buildQuery", () => {
+  it("returns a single meaningful message as-is", () => {
+    expect(buildQuery(["Need extraction pipeline context"])).toBe("Need extraction pipeline context");
+  });
+
+  it("filters out stopword-only messages", () => {
+    expect(buildQuery(["yes", "do it", "thanks", "no thanks"])).toBe("");
+  });
+
+  it("keeps the last two messages in full and compresses older messages", () => {
+    const first = "Working on extraction pipeline reliability improvements";
+    const second = "Investigated agenr-ai/agenr state handling";
+    const third = "Need to fix PR #312 merge conflict handling";
+    const fourth = "Tell me about Kevin's notes on consolidation";
+
+    const query = buildQuery([first, second, third, fourth]);
+    expect(query).toContain(third);
+    expect(query).toContain(fourth);
+    expect(query).toContain("Working");
+    expect(query).toContain("Investigated");
+    expect(query).not.toContain(second);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(buildQuery([])).toBe("");
+  });
+});
+
+describe("shouldRecall", () => {
+  it("returns false for query with fewer than three tokens", () => {
+    expect(shouldRecall("one two", null, 0.85)).toBe(false);
+  });
+
+  it("returns false when Jaccard similarity exceeds threshold", () => {
+    const query = "tell me about ava and recall status";
+    const lastQuery = "tell me about ava recall status";
+    expect(shouldRecall(query, lastQuery, 0.7)).toBe(false);
+  });
+
+  it("returns true when queries are different enough", () => {
+    const query = "analyze consolidation cluster verification rules";
+    const lastQuery = "tell me about ava recall status";
+    expect(shouldRecall(query, lastQuery, 0.85)).toBe(true);
+  });
+
+  it("returns true when lastQuery is null", () => {
+    expect(shouldRecall("analyze consolidation cluster verification", null, 0.85)).toBe(true);
+  });
+});
+
+describe("mid-session state", () => {
+  beforeEach(() => {
+    clearMidSessionStates();
+  });
+
+  it("creates a new state on first call", () => {
+    const state = getMidSessionState("session-a");
+    expect(state.turnCount).toBe(0);
+    expect(state.lastRecallQuery).toBeNull();
+    expect(state.recentMessages).toEqual([]);
+    expect(state.recalledIds.size).toBe(0);
+  });
+
+  it("returns the same state object for the same key", () => {
+    const stateA = getMidSessionState("session-a");
+    stateA.turnCount = 3;
+    const stateB = getMidSessionState("session-a");
+    expect(stateB).toBe(stateA);
+    expect(stateB.turnCount).toBe(3);
+  });
+
+  it("clears all state entries", () => {
+    const stateA = getMidSessionState("session-a");
+    const stateB = getMidSessionState("session-b");
+    stateA.turnCount = 1;
+    stateB.turnCount = 2;
+
+    clearMidSessionStates();
+
+    const stateANext = getMidSessionState("session-a");
+    const stateBNext = getMidSessionState("session-b");
+    expect(stateANext).not.toBe(stateA);
+    expect(stateBNext).not.toBe(stateB);
+    expect(stateANext.turnCount).toBe(0);
+    expect(stateBNext.turnCount).toBe(0);
+  });
+
+  it("caps window buffer at five messages", () => {
+    const state = getMidSessionState("session-window");
+    for (let index = 1; index <= 7; index += 1) {
+      state.recentMessages.push(`message-${index}`);
+    }
+    expect(state.recentMessages).toHaveLength(5);
+    expect(state.recentMessages[0]).toBe("message-3");
+    expect(state.recentMessages[4]).toBe("message-7");
+  });
+
+  it("truncates buffered messages to 200 chars", () => {
+    const state = getMidSessionState("session-truncate");
+    state.recentMessages.push("x".repeat(240));
+    expect(state.recentMessages).toHaveLength(1);
+    expect(state.recentMessages[0]).toHaveLength(200);
+  });
+});
+
+describe("formatMidSessionRecall", () => {
+  it("returns undefined for empty input", () => {
+    expect(formatMidSessionRecall([])).toBeUndefined();
+  });
+
+  it("formats recalled rows under a recalled context heading", () => {
+    const markdown = formatMidSessionRecall([
+      {
+        entry: {
+          subject: "Ava",
+          content: "Maintains the release checklist.",
+        },
+      },
+    ]);
+    expect(markdown).toContain("## Recalled context");
+    expect(markdown).toContain("- [Ava] Maintains the release checklist.");
+  });
+});

--- a/src/openclaw-plugin/mid-session-recall.test.ts
+++ b/src/openclaw-plugin/mid-session-recall.test.ts
@@ -12,6 +12,10 @@ import {
 describe("classifyMessage", () => {
   it.each([
     { input: "yes", expected: "trivial" },
+    { input: "ok", expected: "trivial" },
+    { input: "Okay.", expected: "trivial" },
+    { input: "thanks!", expected: "trivial" },
+    { input: "sure.", expected: "trivial" },
     { input: "do it", expected: "trivial" },
     { input: "what do you think?", expected: "normal" },
     { input: "How's Duke doing?", expected: "complex" },

--- a/src/openclaw-plugin/mid-session-recall.test.ts
+++ b/src/openclaw-plugin/mid-session-recall.test.ts
@@ -63,8 +63,8 @@ describe("buildQuery", () => {
 });
 
 describe("shouldRecall", () => {
-  it("returns false for query with fewer than three tokens", () => {
-    expect(shouldRecall("one two", null, 0.85)).toBe(false);
+  it("returns false for single-token queries", () => {
+    expect(shouldRecall("one", null, 0.85)).toBe(false);
   });
 
   it("returns false when Jaccard similarity exceeds threshold", () => {
@@ -82,6 +82,10 @@ describe("shouldRecall", () => {
   it("returns true when lastQuery is null", () => {
     expect(shouldRecall("analyze consolidation cluster verification", null, 0.85)).toBe(true);
   });
+
+  it("returns true for two-token entity queries", () => {
+    expect(shouldRecall("check Tesla", null, 0.85)).toBe(true);
+  });
 });
 
 describe("mid-session state", () => {
@@ -93,7 +97,7 @@ describe("mid-session state", () => {
     const state = getMidSessionState("session-a");
     expect(state.turnCount).toBe(0);
     expect(state.lastRecallQuery).toBeNull();
-    expect(state.recentMessages).toEqual([]);
+    expect(state.recentMessages.toArray()).toEqual([]);
     expect(state.recalledIds.size).toBe(0);
   });
 
@@ -126,16 +130,17 @@ describe("mid-session state", () => {
     for (let index = 1; index <= 7; index += 1) {
       state.recentMessages.push(`message-${index}`);
     }
-    expect(state.recentMessages).toHaveLength(5);
-    expect(state.recentMessages[0]).toBe("message-3");
-    expect(state.recentMessages[4]).toBe("message-7");
+    expect(state.recentMessages.length).toBe(5);
+    const values = state.recentMessages.toArray();
+    expect(values[0]).toBe("message-3");
+    expect(values[4]).toBe("message-7");
   });
 
   it("truncates buffered messages to 200 chars", () => {
     const state = getMidSessionState("session-truncate");
     state.recentMessages.push("x".repeat(240));
-    expect(state.recentMessages).toHaveLength(1);
-    expect(state.recentMessages[0]).toHaveLength(200);
+    expect(state.recentMessages.length).toBe(1);
+    expect(state.recentMessages.slice(0, 1)[0]).toHaveLength(200);
   });
 });
 

--- a/src/openclaw-plugin/mid-session-recall.ts
+++ b/src/openclaw-plugin/mid-session-recall.ts
@@ -1,0 +1,419 @@
+type MessageClassification = "trivial" | "normal" | "complex";
+
+const TRIVIAL_EXACT = new Set([
+  "yes",
+  "no",
+  "yep",
+  "nope",
+  "yeah",
+  "nah",
+  "ok",
+  "okay",
+  "k",
+  "sure",
+  "thanks",
+  "ty",
+  "thx",
+  "nice",
+  "cool",
+  "great",
+  "awesome",
+  "lol",
+  "haha",
+  "wow",
+  "hmm",
+  "hm",
+  "ah",
+  "oh",
+  "yikes",
+  "done",
+  "agreed",
+  "correct",
+  "right",
+  "true",
+  "false",
+  "lgtm",
+  "sgtm",
+  "wfm",
+  "ack",
+  "np",
+  "nvm",
+]);
+
+const TRIVIAL_PHRASES =
+  /^(?:do it|go ahead|ship it|sounds good|got it|makes sense|go for it|lgtm ship it|yes please|no thanks|that works|perfect thanks|will do)$/i;
+const TEMPORAL_PATTERNS =
+  /\b(?:remember|remind|forgot|last time|last (?:week|month|year|night|session)|before|previously|earlier|the other day|a while ago|we decided|did we decide|have we|were we|you said|you told me|you mentioned|we discussed|we talked about|what was|who is|who was|who's|when did|how did|what happened)\b/i;
+const EXPLICIT_RECALL =
+  /\b(?:tell me about|what do you know about|what do we know about|can you recall|do you remember|remind me|fill me in on|catch me up|what's the (?:deal|story|status) with)\b/i;
+
+const ENTITY_PATTERNS = [
+  /\b[A-Z][a-z]{2,}\b/,
+  /\b(?:PR|issue|ticket|bug)\s*#?\d+\b/i,
+  /\b[a-z][\w-]*\/[a-z][\w-]*/,
+  /\b(?:https?:\/\/)\S+/,
+  /\b[A-Z]{2,}\b/,
+];
+
+const FALSE_POSITIVE_NOUNS = new Set([
+  "How",
+  "What",
+  "When",
+  "Where",
+  "Why",
+  "Who",
+  "Which",
+  "Can",
+  "Could",
+  "Would",
+  "Should",
+  "Will",
+  "Does",
+  "Did",
+  "The",
+  "This",
+  "That",
+  "There",
+  "These",
+  "Those",
+  "Have",
+  "Has",
+  "Had",
+  "Are",
+  "Were",
+  "Was",
+  "Not",
+  "But",
+  "And",
+  "Also",
+  "Just",
+  "Let",
+  "Hey",
+  "Hello",
+  "Sure",
+  "Yes",
+  "Yeah",
+  "Thanks",
+  "So",
+  "Now",
+  "Well",
+  "Still",
+  "Yet",
+  "Here",
+  "If",
+  "Or",
+  "For",
+  "From",
+  "Into",
+  "With",
+  "About",
+  "After",
+  "Before",
+  "Your",
+  "Our",
+  "My",
+  "His",
+  "Her",
+  "Its",
+  "Their",
+  "Some",
+  "Any",
+  "All",
+  "Each",
+  "Every",
+  "Most",
+  "Many",
+  "Much",
+  "Very",
+  "Too",
+  "More",
+]);
+
+const MAX_RECENT_MESSAGES = 5;
+const MAX_BUFFERED_MESSAGE_CHARS = 200;
+
+function normalizeBufferedMessage(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.length > MAX_BUFFERED_MESSAGE_CHARS) {
+    return trimmed.slice(0, MAX_BUFFERED_MESSAGE_CHARS);
+  }
+  return trimmed;
+}
+
+class RecentMessagesBuffer extends Array<string> {
+  push(...items: string[]): number {
+    for (const item of items) {
+      const normalized = normalizeBufferedMessage(item);
+      if (!normalized) {
+        continue;
+      }
+      super.push(normalized);
+    }
+    while (this.length > MAX_RECENT_MESSAGES) {
+      super.shift();
+    }
+    return this.length;
+  }
+}
+
+function toGlobalPattern(pattern: RegExp): RegExp {
+  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  return new RegExp(pattern.source, flags);
+}
+
+function normalizeToken(token: string): string {
+  return token.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9]+$/g, "");
+}
+
+function collectEntities(text: string): Set<string> {
+  const entities = new Set<string>();
+
+  for (const pattern of ENTITY_PATTERNS) {
+    const matcher = toGlobalPattern(pattern);
+    const matches = text.match(matcher);
+    if (!matches) {
+      continue;
+    }
+    for (const rawMatch of matches) {
+      const normalized = normalizeToken(rawMatch);
+      if (!normalized) {
+        continue;
+      }
+      if (FALSE_POSITIVE_NOUNS.has(normalized)) {
+        continue;
+      }
+      entities.add(normalized.toLowerCase());
+    }
+  }
+
+  return entities;
+}
+
+function containsEntity(text: string): boolean {
+  return collectEntities(text).size > 0;
+}
+
+function countEntities(text: string): number {
+  return collectEntities(text).size;
+}
+
+function isSingleEmoji(text: string): boolean {
+  return /^[\p{Emoji}\s]+$/u.test(text);
+}
+
+export function classifyMessage(text: string): MessageClassification {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "trivial";
+  }
+
+  const words = trimmed.split(/\s+/).filter(Boolean);
+  const wordCount = words.length;
+  const lower = trimmed.toLowerCase();
+
+  if (wordCount === 1) {
+    if (TRIVIAL_EXACT.has(lower)) {
+      return "trivial";
+    }
+    if (/^\d+$/.test(trimmed)) {
+      return "trivial";
+    }
+    if (isSingleEmoji(trimmed)) {
+      return "trivial";
+    }
+    if (containsEntity(trimmed)) {
+      return "normal";
+    }
+    return "trivial";
+  }
+
+  if (TRIVIAL_PHRASES.test(trimmed)) {
+    return "trivial";
+  }
+  if (wordCount <= 3 && !containsEntity(trimmed)) {
+    return "trivial";
+  }
+
+  if (EXPLICIT_RECALL.test(trimmed)) {
+    return "complex";
+  }
+  if (TEMPORAL_PATTERNS.test(trimmed)) {
+    return "complex";
+  }
+  if (wordCount <= 6 && containsEntity(trimmed)) {
+    return "complex";
+  }
+  if (countEntities(trimmed) >= 2) {
+    return "complex";
+  }
+
+  return "normal";
+}
+
+function isStopWordMessage(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+  if (TRIVIAL_EXACT.has(normalized)) {
+    return true;
+  }
+  return TRIVIAL_PHRASES.test(normalized);
+}
+
+function extractKeyTerms(text: string): string {
+  const tokens = text.split(/\s+/).map(normalizeToken).filter(Boolean);
+  const keyTerms = tokens.filter((token) => {
+    if (token.length > 5) {
+      return true;
+    }
+    if (/^[A-Z]/.test(token)) {
+      return true;
+    }
+    return /[-_.]/.test(token) && token.length > 3;
+  });
+  return keyTerms.join(" ");
+}
+
+export function buildQuery(messages: string[]): string {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return "";
+  }
+
+  const meaningful = messages
+    .map(normalizeBufferedMessage)
+    .filter((message) => message.length > 0)
+    .filter((message) => !isStopWordMessage(message));
+
+  if (meaningful.length === 0) {
+    return "";
+  }
+
+  const recentMessages = meaningful.slice(-2).join(" ");
+  const olderMessages = meaningful
+    .slice(0, -2)
+    .map((message) => extractKeyTerms(message))
+    .filter((value) => value.length > 0)
+    .join(" ");
+
+  return `${olderMessages} ${recentMessages}`.trim();
+}
+
+function tokenizeForSimilarity(text: string): Set<string> {
+  const tokens = text
+    .toLowerCase()
+    .split(/\s+/)
+    .map((token) => token.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ""))
+    .filter((token) => token.length > 0);
+  return new Set(tokens);
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  const union = new Set<string>([...a, ...b]);
+  if (union.size === 0) {
+    return 1;
+  }
+  let intersectionCount = 0;
+  for (const token of a) {
+    if (b.has(token)) {
+      intersectionCount += 1;
+    }
+  }
+  return intersectionCount / union.size;
+}
+
+export function shouldRecall(query: string, lastQuery: string | null, threshold: number): boolean {
+  const queryTokens = tokenizeForSimilarity(query);
+  if (queryTokens.size < 3) {
+    return false;
+  }
+  if (!lastQuery) {
+    return true;
+  }
+  const lastQueryTokens = tokenizeForSimilarity(lastQuery);
+  return jaccardSimilarity(queryTokens, lastQueryTokens) <= threshold;
+}
+
+export interface MidSessionState {
+  recentMessages: string[];
+  lastRecallQuery: string | null;
+  recalledIds: Set<string>;
+  turnCount: number;
+}
+
+const midSessionStates = new Map<string, MidSessionState>();
+
+export function getMidSessionState(key: string): MidSessionState {
+  const normalizedKey = key.trim();
+  if (normalizedKey.length === 0) {
+    return {
+      recentMessages: new RecentMessagesBuffer(),
+      lastRecallQuery: null,
+      recalledIds: new Set<string>(),
+      turnCount: 0,
+    };
+  }
+
+  const existing = midSessionStates.get(normalizedKey);
+  if (existing) {
+    return existing;
+  }
+
+  const nextState: MidSessionState = {
+    recentMessages: new RecentMessagesBuffer(),
+    lastRecallQuery: null,
+    recalledIds: new Set<string>(),
+    turnCount: 0,
+  };
+  midSessionStates.set(normalizedKey, nextState);
+  return nextState;
+}
+
+export function clearMidSessionStates(): void {
+  midSessionStates.clear();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+type MidSessionRecallRow = {
+  subject: string;
+  content: string;
+};
+
+function toRecallRow(item: unknown): MidSessionRecallRow | null {
+  if (!isRecord(item)) {
+    return null;
+  }
+  const rawEntry = item["entry"];
+  if (!isRecord(rawEntry)) {
+    return null;
+  }
+  const subject = typeof rawEntry["subject"] === "string" ? rawEntry["subject"].trim() : "";
+  const content = typeof rawEntry["content"] === "string" ? rawEntry["content"].trim() : "";
+  if (!subject || !content) {
+    return null;
+  }
+  return { subject, content };
+}
+
+export function formatMidSessionRecall(results: unknown[]): string | undefined {
+  if (!Array.isArray(results) || results.length === 0) {
+    return undefined;
+  }
+
+  const rows = results.map((item) => toRecallRow(item)).filter((row): row is MidSessionRecallRow => row !== null);
+  if (rows.length === 0) {
+    return undefined;
+  }
+
+  const lines: string[] = ["## Recalled context", ""];
+  for (const row of rows) {
+    lines.push(`- [${row.subject}] ${row.content}`);
+  }
+  return lines.join("\n");
+}

--- a/src/openclaw-plugin/mid-session-recall.ts
+++ b/src/openclaw-plugin/mid-session-recall.ts
@@ -393,8 +393,12 @@ export function clearMidSessionStates(): void {
   midSessionStates.clear();
 }
 
+export function clearMidSessionState(key: string): void {
+  midSessionStates.delete(key.trim());
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 type MidSessionRecallRow = {

--- a/src/openclaw-plugin/mid-session-recall.ts
+++ b/src/openclaw-plugin/mid-session-recall.ts
@@ -227,12 +227,16 @@ export function classifyMessage(text: string): MessageClassification {
     return "trivial";
   }
 
-  const words = trimmed.split(/\s+/).filter(Boolean);
+  const words = trimmed
+    .split(/\s+/)
+    .map((word) => word.replace(/^[.!?,;:]+|[.!?,;:]+$/g, ""))
+    .filter(Boolean);
   const wordCount = words.length;
   const lower = trimmed.toLowerCase();
+  const stripped = lower.replace(/[.!?,;:]+$/g, "");
 
   if (wordCount === 1) {
-    if (TRIVIAL_EXACT.has(lower)) {
+    if (TRIVIAL_EXACT.has(stripped)) {
       return "trivial";
     }
     if (/^\d+$/.test(trimmed)) {
@@ -247,7 +251,7 @@ export function classifyMessage(text: string): MessageClassification {
     return "trivial";
   }
 
-  if (TRIVIAL_PHRASES.test(trimmed)) {
+  if (TRIVIAL_PHRASES.test(stripped)) {
     return "trivial";
   }
   if (wordCount <= 3 && !containsEntity(trimmed)) {
@@ -271,7 +275,7 @@ export function classifyMessage(text: string): MessageClassification {
 }
 
 function isStopWordMessage(text: string): boolean {
-  const normalized = text.trim().toLowerCase();
+  const normalized = text.trim().toLowerCase().replace(/[.!?,;:]+$/g, "");
   if (!normalized) {
     return true;
   }

--- a/src/openclaw-plugin/recall.test.ts
+++ b/src/openclaw-plugin/recall.test.ts
@@ -123,6 +123,28 @@ describe("runRecall query args", () => {
       "status update",
     ]);
   });
+
+  it("passes --limit for non-browse semantic recall used by mid-session recall", async () => {
+    let capturedArgs: string[] = [];
+    spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      return createMockChild(JSON.stringify({ query: "Tell me about Ava", results: [] }));
+    });
+
+    await runRecall("/path/to/agenr", 1234, undefined, "Tell me about Ava", { limit: 8 });
+
+    expect(capturedArgs).toEqual([
+      "recall",
+      "--context",
+      "session-start",
+      "--budget",
+      "1234",
+      "--json",
+      "--limit",
+      "8",
+      "Tell me about Ava",
+    ]);
+  });
 });
 
 describe("runRecall browse mode args", () => {

--- a/src/openclaw-plugin/recall.test.ts
+++ b/src/openclaw-plugin/recall.test.ts
@@ -98,6 +98,31 @@ describe("runRecall query args", () => {
     expect(positionalQuery.length).toBe(500);
     expect(positionalQuery).toBe("x".repeat(500));
   });
+
+  it("passes --limit for session-start context when provided", async () => {
+    let capturedArgs: string[] = [];
+    spawnMock.mockImplementationOnce((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      return createMockChild(JSON.stringify({ query: "session-start", results: [] }));
+    });
+
+    await runRecall("/path/to/agenr", 1234, undefined, "status update", {
+      context: "session-start",
+      limit: 8,
+    });
+
+    expect(capturedArgs).toEqual([
+      "recall",
+      "--context",
+      "session-start",
+      "--budget",
+      "1234",
+      "--json",
+      "--limit",
+      "8",
+      "status update",
+    ]);
+  });
 });
 
 describe("runRecall browse mode args", () => {

--- a/src/openclaw-plugin/recall.ts
+++ b/src/openclaw-plugin/recall.ts
@@ -74,7 +74,7 @@ export async function runRecall(
     const args = isBrowse
       ? ["recall", "--browse", "--since", options?.since ?? "1d", "--json"]
       : ["recall", "--context", "session-start", "--budget", String(budget), "--json"];
-    if (isBrowse && options?.limit !== undefined) {
+    if (options?.limit !== undefined) {
       args.push("--limit", String(options.limit));
     }
     if (project) {

--- a/src/openclaw-plugin/session-handoff.test.ts
+++ b/src/openclaw-plugin/session-handoff.test.ts
@@ -704,7 +704,7 @@ describe("summarizeSessionForHandoff", () => {
       },
     });
     const logger = makeLogger();
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const dir = await makeTempDir("agenr-handoff-summary-");
     const currentSessionFile = path.join(dir, "current-uuid.jsonl");
     await fs.writeFile(currentSessionFile, "", "utf8");
@@ -716,12 +716,15 @@ describe("summarizeSessionForHandoff", () => {
       logger,
       false,
       makeStreamSimple({ message: makeAssistantMessage("summary text") }),
+      false,
+      undefined,
+      true,
     );
 
     expect(summary).toBe("summary text");
-    expect(consoleLogSpy).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringMatching(
-        /^\[agenr\] before_reset: sending to LLM model=gpt-4\.1-nano chars=\d+ msgs=5$/,
+        /^\[before_reset\] sending to LLM model=gpt-4\.1-nano chars=\d+ msgs=5$/,
       ),
     );
   });
@@ -739,7 +742,7 @@ describe("summarizeSessionForHandoff", () => {
         source: "env:OPENAI_API_KEY",
       },
     });
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const dir = await makeTempDir("agenr-handoff-summary-");
     const currentSessionFile = path.join(dir, "current-uuid.jsonl");
     await fs.writeFile(currentSessionFile, "", "utf8");
@@ -751,12 +754,15 @@ describe("summarizeSessionForHandoff", () => {
       makeLogger(),
       false,
       makeStreamSimple({ message: makeAssistantMessage("summary text") }),
+      false,
+      undefined,
+      true,
     );
 
     expect(summary).toBe("summary text");
-    const sendingLog = consoleLogSpy.mock.calls
+    const sendingLog = consoleErrorSpy.mock.calls
       .map((call) => (typeof call[0] === "string" ? call[0] : ""))
-      .find((line) => line.includes("[agenr] before_reset: sending to LLM"));
+      .find((line) => line.includes("[before_reset] sending to LLM"));
     expect(sendingLog).toContain("model=gpt-4.1-nano-test");
     expect(sendingLog).not.toContain("[object Object]");
   });
@@ -1189,7 +1195,7 @@ describe("summarizeSessionForHandoff", () => {
       throw new Error("Not configured. Run `agenr setup`.");
     });
     const logger = makeLogger();
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const dir = await makeTempDir("agenr-handoff-summary-");
     const currentSessionFile = path.join(dir, "current-uuid.jsonl");
     await fs.writeFile(currentSessionFile, "", "utf8");
@@ -1201,10 +1207,15 @@ describe("summarizeSessionForHandoff", () => {
       logger,
       false,
       makeStreamSimple({ message: makeAssistantMessage("unused") }),
+      false,
+      undefined,
+      true,
     );
 
     expect(summary).toBeNull();
-    expect(consoleLogSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[before_reset] skipping LLM summary - reason: LLM client init failed",
+    );
   });
 
   it("returns null and logs when credentials.apiKey is missing", async () => {
@@ -1218,7 +1229,7 @@ describe("summarizeSessionForHandoff", () => {
       credentials: {} as { apiKey?: string },
     });
     const logger = makeLogger();
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const dir = await makeTempDir("agenr-handoff-summary-");
     const currentSessionFile = path.join(dir, "current-uuid.jsonl");
     await fs.writeFile(currentSessionFile, "", "utf8");
@@ -1230,11 +1241,14 @@ describe("summarizeSessionForHandoff", () => {
       logger,
       false,
       makeStreamSimple({ message: makeAssistantMessage("unused") }),
+      false,
+      undefined,
+      true,
     );
 
     expect(summary).toBeNull();
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      "[agenr] before_reset: no apiKey available, skipping LLM summary",
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[before_reset] no apiKey available, skipping LLM summary",
     );
   });
 });

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -117,6 +117,8 @@ export type AgenrPluginConfig = {
   project?: string;
   /** Set to false to disable memory injection without removing the plugin */
   enabled?: boolean;
+  /** Enable debug logging to stderr (default: false) */
+  debug?: boolean;
   /** Path to agenr DB. Defaults to AGENR_DB_PATH env or ~/.agenr/knowledge.db */
   dbPath?: string;
   /** Handoff summarizer options */

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -37,6 +37,17 @@ export type BeforeResetEvent = {
   [key: string]: unknown;
 };
 
+export type MidSessionRecallConfig = {
+  /** Set to false to disable mid-session recall (default: true) */
+  enabled?: boolean;
+  /** Max entries to fetch for normal messages (default: 5) */
+  normalLimit?: number;
+  /** Max entries to fetch for complex messages (default: 8) */
+  complexLimit?: number;
+  /** Skip recall when query Jaccard similarity exceeds this threshold (default: 0.85) */
+  querySimilarityThreshold?: number;
+};
+
 export type PluginLogger = {
   debug?: (message: string) => void;
   info?: (message: string) => void;
@@ -119,6 +130,8 @@ export type AgenrPluginConfig = {
   };
   /** Set to false to disable mid-session signals (default: true) */
   signalsEnabled?: boolean;
+  /** Mid-session recall tuning */
+  midSessionRecall?: MidSessionRecallConfig;
   /** Minimum importance for signal entries (default: 8) */
   signalMinImportance?: number;
   /** Max entries per signal notification (default: 3) */

--- a/tests/commands/recall.test.ts
+++ b/tests/commands/recall.test.ts
@@ -221,6 +221,66 @@ describe("recall command", () => {
     expect(parsed.results.some((item) => item.category === "core")).toBe(true);
   });
 
+  it("caps session-start output by --limit", async () => {
+    const freshIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const recallFn = vi.fn(async (_db: unknown, query: { expiry?: string | string[] }) => {
+      if (query.expiry === "core") {
+        return [
+          makeResult({
+            entry: makeEntry({
+              id: "core-1",
+              expiry: "core",
+              created_at: freshIso,
+              updated_at: freshIso,
+            }),
+          }),
+          makeResult({
+            entry: makeEntry({
+              id: "core-2",
+              expiry: "core",
+              created_at: freshIso,
+              updated_at: freshIso,
+            }),
+          }),
+          makeResult({
+            entry: makeEntry({
+              id: "core-3",
+              expiry: "core",
+              created_at: freshIso,
+              updated_at: freshIso,
+            }),
+          }),
+        ];
+      }
+
+      return [
+        makeResult({
+          entry: makeEntry({
+            id: "todo-1",
+            type: "todo",
+            expiry: "temporary",
+            created_at: freshIso,
+            updated_at: freshIso,
+          }),
+        }),
+        makeResult({
+          entry: makeEntry({
+            id: "todo-2",
+            type: "todo",
+            expiry: "temporary",
+            created_at: freshIso,
+            updated_at: freshIso,
+          }),
+        }),
+      ];
+    });
+
+    const deps = makeDeps({ recallFn });
+    const output = await runRecallCommand(undefined, { context: "session-start", json: true, limit: 2 }, deps);
+
+    expect(output.payload.results).toHaveLength(2);
+  });
+
   it("shapes topic context text as [topic: value] <query>", async () => {
     const recallFn = vi.fn(async () => []);
     const deps = makeDeps({ recallFn });

--- a/tests/db/contradiction.test.ts
+++ b/tests/db/contradiction.test.ts
@@ -361,7 +361,7 @@ describe("contradiction", () => {
   });
 
   it("returns unrelated with confidence 0 on LLM error", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(runSimpleStream).mockRejectedValueOnce(new Error("LLM failure"));
 
     const result = await contradictionModule.classifyConflict(
@@ -375,11 +375,11 @@ describe("contradiction", () => {
       confidence: 0,
       explanation: "LLM error",
     });
-    expect(warnSpy).toHaveBeenCalledWith("[contradiction] LLM judge call failed: LLM failure");
+    expect(errorSpy).toHaveBeenCalledWith("[contradiction] LLM judge call failed: LLM failure");
   });
 
   it("returns unrelated with confidence 0 on missing tool call", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(runSimpleStream).mockResolvedValueOnce(makeTextMessage());
 
     const result = await contradictionModule.classifyConflict(
@@ -393,11 +393,11 @@ describe("contradiction", () => {
       confidence: 0,
       explanation: "LLM error",
     });
-    expect(warnSpy).toHaveBeenCalledWith("[contradiction] LLM judge returned unparseable response");
+    expect(errorSpy).toHaveBeenCalledWith("[contradiction] LLM judge returned unparseable response");
   });
 
   it("returns unrelated with confidence 0 on LLM stop error response", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(runSimpleStream).mockResolvedValueOnce({
       ...makeTextMessage(),
       stopReason: "error",
@@ -415,7 +415,7 @@ describe("contradiction", () => {
       confidence: 0,
       explanation: "LLM error",
     });
-    expect(warnSpy).toHaveBeenCalledWith("[contradiction] LLM judge error: provider timeout");
+    expect(errorSpy).toHaveBeenCalledWith("[contradiction] LLM judge error: provider timeout");
   });
 
   it("finds candidates via subject index when subjectKey is set and still runs embedding lookup", async () => {

--- a/tests/db/store.test.ts
+++ b/tests/db/store.test.ts
@@ -980,7 +980,7 @@ describe("db store pipeline", () => {
     const client = makeClient();
     await initDb(client);
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const getDistinctEntitiesSpy = vi
       .spyOn(claimExtractionModule, "getDistinctEntities")
       .mockRejectedValue(new Error("database unavailable"));
@@ -1008,7 +1008,7 @@ describe("db store pipeline", () => {
     expect(getDistinctEntitiesSpy).toHaveBeenCalledTimes(1);
     expect(extractClaimSpy).toHaveBeenCalledTimes(1);
     expect(extractClaimSpy.mock.calls[0]?.[4]).toMatchObject({ entityHints: [] });
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("[store] entity hints lookup failed, proceeding without hints: database unavailable"),
     );
 


### PR DESCRIPTION
## Summary

Ships three changes as v0.9.18:

### #314 - Subsequent-turn auto-recall
OpenClaw plugin now runs heuristic-gated memory recall on every non-trivial subsequent turn. Messages are classified as trivial (skip), normal (5 results), or complex (8 results) based on entity detection, temporal patterns, and explicit recall phrases. Queries built from a sliding window of recent messages with Jaccard similarity dedup. Recalled entries are deduplicated against session-start and prior mid-session context. Configurable via `midSessionRecall` plugin config.

### #315 - MCP stdout corruption fix
Routed all diagnostic logging in `db/store.ts` and `db/contradiction.ts` from `console.log`/`console.warn` to `console.error` (stderr). Prevents corruption of MCP JSON-RPC framing on stdout.

### #316 - Remove agenr_store from MCP server
Removed `agenr_store` tool and `store` option from `agenr_extract`. Coding agents should rely on Watcher for knowledge ingest from session transcripts. Simpler MCP surface, fewer failure modes.

Closes #314, closes #315, closes #316.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mid-session recall: message classification, deduped recalled context, configurable limits and similarity tuning, formatted recall injected into prompts.

* **Bug Fixes**
  * Diagnostic/debug output routed to stderr to keep stdout clean.

* **Changed**
  * Server no longer stores extracted entries; extraction returns entries only and prompts warn about no-store.
  * Plugin config adds debug and midSessionRecall options.
  * Recall now respects a provided limit in all contexts.

* **Tests**
  * Extensive tests added for mid-session recall, limits, state, and extraction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->