### PR TITLE
feat(openclaw): store nudging for missed agenr_store calls (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.19 (2026-02-28)
+
+### Features
+- OpenClaw plugin: store nudging - injects a system nudge when the
+  agent has not called agenr_store in 8+ turns (configurable via
+  storeNudge plugin config). Caps at 3 nudges per session. (#290)
+
 ## 0.9.18 (2026-02-28)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features
 - OpenClaw plugin: store nudging - injects a system nudge when the
   agent has not called agenr_store in 8+ turns (configurable via
-  storeNudge plugin config). Caps at 3 nudges per session. (#290)
+  storeNudge plugin config). Nudges are spaced by the threshold
+  interval, capped at 3 per session. (#290)
 
 ## 0.9.18 (2026-02-28)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -1530,13 +1530,12 @@ const plugin = {
               if (gap >= nudgeConfig.threshold && state.nudgeCount < nudgeConfig.maxPerSession) {
                 storeNudge = "[MEMORY CHECK] You have not stored any knowledge recently. Review the conversation for decisions, preferences, lessons, or facts worth remembering.";
                 state.nudgeCount += 1;
+                state.lastStoreTurn = state.turnCount;
                 debugLog(debug, "store-nudge", `injecting nudge #${state.nudgeCount}`);
               } else {
                 const reason = gap < nudgeConfig.threshold
                   ? "gap_below_threshold"
-                  : state.nudgeCount >= nudgeConfig.maxPerSession
-                  ? "max_reached"
-                  : "disabled";
+                  : "max_reached";
                 debugLog(debug, "store-nudge", `skipped reason=${reason}`);
               }
             } else {

--- a/src/openclaw-plugin/mid-session-recall.test.ts
+++ b/src/openclaw-plugin/mid-session-recall.test.ts
@@ -6,6 +6,7 @@ import {
   clearMidSessionStates,
   formatMidSessionRecall,
   getMidSessionState,
+  markStoreCall,
   shouldRecall,
 } from "./mid-session-recall.js";
 
@@ -104,6 +105,8 @@ describe("mid-session state", () => {
     expect(state.lastRecallQuery).toBeNull();
     expect(state.recentMessages.toArray()).toEqual([]);
     expect(state.recalledIds.size).toBe(0);
+    expect(state.lastStoreTurn).toBe(0);
+    expect(state.nudgeCount).toBe(0);
   });
 
   it("returns the same state object for the same key", () => {
@@ -162,6 +165,27 @@ describe("mid-session state", () => {
     state.recentMessages.push("x".repeat(240));
     expect(state.recentMessages.length).toBe(1);
     expect(state.recentMessages.slice(0, 1)[0]).toHaveLength(200);
+  });
+
+  it("markStoreCall updates lastStoreTurn to current turnCount", () => {
+    const state = getMidSessionState("session-store");
+    state.turnCount = 6;
+
+    markStoreCall("session-store");
+
+    expect(state.lastStoreTurn).toBe(6);
+  });
+
+  it("markStoreCall with empty key is a no-op", () => {
+    expect(() => markStoreCall("")).not.toThrow();
+  });
+
+  it("markStoreCall with a new key creates state and sets lastStoreTurn to zero", () => {
+    markStoreCall("session-new");
+
+    const state = getMidSessionState("session-new");
+    expect(state.turnCount).toBe(0);
+    expect(state.lastStoreTurn).toBe(0);
   });
 });
 

--- a/src/openclaw-plugin/mid-session-recall.ts
+++ b/src/openclaw-plugin/mid-session-recall.ts
@@ -363,6 +363,8 @@ export interface MidSessionState {
   lastRecallQuery: string | null;
   recalledIds: Set<string>;
   turnCount: number;
+  lastStoreTurn: number;
+  nudgeCount: number;
 }
 
 const midSessionStates = new Map<string, MidSessionState>();
@@ -375,6 +377,8 @@ export function getMidSessionState(key: string): MidSessionState {
       lastRecallQuery: null,
       recalledIds: new Set<string>(),
       turnCount: 0,
+      lastStoreTurn: 0,
+      nudgeCount: 0,
     };
   }
 
@@ -388,9 +392,19 @@ export function getMidSessionState(key: string): MidSessionState {
     lastRecallQuery: null,
     recalledIds: new Set<string>(),
     turnCount: 0,
+    lastStoreTurn: 0,
+    nudgeCount: 0,
   };
   midSessionStates.set(normalizedKey, nextState);
   return nextState;
+}
+
+export function markStoreCall(key: string): void {
+  if (typeof key !== "string" || key.trim().length === 0) {
+    return;
+  }
+  const state = getMidSessionState(key);
+  state.lastStoreTurn = state.turnCount;
 }
 
 export function clearMidSessionStates(): void {

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -134,6 +134,14 @@ export type AgenrPluginConfig = {
   signalsEnabled?: boolean;
   /** Mid-session recall tuning */
   midSessionRecall?: MidSessionRecallConfig;
+  storeNudge?: {
+    /** Set to false to disable store nudging (default: true) */
+    enabled?: boolean;
+    /** Turns without agenr_store before nudging (default: 8) */
+    threshold?: number;
+    /** Max nudges per session (default: 3) */
+    maxPerSession?: number;
+  };
   /** Minimum importance for signal entries (default: 8) */
   signalMinImportance?: number;
   /** Max entries per signal notification (default: 3) */


### PR DESCRIPTION
## Summary

Adds turn-gap store nudging to the OpenClaw plugin. When the agent has not called `agenr_store` in N turns (default 8), a system nudge is injected reminding it to review the conversation for knowledge worth storing.

## Key Design Decisions

- **Spaced nudging**: After each nudge, the gap counter resets so the next nudge waits another threshold interval (turns 8, 16, 24 - not 8, 9, 10)
- **Store detection**: Wraps `agenr_store` tool execute via a `sessionRef` closure to track store calls per session (documented single-concurrency assumption)
- **State on MidSessionState**: `lastStoreTurn` and `nudgeCount` live on the existing state object, automatically cleaned up on session reset
- **Config resolver**: `resolveStoreNudgeConfig()` follows the existing `resolveSignalConfig()` pattern
- **Debug logging**: All decision points logged with `store-nudge` tag

## Configuration

```json
{
  "storeNudge": {
    "enabled": true,
    "threshold": 8,
    "maxPerSession": 3
  }
}
```

## Files Changed

- `src/openclaw-plugin/mid-session-recall.ts` - MidSessionState fields + markStoreCall
- `src/openclaw-plugin/types.ts` - storeNudge config type
- `src/openclaw-plugin/index.ts` - nudge check, store wrapper, sessionRef, resolveStoreNudgeConfig
- `src/openclaw-plugin/mid-session-recall.test.ts` - markStoreCall unit tests
- `src/openclaw-plugin/index.test.ts` - nudge injection, spacing, store reset, max cap tests

## Known Limitations

- `agenr_extract` with `store: true` does not reset the nudge counter (rare usage pattern)
- `sessionRef` assumes single-concurrency per plugin instance

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added store nudging: the assistant now injects a gentle reminder to save/store knowledge after a configurable inactivity threshold, with spacing controls and a per-session cap.

* **Tests**
  * Added comprehensive tests covering nudging behavior, session tracking, enabling/disabling via config, and state resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->