### PR TITLE
fix(openclaw): simplify mid-session recall to two-tier classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.21 (2026-02-28)
+
+### Improvements
+- OpenClaw plugin: simplified mid-session recall from three-tier
+  classification (trivial/normal/complex) to two-tier (trivial/recall).
+  All non-trivial messages now use a single recall limit of 8, eliminating
+  fragile regex-driven classification that missed edge cases like
+  "What's the status of X?" being classified as normal instead of complex.
+  Config fields normalLimit and complexLimit are deprecated in favor of
+  a single limit field. (#326)
+
 ## 0.9.20 (2026-02-28)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -54,8 +54,7 @@ const SKIP_SESSION_PATTERNS = [":subagent:", ":cron:"];
 const DEFAULT_MAX_SEEN_SESSIONS = 1000;
 const seenSessions = new Map<string, true>();
 const MAX_RECALLED_SESSIONS = 200;
-const DEFAULT_MID_SESSION_NORMAL_LIMIT = 5;
-const DEFAULT_MID_SESSION_COMPLEX_LIMIT = 8;
+const DEFAULT_MID_SESSION_RECALL_LIMIT = 8;
 const DEFAULT_MID_SESSION_QUERY_SIMILARITY_THRESHOLD = 0.85;
 const DEFAULT_STORE_NUDGE_THRESHOLD = 8;
 const DEFAULT_STORE_NUDGE_MAX_PER_SESSION = 3;
@@ -1435,15 +1434,10 @@ const plugin = {
                 config?.midSessionRecall?.querySimilarityThreshold,
               );
               if (shouldRecall(query, state.lastRecallQuery, threshold)) {
-                const limit = classification === "complex"
-                  ? resolveMidSessionLimit(
-                    config?.midSessionRecall?.complexLimit,
-                    DEFAULT_MID_SESSION_COMPLEX_LIMIT,
-                  )
-                  : resolveMidSessionLimit(
-                    config?.midSessionRecall?.normalLimit,
-                    DEFAULT_MID_SESSION_NORMAL_LIMIT,
-                  );
+                const limit = resolveMidSessionLimit(
+                  config?.midSessionRecall?.limit,
+                  DEFAULT_MID_SESSION_RECALL_LIMIT,
+                );
                 debugLog(
                   debug,
                   "mid-session-recall",

--- a/src/openclaw-plugin/mid-session-recall.test.ts
+++ b/src/openclaw-plugin/mid-session-recall.test.ts
@@ -18,38 +18,41 @@ describe("classifyMessage", () => {
     { input: "thanks!", expected: "trivial" },
     { input: "sure.", expected: "trivial" },
     { input: "do it", expected: "trivial" },
-    { input: "what do you think?", expected: "normal" },
-    { input: "How's Duke doing?", expected: "complex" },
-    { input: "Can you check PR #312?", expected: "complex" },
+    { input: "what do you think?", expected: "recall" },
+    { input: "How's Duke doing?", expected: "recall" },
+    { input: "Can you check PR #312?", expected: "recall" },
     { input: "yeah put it in the web ui", expected: "trivial" },
-    { input: "What did we decide about the extraction pipeline?", expected: "complex" },
+    { input: "What did we decide about the extraction pipeline?", expected: "recall" },
     { input: "fix the bug", expected: "trivial" },
-    { input: "Jim mentioned something about the Tesla last week", expected: "complex" },
-    { input: "send Kevin a message", expected: "complex" },
+    { input: "Jim mentioned something about the Tesla last week", expected: "recall" },
+    { input: "send Kevin a message", expected: "recall" },
     { input: "lgtm ship it", expected: "trivial" },
-    { input: "How does consolidate handle crashes?", expected: "normal" },
+    { input: "How does consolidate handle crashes?", expected: "recall" },
     { input: "1", expected: "trivial" },
     {
       input: "can you remind me what agenr-ai/agenr's default branch is?",
-      expected: "complex",
+      expected: "recall",
     },
     { input: "nice", expected: "trivial" },
-    { input: "Tell me about Ava", expected: "complex" },
+    { input: "Tell me about Ava", expected: "recall" },
+    { input: "What's the status of the exploration agents idea?", expected: "recall" },
+    { input: "What's the status with the recall bug?", expected: "recall" },
+    { input: "remember to check the PR", expected: "recall" },
     { input: "sounds like a plan", expected: "trivial" },
     { input: "one sec", expected: "trivial" },
     { input: "no worries", expected: "trivial" },
     { input: "fair enough", expected: "trivial" },
     { input: "all good", expected: "trivial" },
     { input: "Let me check", expected: "trivial" },
-    { input: "I'm tailing it right now. Do you want me to paste something in?", expected: "normal" },
+    { input: "I'm tailing it right now. Do you want me to paste something in?", expected: "recall" },
     {
       input: "That's okay. I don't need a reminder. I'm just going to do it probably before my haircut.",
-      expected: "normal",
+      expected: "recall",
     },
     {
       input:
         "i can finish this soon and share a detailed update once everything looks stable on my machine today",
-      expected: "normal",
+      expected: "recall",
     },
   ])("$input -> $expected", ({ input, expected }) => {
     expect(classifyMessage(input)).toBe(expected);
@@ -57,7 +60,7 @@ describe("classifyMessage", () => {
 
   it("does not classify short reminder ack as complex", () => {
     const classification = classifyMessage("That's okay. I don't need a reminder.");
-    expect(classification === "trivial" || classification === "normal").toBe(true);
+    expect(classification).toBe("trivial");
   });
 });
 

--- a/src/openclaw-plugin/mid-session-recall.ts
+++ b/src/openclaw-plugin/mid-session-recall.ts
@@ -1,4 +1,4 @@
-type MessageClassification = "trivial" | "normal" | "complex";
+type MessageClassification = "trivial" | "recall";
 
 const TRIVIAL_EXACT = new Set([
   "yes",
@@ -246,7 +246,7 @@ export function classifyMessage(text: string): MessageClassification {
       return "trivial";
     }
     if (entityCount > 0) {
-      return "normal";
+      return "recall";
     }
     return "trivial";
   }
@@ -267,23 +267,7 @@ export function classifyMessage(text: string): MessageClassification {
     return "trivial";
   }
 
-  if (hasExplicitRecall) {
-    return "complex";
-  }
-  if (hasTemporalPattern) {
-    return "complex";
-  }
-  if (wordCount <= 6 && entityCount > 0) {
-    return "complex";
-  }
-  if (entityCount >= 2) {
-    return "complex";
-  }
-  if (wordCount > 6 && entityCount === 0 && !hasTemporalPattern && !hasExplicitRecall) {
-    return "normal";
-  }
-
-  return "normal";
+  return "recall";
 }
 
 export function buildQuery(message: string): string {

--- a/src/openclaw-plugin/types.ts
+++ b/src/openclaw-plugin/types.ts
@@ -40,9 +40,11 @@ export type BeforeResetEvent = {
 export type MidSessionRecallConfig = {
   /** Set to false to disable mid-session recall (default: true) */
   enabled?: boolean;
-  /** Max entries to fetch for normal messages (default: 5) */
+  /** Max entries to fetch for non-trivial messages (default: 8) */
+  limit?: number;
+  /** @deprecated Ignored. Use limit instead. */
   normalLimit?: number;
-  /** Max entries to fetch for complex messages (default: 8) */
+  /** @deprecated Ignored. Use limit instead. */
   complexLimit?: number;
   /** Skip recall when query Jaccard similarity exceeds this threshold (default: 0.85) */
   querySimilarityThreshold?: number;


### PR DESCRIPTION
## Summary

Simplifies mid-session recall from three-tier classification (trivial/normal/complex) to two-tier (trivial/recall). All non-trivial messages now use a single recall limit of 8.

## Problem

The three-tier system relied on fragile regex lists (EXPLICIT_RECALL, TEMPORAL_PATTERNS) to distinguish normal from complex. These kept missing edge cases - e.g. "What's the status of the exploration agents idea?" classified as normal (limit=5) because the regex matched "status with" but not "status of".

## Changes

- Collapsed MessageClassification to `trivial | recall`
- Removed normal/complex branching in classifyMessage() - everything past trivial returns `recall`
- Single DEFAULT_MID_SESSION_RECALL_LIMIT = 8
- Config: single `limit` field replaces deprecated `normalLimit`/`complexLimit`
- Updated all tests, added 3 new cases

Net -6 lines.

Closes #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined mid-session recall with a simplified two-tier classification model.
  * Unified recall limit configuration: all non-trivial messages now use a single limit (default: 8).
  * Legacy configuration fields are now deprecated; use the new single limit field instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->