### PR TITLE
fix(openclaw-plugin): false entity detection + standardize AGENR log prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.22 (2026-02-28)
+
+### Bug Fixes
+- OpenClaw plugin: added missing pronouns (You, She, They) to
+  FALSE_POSITIVE_NOUNS so short messages like "You there?" correctly
+  classify as trivial instead of triggering recall. (#329)
+
+### Improvements
+- OpenClaw plugin: standardized all log output with `[AGENR:tag]`
+  prefix for easy filtering from OpenClaw internal logs. (#329)
+
 ## 0.9.21 (2026-02-28)
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenr",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "openclaw": {
     "extensions": [
       "dist/openclaw-plugin/index.js"

--- a/src/openclaw-plugin/index.test.ts
+++ b/src/openclaw-plugin/index.test.ts
@@ -2054,9 +2054,9 @@ describe("command hook handoff", () => {
     expect(payload.entries[0]?.importance).toBe(9);
     expect(payload.entries[0]?.tags).toContain("handoff");
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "[command] triggered action=new sessionKey=agent:main:command-new",
+      "[AGENR:command] triggered action=new sessionKey=agent:main:command-new",
     );
-    expect(consoleErrorSpy).toHaveBeenCalledWith("[command] handoff complete");
+    expect(consoleErrorSpy).toHaveBeenCalledWith("[AGENR:command] handoff complete");
   });
 
   it("skips handoff for action=stop", async () => {
@@ -2209,7 +2209,7 @@ describe("command hook handoff", () => {
 
     expect(runStoreMock).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "[command] dedup skip sessionId=session-210-cmd-dedup",
+      "[AGENR:command] dedup skip sessionId=session-210-cmd-dedup",
     );
   });
 

--- a/src/openclaw-plugin/index.ts
+++ b/src/openclaw-plugin/index.ts
@@ -69,7 +69,7 @@ function isDebugEnabled(config: AgenrPluginConfig | undefined): boolean {
 
 function debugLog(enabled: boolean, tag: string, message: string): void {
   if (enabled) {
-    console.error(`[${tag}] ${message}`);
+    console.error(`[AGENR:${tag}] ${message}`);
   }
 }
 
@@ -895,7 +895,7 @@ async function summarizeSessionForHandoff(
         debugLog(debugEnabled, "handoff", `logged LLM request/response to ${normalizedLogDir}`);
       } catch (err) {
         console.error(
-          `[agenr] handoff: failed to write LLM request/response logs: ${err instanceof Error ? err.message : String(err)}`,
+          `[AGENR:handoff] failed to write LLM request/response logs: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
@@ -905,7 +905,7 @@ async function summarizeSessionForHandoff(
     return summaryText;
   } catch (err) {
     console.error(
-      `[agenr] before_reset: summarize handoff failed: ${err instanceof Error ? err.message : String(err)}`,
+      `[AGENR:before_reset] summarize handoff failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;
   }
@@ -1099,7 +1099,7 @@ async function runHandoffForSession(opts: {
       debugLog(Boolean(opts.debugEnabled), opts.source, "fallback handoff stored");
     } catch (err) {
       console.error(
-        `[agenr] ${opts.source}: fallback store failed: ${err instanceof Error ? err.message : String(err)}`,
+        `[AGENR:${opts.source}] fallback store failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       fallbackEntrySubject = null;
     }
@@ -1158,7 +1158,7 @@ async function runHandoffForSession(opts: {
         debugLog(Boolean(opts.debugEnabled), opts.source, "LLM handoff stored");
       } catch (err) {
         console.error(
-          `[agenr] ${opts.source}: LLM handoff store failed: ${err instanceof Error ? err.message : String(err)}`,
+          `[AGENR:${opts.source}] LLM handoff store failed: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
@@ -1301,7 +1301,7 @@ const plugin = {
                   debugLog(debug, "session-start", "runHandoffForSession completed");
                 } catch (err) {
                   console.error(
-                    `[agenr] session_start: handoff failed: ${err instanceof Error ? err.message : String(err)}`,
+                    `[AGENR:session_start] handoff failed: ${err instanceof Error ? err.message : String(err)}`,
                   );
                 }
               }
@@ -1363,7 +1363,7 @@ const plugin = {
                       })
                       .catch((err) => {
                         console.error(
-                          `[agenr] session-start: retire handoff ${entryId} failed: ${err instanceof Error ? err.message : String(err)}`,
+                          `[AGENR:session-start] retire handoff ${entryId} failed: ${err instanceof Error ? err.message : String(err)}`,
                         );
                       }),
                   );

--- a/src/openclaw-plugin/mid-session-recall.ts
+++ b/src/openclaw-plugin/mid-session-recall.ts
@@ -64,6 +64,7 @@ const FALSE_POSITIVE_NOUNS = new Set([
   "Who",
   "Which",
   "Can",
+  "Check",
   "Could",
   "Would",
   "Should",
@@ -96,6 +97,7 @@ const FALSE_POSITIVE_NOUNS = new Set([
   "Thanks",
   "So",
   "Now",
+  "Really",
   "Well",
   "Still",
   "Yet",
@@ -116,6 +118,9 @@ const FALSE_POSITIVE_NOUNS = new Set([
   "Her",
   "Its",
   "Their",
+  "She",
+  "They",
+  "You",
   "Some",
   "Any",
   "All",
@@ -210,7 +215,7 @@ function collectEntities(text: string): Set<string> {
   return entities;
 }
 
-function countEntities(text: string): number {
+export function countEntities(text: string): number {
   return collectEntities(text).size;
 }
 

--- a/src/openclaw-plugin/session-handoff.test.ts
+++ b/src/openclaw-plugin/session-handoff.test.ts
@@ -724,7 +724,7 @@ describe("summarizeSessionForHandoff", () => {
     expect(summary).toBe("summary text");
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringMatching(
-        /^\[before_reset\] sending to LLM model=gpt-4\.1-nano chars=\d+ msgs=5$/,
+        /^\[AGENR:before_reset\] sending to LLM model=gpt-4\.1-nano chars=\d+ msgs=5$/,
       ),
     );
   });
@@ -762,7 +762,7 @@ describe("summarizeSessionForHandoff", () => {
     expect(summary).toBe("summary text");
     const sendingLog = consoleErrorSpy.mock.calls
       .map((call) => (typeof call[0] === "string" ? call[0] : ""))
-      .find((line) => line.includes("[before_reset] sending to LLM"));
+      .find((line) => line.includes("[AGENR:before_reset] sending to LLM"));
     expect(sendingLog).toContain("model=gpt-4.1-nano-test");
     expect(sendingLog).not.toContain("[object Object]");
   });
@@ -1214,7 +1214,7 @@ describe("summarizeSessionForHandoff", () => {
 
     expect(summary).toBeNull();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "[before_reset] skipping LLM summary - reason: LLM client init failed",
+      "[AGENR:before_reset] skipping LLM summary - reason: LLM client init failed",
     );
   });
 
@@ -1248,7 +1248,7 @@ describe("summarizeSessionForHandoff", () => {
 
     expect(summary).toBeNull();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "[before_reset] no apiKey available, skipping LLM summary",
+      "[AGENR:before_reset] no apiKey available, skipping LLM summary",
     );
   });
 });

--- a/src/openclaw-plugin/tools.ts
+++ b/src/openclaw-plugin/tools.ts
@@ -52,7 +52,7 @@ function resolveWarn(pluginConfig?: Record<string, unknown>): (message: string) 
     }
   }
   return (message: string) => {
-    console.warn(message);
+    console.warn(`[AGENR] ${message}`);
   };
 }
 

--- a/tests/openclaw-plugin/classify-message.test.ts
+++ b/tests/openclaw-plugin/classify-message.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { classifyMessage, countEntities } from "../../src/openclaw-plugin/mid-session-recall.js";
+
+describe("classifyMessage", () => {
+  it("classifies 'You there?' as trivial", () => {
+    expect(classifyMessage("You there?")).toBe("trivial");
+  });
+
+  it("classifies 'She left' as trivial", () => {
+    expect(classifyMessage("She left")).toBe("trivial");
+  });
+
+  it("classifies 'They agreed' as trivial", () => {
+    expect(classifyMessage("They agreed")).toBe("trivial");
+  });
+
+  it("classifies single-word 'You' as trivial", () => {
+    expect(classifyMessage("You")).toBe("trivial");
+  });
+
+  it("classifies short no-entity questions as trivial", () => {
+    expect(classifyMessage("Really?")).toBe("trivial");
+    expect(classifyMessage("You sure?")).toBe("trivial");
+    expect(classifyMessage("Right?")).toBe("trivial");
+  });
+
+  it("keeps real entity questions as recall", () => {
+    expect(classifyMessage("What happened with PR #42?")).toBe("recall");
+  });
+});
+
+describe("countEntities", () => {
+  it("returns 0 for pronoun-only short messages", () => {
+    expect(countEntities("You there?")).toBe(0);
+  });
+
+  it("counts real named entities", () => {
+    expect(countEntities("Check the Codex logs")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Changes

- Added missing pronouns (You, She, They) to FALSE_POSITIVE_NOUNS so short messages like "You there?" correctly classify as trivial instead of triggering recall
- Standardized all plugin log output with `[AGENR:tag]` prefix for easy filtering from OpenClaw internal logs

## Tests

- 8 new tests in `tests/openclaw-plugin/classify-message.test.ts`
- All 1706 tests pass

Closes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Short messages containing only pronouns (You, She, They) are now correctly classified as non-recall-triggering instead of incorrectly triggering recall functionality.

* **Improvements**
  * Standardized internal log output formatting for improved consistency and easier troubleshooting.

* **Chores**
  * Version bumped to 0.9.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->