### PR TITLE
fix(openclaw): improve mid-session recall query quality (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.9.20 (2026-02-28)
+
+### Bug Fixes
+- OpenClaw plugin: mid-session recall query now uses the raw current
+  message instead of accumulating a sliding window with stop-word
+  stripping. Fixes garbled queries that returned irrelevant context.
+- OpenClaw plugin: tightened message classifier to avoid marking
+  conversational acks as complex. Messages with no entities, temporal
+  patterns, or recall phrases now correctly classify as normal or
+  trivial regardless of length.
+- OpenClaw plugin: expanded trivial phrase list and added word-count
+  gate so low-signal conversational messages skip recall entirely.
+- OpenClaw plugin: recall queries are capped at 200 chars to prevent
+  large data pastes from producing oversized embedding queries. (#323)
+
 ## 0.9.19 (2026-02-28)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -1422,9 +1422,6 @@ const plugin = {
           if (state && config?.midSessionRecall?.enabled !== false) {
             const rawPrompt = typeof event.prompt === "string" ? stripPromptMetadata(event.prompt) : "";
             const userMessage = rawPrompt.trim();
-            if (userMessage) {
-              state.recentMessages.push(userMessage);
-            }
 
             const classification = classifyMessage(userMessage);
             debugLog(
@@ -1433,7 +1430,7 @@ const plugin = {
               `turn=${state.turnCount} classification=${classification} msg="${userMessage.slice(0, 80)}"`,
             );
             if (classification !== "trivial") {
-              const query = buildQuery(state.recentMessages.toArray());
+              const query = buildQuery(userMessage);
               const threshold = resolveMidSessionSimilarityThreshold(
                 config?.midSessionRecall?.querySimilarityThreshold,
               );


### PR DESCRIPTION
## Summary

Fixes four related bugs in mid-session recall discovered via production debug logging (v0.9.19):

1. **Query accumulation removed** - `buildQuery()` now takes a single message string instead of accumulating a sliding window with stop-word stripping. Eliminates garbled queries like `"What switch topics Like talking I haircut appointment"`.

2. **Classifier tightened** - Messages with no entities, temporal patterns, or explicit recall phrases now correctly classify as `normal` regardless of length. Fixes conversational acks being marked `complex`.

3. **Skip gate added** - Expanded trivial phrases and added a word-count gate (`<= 8 words, no entities, no temporal, no recall, not a question = trivial`). Low-signal messages now skip recall entirely.

4. **Query capped at 200 chars** - Prevents large data pastes from producing oversized embedding queries.

Also removed `"before"` from TEMPORAL_PATTERNS to prevent false positives like "before my haircut".

Closes #323

## Changes
- `src/openclaw-plugin/mid-session-recall.ts` - Core fixes
- `src/openclaw-plugin/mid-session-recall.test.ts` - New test cases
- `src/openclaw-plugin/index.ts` - Updated caller for new `buildQuery` signature
- `CHANGELOG.md` - Added 0.9.20 entry
- `package.json` - Version bump to 0.9.20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved garbled and irrelevant recall queries in active conversations by improving query processing with current message input
  * Enhanced message classification to better distinguish conversational acknowledgments and low-signal messages, preventing false-positive complex classifications
  * Expanded recognized conversational phrases and added word-count thresholds for improved message detection
  * Added 200-character limit on recall queries to optimize performance with large data inputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->